### PR TITLE
[ci/cd] 배포 환경별 CI 흐름 정비

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -19,7 +19,7 @@ This project uses Git Flow. Feature branches must be created from `develop` and 
 2. Infer an appropriate branch name from the changes:
     - Format: `<type>/<kebab-case-description>` — use the same type as the planned commit (exception: use `cicd/` for `ci/cd` type)
     - Reflect the domain scope in the name
-    - Examples: `add/add-student-major-filter`, `fix/auth-api-key-deletion`, `refactor/optimize-club-query`
+    - Examples: `add/add-user-profile-api`, `fix/authorization-token-expiry`, `refactor/optimize-chat-query`
 3. Create and checkout the branch:
    ```bash
    git checkout -b <type>/<inferred-name>

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -36,19 +36,11 @@ Format: `type(scope): 설명`
 
 - **Types**: `add` / `update` / `fix` / `refactor` / `ci/cd` / `docs` / `test` / `delete` / `merge` (English)
 - **Scopes** (English):
-    - **Primary**: Domain names
-    - **Cross-cutting concerns only**: Module names or `global`
-    - Use domain names by default. Only use module names when changes affect multiple modules or are cross-cutting.
+    - **Primary**: Module names or `global`
 - **Description**: Korean, no period, avoid endings: `~한다/~된다`, `~하기/~하기 위해`, `~합니다/~됩니다`, `~했습니다`
     - Good examples: `엔티티 필드 추가`, `트랜잭션 롤백 방지`, `로직 개선`
 - Subject line only (no body)
 - Do NOT add AI tool as co-author
-
-## Scope Selection
-
-For the full scope selection table and examples, read `references/scope-guide.md`.
-
-Quick rule: use domain name by default. Use `global` / `ci/cd` / module names only for cross-cutting changes.
 
 ## Commit Flow
 

--- a/.agents/skills/write-pr/SKILL.md
+++ b/.agents/skills/write-pr/SKILL.md
@@ -25,7 +25,7 @@ Read `references/labels.md` and select 1–2 appropriate labels based on the nat
 ## Step 3 — Generate PR Content
 
 **Title** — Generate 3 options in the format `[scope] description`:
-- Scope: domain name (`[student]`, `[auth]`, `[application]`, `[club]`, etc.) or `[global]` / `[ci/cd]` for cross-cutting changes
+- Scope: Module name (`[user]`, `[authorization]`, `[gateway]`, `[chat]`, etc.) or `[global]` / `[ci/cd]` for cross-cutting changes
 - Description: Korean, concise, no emojis, max 50 characters total
 - Mark the best option with `← 추천`
 

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -19,7 +19,7 @@ This project uses Git Flow. Feature branches must be created from `develop` and 
 2. Infer an appropriate branch name from the changes:
     - Format: `<type>/<kebab-case-description>` — use the same type as the planned commit (exception: use `cicd/` for `ci/cd` type)
     - Reflect the domain scope in the name
-    - Examples: `add/add-student-major-filter`, `fix/auth-api-key-deletion`, `refactor/optimize-club-query`
+    - Examples: `add/add-user-profile-api`, `fix/authorization-token-expiry`, `refactor/optimize-chat-query`
 3. Create and checkout the branch:
    ```bash
    git checkout -b <type>/<inferred-name>

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -36,19 +36,11 @@ Format: `type(scope): 설명`
 
 - **Types**: `add` / `update` / `fix` / `refactor` / `ci/cd` / `docs` / `test` / `delete` / `merge` (English)
 - **Scopes** (English):
-    - **Primary**: Domain names
-    - **Cross-cutting concerns only**: Module names or `global`
-    - Use domain names by default. Only use module names when changes affect multiple modules or are cross-cutting.
+    - **Primary**: Module names or `global`
 - **Description**: Korean, no period, avoid endings: `~한다/~된다`, `~하기/~하기 위해`, `~합니다/~됩니다`, `~했습니다`
     - Good examples: `엔티티 필드 추가`, `트랜잭션 롤백 방지`, `로직 개선`
 - Subject line only (no body)
 - Do NOT add AI tool as co-author
-
-## Scope Selection
-
-For the full scope selection table and examples, read `references/scope-guide.md`.
-
-Quick rule: use domain name by default. Use `global` / `ci/cd` / module names only for cross-cutting changes.
 
 ## Commit Flow
 

--- a/.claude/skills/write-pr/SKILL.md
+++ b/.claude/skills/write-pr/SKILL.md
@@ -25,7 +25,7 @@ Read `references/labels.md` and select 1–2 appropriate labels based on the nat
 ## Step 3 — Generate PR Content
 
 **Title** — Generate 3 options in the format `[scope] description`:
