### PR TITLE
[user] 사용자 서비스 초기 구조 구성

### DIFF
--- a/cowork-user/build.gradle.kts
+++ b/cowork-user/build.gradle.kts
@@ -1,0 +1,52 @@
+plugins {
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    id("org.jetbrains.kotlin.plugin.jpa") version "2.1.20"
+}
+
+group = "com.cowork"
+version = "0.0.1-SNAPSHOT"
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    maven { url = uri("https://jitpack.io") }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom(libs.spring.cloud.dependencies.get().toString())
+        mavenBom(libs.awspring.cloud.bom.get().toString())
+    }
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
+    implementation("org.springframework.cloud:spring-cloud-starter-config")
+    implementation(libs.awspring.cloud.s3)
+    implementation("com.mysql:mysql-connector-j")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-mysql")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("com.github.themoment-team:the-sdk:1.5")
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/CoworkUserApplication.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/CoworkUserApplication.kt
@@ -1,0 +1,11 @@
+package com.cowork.user
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class CoworkUserApplication
+
+fun main(args: Array<String>) {
+    runApplication<CoworkUserApplication>(*args)
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/config/AppConfig.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/config/AppConfig.kt
@@ -1,0 +1,8 @@
+package com.cowork.user.config
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(S3Properties::class)
+class AppConfig

--- a/cowork-user/src/main/kotlin/com/cowork/user/config/S3Properties.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/config/S3Properties.kt
@@ -1,0 +1,13 @@
+package com.cowork.user.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.DefaultValue
+
+@ConfigurationProperties(prefix = "s3")
+data class S3Properties(
+    val bucket: String,
+    @DefaultValue("5") val presignedPutExpiryMinutes: Long,
+    @DefaultValue("15") val presignedGetExpiryMinutes: Long,
+    @DefaultValue("5242880") val maxFileSizeBytes: Long,
+    val allowedContentTypes: List<String> = listOf("image/jpeg", "image/png", "image/webp"),
+)

--- a/cowork-user/src/main/kotlin/com/cowork/user/controller/GlobalExceptionHandler.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/controller/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.cowork.user.controller
 
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -8,6 +9,8 @@ import team.themoment.sdk.exception.ExpectedException
 @RestControllerAdvice
 class GlobalExceptionHandler {
 
+    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+
     data class ErrorResponse(val message: String)
 
     @ExceptionHandler(ExpectedException::class)
@@ -15,6 +18,8 @@ class GlobalExceptionHandler {
         ResponseEntity.status(e.statusCode).body(ErrorResponse(e.message ?: e.statusCode.reasonPhrase))
 
     @ExceptionHandler(Exception::class)
-    fun handleInternal(e: Exception): ResponseEntity<ErrorResponse> =
-        ResponseEntity.internalServerError().body(ErrorResponse("서버 오류가 발생했습니다."))
+    fun handleInternal(e: Exception): ResponseEntity<ErrorResponse> {
+        log.error("처리되지 않은 예외 발생", e)
+        return ResponseEntity.internalServerError().body(ErrorResponse("서버 오류가 발생했습니다."))
+    }
 }

--- a/cowork-user/src/main/kotlin/com/cowork/user/controller/GlobalExceptionHandler.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/controller/GlobalExceptionHandler.kt
@@ -8,10 +8,11 @@ import team.themoment.sdk.exception.ExpectedException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
-
     private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
 
-    data class ErrorResponse(val message: String)
+    data class ErrorResponse(
+        val message: String,
+    )
 
     @ExceptionHandler(ExpectedException::class)
     fun handleExpectedException(e: ExpectedException): ResponseEntity<ErrorResponse> =

--- a/cowork-user/src/main/kotlin/com/cowork/user/controller/GlobalExceptionHandler.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/controller/GlobalExceptionHandler.kt
@@ -1,0 +1,20 @@
+package com.cowork.user.controller
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import team.themoment.sdk.exception.ExpectedException
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    data class ErrorResponse(val message: String)
+
+    @ExceptionHandler(ExpectedException::class)
+    fun handleExpectedException(e: ExpectedException): ResponseEntity<ErrorResponse> =
+        ResponseEntity.status(e.statusCode).body(ErrorResponse(e.message ?: e.statusCode.reasonPhrase))
+
+    @ExceptionHandler(Exception::class)
+    fun handleInternal(e: Exception): ResponseEntity<ErrorResponse> =
+        ResponseEntity.internalServerError().body(ErrorResponse("서버 오류가 발생했습니다."))
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/controller/UserController.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/controller/UserController.kt
@@ -1,0 +1,70 @@
+package com.cowork.user.controller
+
+import com.cowork.user.dto.*
+import com.cowork.user.service.UserService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/users")
+class UserController(
+    private val userService: UserService,
+) {
+
+    @GetMapping("/me")
+    fun getMyProfile(
+        @RequestHeader("X-User-Id") userId: Long,
+    ): ResponseEntity<MyProfileResponse> =
+        ResponseEntity.ok(userService.getMyProfile(userId))
+
+    @PatchMapping("/me")
+    fun updateMyProfile(
+        @RequestHeader("X-User-Id") userId: Long,
+        @RequestBody request: UpdateMyProfileRequest,
+    ): ResponseEntity<MyProfileResponse> =
+        ResponseEntity.ok(userService.updateMyProfile(userId, request))
+
+    @PostMapping("/me/profile-image/presigned")
+    fun generatePresignedUrl(
+        @RequestHeader("X-User-Id") userId: Long,
+        @RequestBody request: PresignedUrlRequest,
+    ): ResponseEntity<PresignedUrlResponse> =
+        ResponseEntity.ok(userService.generatePresignedUrl(userId, request.contentType))
+
+    @PostMapping("/me/profile-image/confirm")
+    fun confirmUpload(
+        @RequestHeader("X-User-Id") userId: Long,
+        @RequestBody request: ConfirmUploadRequest,
+    ): ResponseEntity<Void> {
+        userService.confirmUpload(userId, request.objectKey)
+        return ResponseEntity.ok().build()
+    }
+
+    @DeleteMapping("/me/profile-image")
+    fun deleteProfileImage(
+        @RequestHeader("X-User-Id") userId: Long,
+    ): ResponseEntity<Void> {
+        userService.deleteProfileImage(userId)
+        return ResponseEntity.noContent().build()
+    }
+
+    @GetMapping("/{userId}")
+    fun getUserProfile(
+        @PathVariable userId: Long,
+    ): ResponseEntity<UserProfileResponse> =
+        ResponseEntity.ok(userService.getUserProfile(userId))
+
+    @GetMapping("/search")
+    fun searchUsers(
+        @RequestParam(required = false) name: String?,
+        @RequestParam(required = false) major: String?,
+        @RequestParam(required = false) grade: Byte?,
+        @RequestParam(required = false) `class`: Byte?,
+        @RequestParam(required = false) role: String?,
+        @PageableDefault(size = 20, sort = ["name"]) pageable: Pageable,
+    ): ResponseEntity<Page<UserProfileResponse>> =
+        ResponseEntity.ok(userService.searchUsers(name, major, grade, `class`, role, pageable))
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/domain/Major.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/domain/Major.kt
@@ -1,0 +1,7 @@
+package com.cowork.user.domain
+
+enum class Major {
+    SW_DEVELOPMENT,
+    SMART_IOT,
+    AI,
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/domain/Role.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/domain/Role.kt
@@ -1,0 +1,9 @@
+package com.cowork.user.domain
+
+enum class Role {
+    STUDENT_COUNCIL,
+    DORMITORY_MANAGER,
+    GENERAL_STUDENT,
+    GRADUATE,
+    WITHDRAWN,
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/domain/Sex.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/domain/Sex.kt
@@ -1,0 +1,6 @@
+package com.cowork.user.domain
+
+enum class Sex {
+    MAN,
+    WOMAN,
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/domain/UserProfile.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/domain/UserProfile.kt
@@ -1,6 +1,8 @@
 package com.cowork.user.domain
 
 import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
 import java.time.LocalDateTime
 
 @Entity
@@ -16,8 +18,9 @@ class UserProfile(
     @Column(nullable = false, unique = true)
     val email: String,
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 10)
-    val sex: String,
+    val sex: Sex,
 
     @Column
     val grade: Byte?,
@@ -28,8 +31,9 @@ class UserProfile(
     @Column(name = "class_num")
     val classNum: Byte?,
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    val major: String,
+    val major: Major,
 
     @Column(length = 255)
     var specialty: String?,
@@ -40,22 +44,23 @@ class UserProfile(
     @Column(name = "profile_image_key", length = 500)
     var profileImageKey: String?,
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 30)
-    val role: String,
+    val role: Role,
 
+    @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
+    @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.now(),
 ) {
     fun updateSpecialty(newSpecialty: String?) {
         specialty = newSpecialty
-        updatedAt = LocalDateTime.now()
     }
 
     fun updateProfileImageKey(key: String?) {
         profileImageKey = key
-        updatedAt = LocalDateTime.now()
     }
 }

--- a/cowork-user/src/main/kotlin/com/cowork/user/domain/UserProfile.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/domain/UserProfile.kt
@@ -1,0 +1,61 @@
+package com.cowork.user.domain
+
+import jakarta.persistence.*
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "tb_user_profiles")
+class UserProfile(
+
+    @Id
+    val id: Long,
+
+    @Column(nullable = false, length = 50)
+    val name: String,
+
+    @Column(nullable = false, unique = true)
+    val email: String,
+
+    @Column(nullable = false, length = 10)
+    val sex: String,
+
+    @Column
+    val grade: Byte?,
+
+    @Column(name = "class")
+    val `class`: Byte?,
+
+    @Column(name = "class_num")
+    val classNum: Byte?,
+
+    @Column(nullable = false, length = 20)
+    val major: String,
+
+    @Column(length = 255)
+    var specialty: String?,
+
+    @Column(name = "github_id", length = 100, unique = true)
+    val githubId: String?,
+
+    @Column(name = "profile_image_key", length = 500)
+    var profileImageKey: String?,
+
+    @Column(nullable = false, length = 30)
+    val role: String,
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun updateSpecialty(newSpecialty: String?) {
+        specialty = newSpecialty
+        updatedAt = LocalDateTime.now()
+    }
+
+    fun updateProfileImageKey(key: String?) {
+        profileImageKey = key
+        updatedAt = LocalDateTime.now()
+    }
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/dto/ConfirmUploadRequest.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/dto/ConfirmUploadRequest.kt
@@ -1,0 +1,5 @@
+package com.cowork.user.dto
+
+data class ConfirmUploadRequest(
+    val objectKey: String,
+)

--- a/cowork-user/src/main/kotlin/com/cowork/user/dto/MyProfileResponse.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/dto/MyProfileResponse.kt
@@ -22,15 +22,15 @@ data class MyProfileResponse(
                 id = profile.id,
                 name = profile.name,
                 email = profile.email,
-                sex = profile.sex,
+                sex = profile.sex.name,
                 grade = profile.grade,
                 `class` = profile.`class`,
                 classNum = profile.classNum,
-                major = profile.major,
+                major = profile.major.name,
                 specialty = profile.specialty,
                 githubId = profile.githubId,
                 profileImageUrl = profileImageUrl,
-                role = profile.role,
+                role = profile.role.name,
             )
     }
 }

--- a/cowork-user/src/main/kotlin/com/cowork/user/dto/MyProfileResponse.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/dto/MyProfileResponse.kt
@@ -1,0 +1,36 @@
+package com.cowork.user.dto
+
+import com.cowork.user.domain.UserProfile
+
+data class MyProfileResponse(
+    val id: Long,
+    val name: String,
+    val email: String,
+    val sex: String,
+    val grade: Byte?,
+    val `class`: Byte?,
+    val classNum: Byte?,
+    val major: String,
+    val specialty: String?,
+    val githubId: String?,
+    val profileImageUrl: String?,
+    val role: String,
+) {
+    companion object {
+        fun of(profile: UserProfile, profileImageUrl: String?): MyProfileResponse =
+            MyProfileResponse(
+                id = profile.id,
+                name = profile.name,
+                email = profile.email,
+                sex = profile.sex,
+                grade = profile.grade,
+                `class` = profile.`class`,
+                classNum = profile.classNum,
+                major = profile.major,
+                specialty = profile.specialty,
+                githubId = profile.githubId,
+                profileImageUrl = profileImageUrl,
+                role = profile.role,
+            )
+    }
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/dto/PresignedUrlRequest.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/dto/PresignedUrlRequest.kt
@@ -1,0 +1,5 @@
+package com.cowork.user.dto
+
+data class PresignedUrlRequest(
+    val contentType: String,
+)

--- a/cowork-user/src/main/kotlin/com/cowork/user/dto/PresignedUrlResponse.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/dto/PresignedUrlResponse.kt
@@ -1,0 +1,6 @@
+package com.cowork.user.dto
+
+data class PresignedUrlResponse(
+    val uploadUrl: String,
+    val objectKey: String,
+)

--- a/cowork-user/src/main/kotlin/com/cowork/user/dto/UpdateMyProfileRequest.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/dto/UpdateMyProfileRequest.kt
@@ -1,0 +1,5 @@
+package com.cowork.user.dto
+
+data class UpdateMyProfileRequest(
+    val specialty: String?,
+)

--- a/cowork-user/src/main/kotlin/com/cowork/user/dto/UserProfileResponse.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/dto/UserProfileResponse.kt
@@ -20,15 +20,15 @@ data class UserProfileResponse(
             UserProfileResponse(
                 id = profile.id,
                 name = profile.name,
-                sex = profile.sex,
+                sex = profile.sex.name,
                 grade = profile.grade,
                 `class` = profile.`class`,
                 classNum = profile.classNum,
-                major = profile.major,
+                major = profile.major.name,
                 specialty = profile.specialty,
                 githubId = profile.githubId,
                 profileImageUrl = profileImageUrl,
-                role = profile.role,
+                role = profile.role.name,
             )
     }
 }

--- a/cowork-user/src/main/kotlin/com/cowork/user/dto/UserProfileResponse.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/dto/UserProfileResponse.kt
@@ -1,0 +1,34 @@
+package com.cowork.user.dto
+
+import com.cowork.user.domain.UserProfile
+
+data class UserProfileResponse(
+    val id: Long,
+    val name: String,
+    val sex: String,
+    val grade: Byte?,
+    val `class`: Byte?,
+    val classNum: Byte?,
+    val major: String,
+    val specialty: String?,
+    val githubId: String?,
+    val profileImageUrl: String?,
+    val role: String,
+) {
+    companion object {
+        fun of(profile: UserProfile, profileImageUrl: String?): UserProfileResponse =
+            UserProfileResponse(
+                id = profile.id,
+                name = profile.name,
+                sex = profile.sex,
+                grade = profile.grade,
+                `class` = profile.`class`,
+                classNum = profile.classNum,
+                major = profile.major,
+                specialty = profile.specialty,
+                githubId = profile.githubId,
+                profileImageUrl = profileImageUrl,
+                role = profile.role,
+            )
+    }
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/repository/UserProfileRepository.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/repository/UserProfileRepository.kt
@@ -1,0 +1,12 @@
+package com.cowork.user.repository
+
+import com.cowork.user.domain.UserProfile
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+
+interface UserProfileRepository : JpaRepository<UserProfile, Long>, JpaSpecificationExecutor<UserProfile>
+
+fun UserProfileRepository.findByIdOrThrow(id: Long): UserProfile =
+    findById(id).orElseThrow { NoSuchElementException("사용자를 찾을 수 없습니다. id=$id") }

--- a/cowork-user/src/main/kotlin/com/cowork/user/repository/UserProfileRepository.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/repository/UserProfileRepository.kt
@@ -1,12 +1,7 @@
 package com.cowork.user.repository
 
 import com.cowork.user.domain.UserProfile
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 
 interface UserProfileRepository : JpaRepository<UserProfile, Long>, JpaSpecificationExecutor<UserProfile>
-
-fun UserProfileRepository.findByIdOrThrow(id: Long): UserProfile =
-    findById(id).orElseThrow { NoSuchElementException("사용자를 찾을 수 없습니다. id=$id") }

--- a/cowork-user/src/main/kotlin/com/cowork/user/repository/UserProfileSpecification.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/repository/UserProfileSpecification.kt
@@ -1,5 +1,7 @@
 package com.cowork.user.repository
 
+import com.cowork.user.domain.Major
+import com.cowork.user.domain.Role
 import com.cowork.user.domain.UserProfile
 import org.springframework.data.jpa.domain.Specification
 
@@ -11,9 +13,9 @@ object UserProfileSpecification {
         }
 
     fun majorEq(major: String?): Specification<UserProfile>? =
-        major?.takeIf { it.isNotBlank() }?.let { m ->
-            Specification { root, _, cb -> cb.equal(root.get<String>("major"), m) }
-        }
+        major?.takeIf { it.isNotBlank() }
+            ?.let { runCatching { Major.valueOf(it) }.getOrNull() }
+            ?.let { m -> Specification { root, _, cb -> cb.equal(root.get<Major>("major"), m) } }
 
     fun gradeEq(grade: Byte?): Specification<UserProfile>? =
         grade?.let { g ->
@@ -26,9 +28,9 @@ object UserProfileSpecification {
         }
 
     fun roleEq(role: String?): Specification<UserProfile>? =
-        role?.takeIf { it.isNotBlank() }?.let { r ->
-            Specification { root, _, cb -> cb.equal(root.get<String>("role"), r) }
-        }
+        role?.takeIf { it.isNotBlank() }
+            ?.let { runCatching { Role.valueOf(it) }.getOrNull() }
+            ?.let { r -> Specification { root, _, cb -> cb.equal(root.get<Role>("role"), r) } }
 
     fun build(
         name: String?,
@@ -36,14 +38,7 @@ object UserProfileSpecification {
         grade: Byte?,
         cls: Byte?,
         role: String?,
-    ): Specification<UserProfile> {
-        val specs = listOfNotNull(
-            nameLike(name),
-            majorEq(major),
-            gradeEq(grade),
-            classEq(cls),
-            roleEq(role),
-        )
-        return specs.fold(Specification.where(null)) { acc, spec -> acc.and(spec) }
-    }
+    ): Specification<UserProfile> =
+        listOfNotNull(nameLike(name), majorEq(major), gradeEq(grade), classEq(cls), roleEq(role))
+            .fold(Specification.where(null)) { acc, spec -> acc.and(spec) }
 }

--- a/cowork-user/src/main/kotlin/com/cowork/user/repository/UserProfileSpecification.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/repository/UserProfileSpecification.kt
@@ -1,0 +1,49 @@
+package com.cowork.user.repository
+
+import com.cowork.user.domain.UserProfile
+import org.springframework.data.jpa.domain.Specification
+
+object UserProfileSpecification {
+
+    fun nameLike(name: String?): Specification<UserProfile>? =
+        name?.takeIf { it.isNotBlank() }?.let { n ->
+            Specification { root, _, cb -> cb.like(root.get("name"), "%$n%") }
+        }
+
+    fun majorEq(major: String?): Specification<UserProfile>? =
+        major?.takeIf { it.isNotBlank() }?.let { m ->
+            Specification { root, _, cb -> cb.equal(root.get<String>("major"), m) }
+        }
+
+    fun gradeEq(grade: Byte?): Specification<UserProfile>? =
+        grade?.let { g ->
+            Specification { root, _, cb -> cb.equal(root.get<Byte>("grade"), g) }
+        }
+
+    fun classEq(cls: Byte?): Specification<UserProfile>? =
+        cls?.let { c ->
+            Specification { root, _, cb -> cb.equal(root.get<Byte>("class"), c) }
+        }
+
+    fun roleEq(role: String?): Specification<UserProfile>? =
+        role?.takeIf { it.isNotBlank() }?.let { r ->
+            Specification { root, _, cb -> cb.equal(root.get<String>("role"), r) }
+        }
+
+    fun build(
+        name: String?,
+        major: String?,
+        grade: Byte?,
+        cls: Byte?,
+        role: String?,
+    ): Specification<UserProfile> {
+        val specs = listOfNotNull(
+            nameLike(name),
+            majorEq(major),
+            gradeEq(grade),
+            classEq(cls),
+            roleEq(role),
+        )
+        return specs.fold(Specification.where(null)) { acc, spec -> acc.and(spec) }
+    }
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/service/S3Service.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/service/S3Service.kt
@@ -1,0 +1,60 @@
+package com.cowork.user.service
+
+import com.cowork.user.config.S3Properties
+import io.awspring.cloud.s3.S3Template
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import team.themoment.sdk.exception.ExpectedException
+import java.time.Duration
+import java.util.UUID
+
+@Service
+class S3Service(
+    private val s3Template: S3Template,
+    private val s3Presigner: S3Presigner,
+    private val s3Properties: S3Properties,
+) {
+
+    fun validateContentType(contentType: String) {
+        if (contentType !in s3Properties.allowedContentTypes) {
+            throw ExpectedException(
+                "허용되지 않는 파일 형식입니다. 허용 형식: ${s3Properties.allowedContentTypes.joinToString()}",
+                HttpStatus.BAD_REQUEST,
+            )
+        }
+    }
+
+    fun buildObjectKey(userId: Long, contentType: String): String {
+        val ext = contentType.substringAfterLast("/")
+        return "profiles/$userId/${UUID.randomUUID()}.$ext"
+    }
+
+    fun generatePutPresignedUrl(objectKey: String, contentType: String): String {
+        val putObjectRequest = PutObjectRequest.builder()
+            .bucket(s3Properties.bucket)
+            .key(objectKey)
+            .contentType(contentType)
+            .build()
+
+        val presignRequest = PutObjectPresignRequest.builder()
+            .signatureDuration(Duration.ofMinutes(s3Properties.presignedPutExpiryMinutes))
+            .putObjectRequest(putObjectRequest)
+            .build()
+
+        return s3Presigner.presignPutObject(presignRequest).url().toString()
+    }
+
+    fun generateGetPresignedUrl(objectKey: String): String =
+        s3Template.createSignedGetURL(
+            s3Properties.bucket,
+            objectKey,
+            Duration.ofMinutes(s3Properties.presignedGetExpiryMinutes),
+        ).toString()
+
+    fun deleteObject(objectKey: String) {
+        s3Template.deleteObject(s3Properties.bucket, objectKey)
+    }
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/service/UserService.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/service/UserService.kt
@@ -1,0 +1,84 @@
+package com.cowork.user.service
+
+import com.cowork.user.dto.*
+import com.cowork.user.repository.UserProfileRepository
+import com.cowork.user.repository.UserProfileSpecification
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+@Transactional(readOnly = true)
+class UserService(
+    private val userProfileRepository: UserProfileRepository,
+    private val s3Service: S3Service,
+) {
+
+    private fun findProfileOrThrow(userId: Long) =
+        userProfileRepository.findById(userId).orElseThrow {
+            ExpectedException("사용자를 찾을 수 없습니다. id=$userId", HttpStatus.NOT_FOUND)
+        }
+
+    fun getMyProfile(userId: Long): MyProfileResponse {
+        val profile = findProfileOrThrow(userId)
+        val imageUrl = profile.profileImageKey?.let { s3Service.generateGetPresignedUrl(it) }
+        return MyProfileResponse.of(profile, imageUrl)
+    }
+
+    @Transactional
+    fun updateMyProfile(userId: Long, request: UpdateMyProfileRequest): MyProfileResponse {
+        val profile = findProfileOrThrow(userId)
+        profile.updateSpecialty(request.specialty)
+        val imageUrl = profile.profileImageKey?.let { s3Service.generateGetPresignedUrl(it) }
+        return MyProfileResponse.of(profile, imageUrl)
+    }
+
+    fun generatePresignedUrl(userId: Long, contentType: String): PresignedUrlResponse {
+        s3Service.validateContentType(contentType)
+        findProfileOrThrow(userId)
+        val objectKey = s3Service.buildObjectKey(userId, contentType)
+        val uploadUrl = s3Service.generatePutPresignedUrl(objectKey, contentType)
+        return PresignedUrlResponse(uploadUrl = uploadUrl, objectKey = objectKey)
+    }
+
+    @Transactional
+    fun confirmUpload(userId: Long, objectKey: String) {
+        if (!objectKey.startsWith("profiles/$userId/")) {
+            throw ExpectedException("유효하지 않은 objectKey입니다.", HttpStatus.BAD_REQUEST)
+        }
+        val profile = findProfileOrThrow(userId)
+        profile.profileImageKey?.let { s3Service.deleteObject(it) }
+        profile.updateProfileImageKey(objectKey)
+    }
+
+    @Transactional
+    fun deleteProfileImage(userId: Long) {
+        val profile = findProfileOrThrow(userId)
+        profile.profileImageKey?.let { s3Service.deleteObject(it) }
+        profile.updateProfileImageKey(null)
+    }
+
+    fun getUserProfile(userId: Long): UserProfileResponse {
+        val profile = findProfileOrThrow(userId)
+        val imageUrl = profile.profileImageKey?.let { s3Service.generateGetPresignedUrl(it) }
+        return UserProfileResponse.of(profile, imageUrl)
+    }
+
+    fun searchUsers(
+        name: String?,
+        major: String?,
+        grade: Byte?,
+        cls: Byte?,
+        role: String?,
+        pageable: Pageable,
+    ): Page<UserProfileResponse> {
+        val spec = UserProfileSpecification.build(name, major, grade, cls, role)
+        return userProfileRepository.findAll(spec, pageable).map { profile ->
+            val imageUrl = profile.profileImageKey?.let { s3Service.generateGetPresignedUrl(it) }
+            UserProfileResponse.of(profile, imageUrl)
+        }
+    }
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/service/UserService.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/service/UserService.kt
@@ -50,15 +50,17 @@ class UserService(
             throw ExpectedException("유효하지 않은 objectKey입니다.", HttpStatus.BAD_REQUEST)
         }
         val profile = findProfileOrThrow(userId)
-        profile.profileImageKey?.let { s3Service.deleteObject(it) }
-        profile.updateProfileImageKey(objectKey)
+        val oldKey = profile.profileImageKey
+        profile.updateProfileImageKey(objectKey)   // DB 먼저
+        oldKey?.let { s3Service.deleteObject(it) } // S3 나중
     }
 
     @Transactional
     fun deleteProfileImage(userId: Long) {
         val profile = findProfileOrThrow(userId)
-        profile.profileImageKey?.let { s3Service.deleteObject(it) }
-        profile.updateProfileImageKey(null)
+        val oldKey = profile.profileImageKey
+        profile.updateProfileImageKey(null)        // DB 먼저
+        oldKey?.let { s3Service.deleteObject(it) } // S3 나중
     }
 
     fun getUserProfile(userId: Long): UserProfileResponse {

--- a/cowork-user/src/main/resources/application.yml
+++ b/cowork-user/src/main/resources/application.yml
@@ -1,0 +1,64 @@
+server:
+  port: 8082
+
+spring:
+  application:
+    name: cowork-user
+  datasource:
+    url: jdbc:mysql://localhost:3306/cowork_user?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${MYSQL_USER:cowork}
+    password: ${MYSQL_PASSWORD:}
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  instance:
+    prefer-ip-address: true
+
+spring.cloud.aws:
+  region:
+    static: ${AWS_REGION:ap-northeast-2}
+  credentials:
+    access-key: ${AWS_ACCESS_KEY:}
+    secret-key: ${AWS_SECRET_KEY:}
+
+s3:
+  bucket: ${S3_BUCKET:cowork-bucket}
+  presigned-put-expiry-minutes: 5
+  presigned-get-expiry-minutes: 15
+  max-file-size-bytes: 5242880  # 5MB
+  allowed-content-types:
+    - image/jpeg
+    - image/png
+    - image/webp
+
+sdk:
+  logging:
+    enabled: true
+    not-logging-urls:
+      - "/v3/api-docs/**"
+      - "/swagger-ui/**"
+  response:
+    enabled: false
+  swagger:
+    enabled: true
+    title: "cowork-user API"
+    description: "cowork-user 사용자 관리 서비스 API"
+    version: "v1"
+    group: "user"
+    paths-to-match:
+      - "/users/**"
+  exception:
+    enabled: false

--- a/cowork-user/src/main/resources/db/migration/V2__add_profile_image_key.sql
+++ b/cowork-user/src/main/resources/db/migration/V2__add_profile_image_key.sql
@@ -1,0 +1,4 @@
+ALTER TABLE tb_user_profiles
+    ADD COLUMN profile_image_key VARCHAR(500) DEFAULT NULL
+        COMMENT 'S3 object key (profiles/{userId}/{uuid}.ext)'
+        AFTER github_id;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,12 @@
 spring-boot = "3.4.4"
 spring-cloud = "2024.0.1"
 kotlin = "2.1.20"
+awspring-cloud = "3.2.1"
 
 [libraries]
 spring-cloud-dependencies = { module = "org.springframework.cloud:spring-cloud-dependencies", version.ref = "spring-cloud" }
+awspring-cloud-bom = { module = "io.awspring.cloud:spring-cloud-aws-dependencies", version.ref = "awspring-cloud" }
+awspring-cloud-s3 = { module = "io.awspring.cloud:spring-cloud-aws-starter-s3" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ include("cowork-config")
 
 // 비즈니스 서비스 모듈 — 스택 확정 후 include 추가
 // include("cowork-authorization")
-// include("cowork-user")
+include("cowork-user")
 // include("cowork-channel")
 // include("cowork-project")
 // include("cowork-team")


### PR DESCRIPTION
## 개요

`cowork-user` 서비스를 신규 모듈로 추가하였습니다.
사용자 프로필 조회, 수정, 검색 API와 S3 기반 프로필 이미지 업로드 플로우를 함께 구성하였습니다.

## 본문

신규 `cowork-user` Spring Boot 모듈을 멀티 모듈 설정에 포함하고, 실행에 필요한 Gradle 의존성과 AWS S3 관련 버전 설정을 추가하였습니다.

사용자 프로필 엔티티, 레포지토리, 검색 스펙, 서비스, 컨트롤러를 추가하여 다음 기능을 지원하도록 구성하였습니다.
- 내 프로필 조회 및 특기 수정
- 사용자 단건 조회
- 이름, 전공, 학년, 반, 역할 조건 기반 사용자 검색
- 프로필 이미지 업로드용 Presigned URL 발급
- 업로드 완료 확정 및 기존 이미지 삭제

S3 연동을 위해 설정 프로퍼티와 전용 서비스를 추가하였고, 허용 Content-Type 검증과 Object Key 규칙 검증을 적용하였습니다.

Flyway 마이그레이션을 추가하여 사용자 프로필 기본 테이블과 `profile_image_key` 컬럼을 반영하였습니다.
