### PR TITLE
[global] Claude Code 에이전트 설정 문서 정비

### DIFF
--- a/.claude/skills/write-pr/SKILL.md
+++ b/.claude/skills/write-pr/SKILL.md
@@ -1,62 +1,65 @@
 ---
-name: commit
-description: Create Git commits by splitting changes into logical units following project conventions. Handles Git Flow automatically — detects develop branch and checks out a feature branch before committing.
+name: write-pr
+description: Generate PR title, body, and labels from commits since the base branch, then create the PR on GitHub. Handles base branch detection, label selection, and PR creation end-to-end.
 ---
 
-## Step 0 — Branch Check (Required)
-
-Check the current branch first:
+## Step 1 — Gather Context
 
 ```bash
 git branch --show-current
+git log origin/develop..HEAD --oneline 2>/dev/null || git log --oneline -15
+git diff origin/develop...HEAD --stat 2>/dev/null || git diff HEAD~5...HEAD --stat
+git diff origin/develop...HEAD 2>/dev/null || git diff HEAD~5...HEAD
 ```
 
-**If current branch is `develop`:**
+Also read the PR template:
 
-This project uses Git Flow. Feature branches must be created from `develop` and merged back into `develop`.
+```bash
+cat .github/PULL_REQUEST_TEMPLATE.md
+```
 
-1. Analyze all changes with `git status` and `git diff`
-2. Infer an appropriate branch name from the changes:
-    - Format: `<type>/<kebab-case-description>` — use the same type as the planned commit (exception: use `cicd/` for `ci/cd` type)
-    - Reflect the domain scope in the name
-    - Examples: `add/add-student-major-filter`, `fix/auth-api-key-deletion`, `refactor/optimize-club-query`
-3. Create and checkout the branch:
-   ```bash
-   git checkout -b <type>/<inferred-name>
-   ```
-4. Proceed with the commit flow below
+## Step 2 — Determine Labels
 
-**If current branch is NOT `develop`:** proceed directly to the commit flow.
+Read `references/labels.md` and select 1–2 appropriate labels based on the nature of the changes.
 
----
+## Step 3 — Generate PR Content
 
-## Commit Message Rules
+**Title** — Generate 3 options in the format `[scope] description`:
+- Scope: domain name (`[student]`, `[auth]`, `[application]`, `[club]`, etc.) or `[global]` / `[ci/cd]` for cross-cutting changes
+- Description: Korean, concise, no emojis, max 50 characters total
+- Mark the best option with `← 추천`
 
-Format: `type(scope): 설명`
+**Body** — Follow the `.github/PULL_REQUEST_TEMPLATE.md` structure:
+- Korean 합쇼체: `~하였습니다`, `~되었습니다`, `~추가하였습니다`
+- No emojis
+- Max 2500 characters
 
-- **Types**: `add` / `update` / `fix` / `refactor` / `ci/cd` / `docs` / `test` / `merge` (English)
-- **Scopes** (English):
-    - **Primary**: Domain names (`account`, `application`, `auth`, `client`, `club`, `neis`, `oauth`, `project`, `student`, `utility`)
-    - **Cross-cutting concerns only**: Module names (`web`, `oauth`, `openapi`) or `global`
-    - Use domain names by default. Only use module names when changes affect multiple modules or are cross-cutting.
-- **Description**: Korean, no period, avoid endings: `~한다/~된다`, `~하기/~하기 위해`, `~합니다/~됩니다`, `~했습니다`
-    - Good examples: `엔티티 필드 추가`, `트랜잭션 롤백 방지`, `로직 개선`
-- Subject line only (no body)
-- Do NOT add AI tool as co-author
+## Step 4 — Write Body & Show Preview
 
-## Scope Selection
+Write the body to `PR_BODY.md`, then display:
 
-For the full scope selection table and examples, read `references/scope-guide.md`.
+```
+## 추천 PR 제목
+1. [title1]
+2. [title2]
+3. [title3] ← 추천
 
-Quick rule: use domain name (`auth`, `application`, `student`, `club`, `neis`, etc.) by default. Use `global` / `ci/cd` / module names only for cross-cutting changes.
+## 선택된 라벨
+- label1, label2
 
-## Commit Flow
+## PR 본문 미리보기
+[body content]
+```
 