-- Scope: domain name (`[student]`, `[auth]`, `[application]`, `[club]`, etc.) or `[global]` / `[ci/cd]` for cross-cutting changes
+- Scope: Module name (`[user]`, `[authorization]`, `[gateway]`, `[chat]`, etc.) or `[global]` / `[ci/cd]` for cross-cutting changes
 - Description: Korean, concise, no emojis, max 50 characters total
 - Mark the best option with `← 추천`
 

--- a/.github/workflows/cowork-prod-ci.yml
+++ b/.github/workflows/cowork-prod-ci.yml
@@ -1,0 +1,141 @@
+name: cowork prod CI Workflow
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-title:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Validate PR Title
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const prNumber = context.payload.pull_request.number;
+            const allowedScopes = [
+              'global', 'gateway', 'authorization', 'user',
+              'team', 'project', 'channel', 'chat', 'voice',
+              'config', 'ci/cd'
+            ];
+
+            const versionPattern = /^v\d{8}\.\d+$/;
+            if (versionPattern.test(title)) {
+              return;
+            }
+
+            const titlePattern = /^\[([^\]]+)\]\s+(.+)$/;
+            const match = title.match(titlePattern);
+            if (!match) {
+              core.setFailed('Invalid title format. Use [scope] title or vYYYYMMDD.n format');
+              return;
+            }
+
+            const scopesPart = match[1];
+            const titlePart = match[2];
+
+            if (titlePart.includes(':')) {
+              core.setFailed('Colon (:) is not allowed in the title');
+              return;
+            }
+            const scopes = scopesPart.split(',').map(s => s.trim());
+            const invalidScopes = scopes.filter(scope => !allowedScopes.includes(scope));
+            if (invalidScopes.length > 0) {
+              core.setFailed(`Invalid scope(s): ${invalidScopes.join(', ')}`);
+              return;
+            }
+
+  setup-pr-metadata:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Setup PR Metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-label "waiting for review:검토 대기"
+          gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-assignee "$PR_AUTHOR"
+          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan-O,hongjm0912,snowykte0426"
+          REVIEWERS=$(echo "$ALL_REVIEWERS" | tr ',' '\n' | grep -v "^${PR_AUTHOR}$" | tr '\n' ',' | sed 's/,$//')
+          if [ -n "$REVIEWERS" ]; then
+            gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "$REVIEWERS"
+          fi
+          gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "team-cowork/cowork-server"
+
+  build-and-test:
+    runs-on: ubuntu-latest
+    needs: [validate-title]
+    if: always() && (needs.validate-title.result == 'success' || needs.validate-title.result == 'skipped')
+
+    steps:
+#      - name: Checkout Code
+#        uses: actions/checkout@v6
+#
+#      - name: Setup JDK 25
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '25'
+#          distribution: 'temurin'
+#
+#      - name: Setup Gradle
+#        uses: gradle/actions/setup-gradle@v5
+#        with:
+#          cache-read-only: false
+#          cache-cleanup: always
+#
+#      - name: Test with Gradle
+#        run: ./gradlew build --parallel --build-cache
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [validate-title, setup-pr-metadata, build-and-test]
+    if: always()
+
+    steps:
+      - name: Determine Status
+        id: status
+        run: |
+          if [[ "${{ needs.validate-title.result }}" == "failure" ]] || \
+             [[ "${{ needs.build-and-test.result }}" == "failure" ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+            echo "color=0xFF4C4C" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.build-and-test.result }}" == "success" ]]; then
+            echo "status=success" >> $GITHUB_OUTPUT
+            echo "color=0x4CAF50" >> $GITHUB_OUTPUT
+          else
+            echo "status=cancelled" >> $GITHUB_OUTPUT
+            echo "color=0xFFA500" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Discord Notification
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
+          status: ${{ steps.status.outputs.status }}
+          color: ${{ steps.status.outputs.color }}
+          title: "Cowork Server Prod CI"
+          description: |
+            **Validate Title:** ${{ needs.validate-title.result }}
+            **Setup Metadata:** ${{ needs.setup-pr-metadata.result }}
+            **Build & Test:** ${{ needs.build-and-test.result }}

--- a/.github/workflows/cowork-stage-ci.yml
+++ b/.github/workflows/cowork-stage-ci.yml
@@ -1,0 +1,140 @@
+name: cowork stage CI Workflow
+
+on:
+  pull_request:
+    branches:
+      - 'develop'
+  push:
+    branches:
+      - 'develop'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate-title:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Validate PR Title
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const prNumber = context.payload.pull_request.number;
+            const allowedScopes = [
+              'global', 'account', 'auth', 'client', 'club',
+              'neis', 'oauth', 'project', 'student', 'utility',
+              'web', 'oauth', 'openapi', 'ci/cd', 'application'
+            ];
+
+            const versionPattern = /^v\d{8}\.\d+$/;
+            if (versionPattern.test(title)) {
+              return;
+            }
+
+            const titlePattern = /^\[([^\]]+)\]\s+(.+)$/;
+            const match = title.match(titlePattern);
+            if (!match) {
+              core.setFailed('Invalid title format. Use [scope] title or vYYYYMMDD.n format');
+              return;
+            }
+
+            const scopesPart = match[1];
+            const titlePart = match[2];
+
+            if (titlePart.includes(':')) {
+              core.setFailed('Colon (:) is not allowed in the title');
+              return;
+            }
+            const scopes = scopesPart.split(',').map(s => s.trim());
+            const invalidScopes = scopes.filter(scope => !allowedScopes.includes(scope));
+            if (invalidScopes.length > 0) {
+              core.setFailed(`Invalid scope(s): ${invalidScopes.join(', ')}`);
+              return;
+            }
+
+  setup-pr-metadata:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Setup PR Metadata
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+          gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-label "waiting for review:검토 대기"
+          gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-assignee "$PR_AUTHOR"
+          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan-O,hongjm0912,snowykte0426"
+          REVIEWERS=$(echo "$ALL_REVIEWERS" | tr ',' '\n' | grep -v "^${PR_AUTHOR}$" | tr '\n' ',' | sed 's/,$//')
+          if [ -n "$REVIEWERS" ]; then
+            gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "$REVIEWERS"
+          fi
+
+  build-and-test:
+    runs-on: ubuntu-latest
+    needs: [validate-title]
+    if: always() && (needs.validate-title.result == 'success' || needs.validate-title.result == 'skipped')
+
+    steps:
+#      - name: Checkout Code
+#        uses: actions/checkout@v6
+#
+#      - name: Setup JDK 25
+#        uses: actions/setup-java@v5
+#        with:
+#          java-version: '25'
+#          distribution: 'temurin'
+#
+#      - name: Setup Gradle
+#        uses: gradle/actions/setup-gradle@v5
+#        with:
+#          cache-read-only: false
+#          cache-cleanup: always
+#
+#      - name: Test with Gradle
+#        run: ./gradlew build --parallel --build-cache
+
+  notify:
+    runs-on: ubuntu-latest
+    needs: [validate-title, setup-pr-metadata, build-and-test]
+    if: always()
+
+    steps:
+      - name: Determine Status
+        id: status
+        run: |
+          if [[ "${{ needs.validate-title.result }}" == "failure" ]] || \
+             [[ "${{ needs.build-and-test.result }}" == "failure" ]]; then
+            echo "status=failure" >> $GITHUB_OUTPUT
+            echo "color=0xFF4C4C" >> $GITHUB_OUTPUT
+          elif [[ "${{ needs.build-and-test.result }}" == "success" ]]; then
+            echo "status=success" >> $GITHUB_OUTPUT
+            echo "color=0x4CAF50" >> $GITHUB_OUTPUT
+          else
+            echo "status=cancelled" >> $GITHUB_OUTPUT
+            echo "color=0xFFA500" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Send Discord Notification
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
+          status: ${{ steps.status.outputs.status }}
+          color: ${{ steps.status.outputs.color }}
+          title: "DataGSM Stage CI"
+          description: |
+            **Validate Title:** ${{ needs.validate-title.result }}
+            **Setup Metadata:** ${{ needs.setup-pr-metadata.result }}
+            **Build & Test:** ${{ needs.build-and-test.result }}


### PR DESCRIPTION
## 개요

`stage`와 `prod` GitHub Actions 워크플로를 분리하고, PR 제목 검증 및 메타데이터 설정 규칙을 환경에 맞게 정리하였습니다.
함께 사용 중인 커밋/PR 작성 스킬 문서도 모듈 기준 규칙에 맞춰 갱신하였습니다.

## 본문

GitHub Actions 워크플로를 stage와 prod 환경 기준으로 분리하였습니다.
`cowork-stage-ci.yml`은 `develop` 브랜치 기준으로 동작하도록 구성하였고, `cowork-prod-ci.yml`은 `main` 브랜치 기준으로 동작하도록 추가하였습니다.

prod 워크플로에는 현재 서버 모듈 구조에 맞는 PR 제목 scope 검증 규칙을 반영하였고, 팀 리뷰어 그룹을 자동으로 추가하도록 메타데이터 설정을 보강하였습니다.

두 워크플로 모두 PR 제목 검증, 리뷰어 및 assignee 설정, Discord 알림 전송 흐름을 포함하도록 정리하였으며, 빌드 단계는 이후 활성화를 고려해 유지하였습니다.

추가로 `.agents`와 `.claude`의 commit/write-pr 스킬 문서를 수정하여 scope 기준을 도메인 중심에서 모듈 중심으로 맞추었습니다.