-1. Inspect changes: `git status`, `git diff`
-2. Categorize into logical units (feature / bug fix / refactoring / etc.)
-3. Group files per unit
-4. For each group:
-    - Stage only relevant files with `git add`
-    - Write a commit message following the rules above
-    - `git commit -m "message"`
-5. Verify with `git log --oneline -n <count>`
+Ask the user to confirm which title to use. If no answer is given, proceed with the recommended (marked) title.
+
+## Step 5 — Create PR
+
+Run the creation script with the confirmed title and labels:
+
+```bash
+bash scripts/create-pr.sh "<confirmed-title>" "PR_BODY.md" "<label1>,<label2>"
+```
+
+After creation, display the PR URL.
+Cleanup: remove `PR_BODY.md`.

--- a/.gitignore
+++ b/.gitignore
@@ -59,5 +59,6 @@ logs/
 
 ### LLM Outputs ###
 PR_BODY.md
+SPEC.md
 .pr-tmp/
 /.claude/command.log

--- a/AGNETS.md
+++ b/AGNETS.md
@@ -1,0 +1,7 @@
+# Cowork Server
+
+## Project Structure
+
+This project is a microservices architecture with multiple tech.
+
+A `docker-compose.yml` is located at the root, and each service is organized as an independent module directory. The main modules are cowork-gateway, cowork-authorization, cowork-user, cowork-team, cowork-project, cowork-channel, cowork-chat, cowork-voice, and cowork-config.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Cowork Server
+
+## Project Structure
+
+This project is a microservices architecture with multiple tech.
+
+A `docker-compose.yml` is located at the root, and each service is organized as an independent module directory. The main modules are cowork-gateway, cowork-authorization, cowork-user, cowork-team, cowork-project, cowork-channel, cowork-chat, cowork-voice, and cowork-config.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -55,7 +55,7 @@ cowork-server/
 6. MySQL 사용 시 [DB 스키마 관리](#3-db-스키마-관리-flyway) 절차 따르기
 7. Eureka Client 등록 (`spring.application.name: cowork-{name}`)
 
-### JVM 외 서비스 (NestJS / Go / .NET 등)
+### JVM 외 서비스 (NestJS / Go / Rust / .NET 등)
 
 1. 루트에 `cowork-{name}/` 디렉터리 생성
 2. `cowork-{name}/README.md` 작성

--- a/cowork-voice/README.md
+++ b/cowork-voice/README.md
@@ -8,7 +8,7 @@
 - Kafka: 음성 세션 이벤트 발행 (`voice.session.event`)
 
 ## 스택
-TBD (Go/Gin, .NET 등 팀 결정)
+Rust (Axum/Tokio 등 팀 결정)
 
 ## 포트
 `9000`


### PR DESCRIPTION
## 개요

프로젝트 루트에 CLAUDE.md 및 AGNETS.md 문서를 추가하여 Claude Code 에이전트가 저장소 구조를 빠르게 파악할 수 있도록 안내 문서를 정비하였습니다. 또한 write-pr 스킬 파일의 내용을 실제 기능에 맞게 업데이트하였습니다.

## 본문

### CLAUDE.md / AGNETS.md 추가

Claude Code가 프로젝트 컨텍스트를 인식할 수 있도록 프로젝트 구조 및 기술 스택을 설명하는 문서를 루트에 추가하였습니다. `docker-compose.yml` 위치와 각 서비스 모듈(cowork-gateway, cowork-authorization, cowork-user, cowork-team, cowork-project, cowork-channel, cowork-chat, cowork-voice, cowork-config)의 구성 방식이 기술되어 있습니다.

### write-pr 스킬 업데이트

`.claude/skills/write-pr/SKILL.md` 파일이 commit 스킬 내용으로 잘못 구성되어 있던 부분을 write-pr 스킬의 실제 동작(PR 제목/본문/라벨 생성 및 GitHub PR 생성)에 맞게 수정하였습니다.