### PR TITLE
[global] PR 리뷰 댓글 자동 처리 스킬 추가

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: review-pr
+description: Collect PR review comments, critically assess each one against project conventions, auto-apply valid ones, post refutation replies for invalid ones, and prompt for partial ones. Replaces resolve-pr-comments.
+compatibility: Requires git, gh (GitHub CLI), and jq
+---
+
+## Step 1 — Collect PR Data
+
+```bash
+bash scripts/get-pr-data.sh
+```
+
+Output files:
+- `.pr-tmp/pr_comments.json` — inline review comments (id, path, line, body, user)
+- `.pr-tmp/pr_changed_files.txt` — changed files
+- `.pr-tmp/pr_commits.txt` — commits in this PR
+- `.pr-tmp/pr_diff.txt` — full diff
+
+Also fetch repo and PR metadata:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+gh pr view --json number,baseRefName -q '{number: .number, base: .baseRefName}'
+```
+
+## Step 2 — Assess Each Comment
+
+For each comment in `pr_comments.json`, apply the following **layered judgment criteria**:
+
+### Judgment criteria (priority order)
+
+1. **Project conventions** (primary): cross-reference CLAUDE.md and CONTRIBUTING.md
+    - DTO annotation rules, commit scope, logging style, exception message format, etc.
+2. **Language/framework best practices** (secondary): Kotlin official guide, Spring Boot recommendations
+    - Apply only when no matching project rule exists
+
+### Verdicts
+
+- **VALID**: reviewer is correct → attempt auto code fix
+- **INVALID**: reviewer is wrong with a clear refutation → skip, post refutation reply
+- **PARTIAL**: intent is correct but application method or scope is ambiguous → confirm with AskUserQuestion
+
+Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`, `Kotlin: prefer val over var`).
+
+## Step 3 — Act on Each Verdict
+
+### VALID → Auto fix
+
+1. Read the target file with the Read tool
+2. Apply the reviewer's concern with the Edit tool
+3. If the changes have not been committed yet, commit them
+4. Record the short commit hash for use in Step 5:
+   ```bash
+   git rev-parse --short HEAD
+   ```
+
+On failure: record the reason and fall back to PARTIAL.
+
+### INVALID → Skip
+
+Do not modify any code. Record the refutation rationale for Step 5.
+
+### PARTIAL → Confirm with AskUserQuestion
+
+Use the AskUserQuestion tool to ask:
+
+```
+⚠️ PARTIAL: [file:line] (reviewer)
+Review: "..."
+Rationale: ...
+Accept? (y / n / s = skip for now)
+```
+
+- `y`: treat as VALID, attempt code fix
+- `n`: treat as INVALID, skip
+- `s` / other: record as PENDING
+
+## Step 4 — Print Report
+
+```
+## review-pr Results
+
+| # | Reviewer | File | Verdict | Rationale | Action |
+|---|----------|------|---------|-----------|--------|
+| 1 | alice | Foo.kt:12 | ✅ VALID | CLAUDE.md §Logging Style | Auto-fixed (abc1234) |
+| 2 | bob | Bar.kt:34 | ❌ INVALID | CLAUDE.md §Exception Message | Skipped |
+| 3 | alice | Baz.kt:56 | ⚠️ PARTIAL | - | PENDING |
+```
+
+## Step 5 — Post GitHub Replies
+
+Post an inline reply for each comment. Always quote `path` and `comment_id` to prevent shell injection.
+
+```bash
+gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
+  -f body="<reply_body>"
+```
+
+For reply body templates, read `references/reply-formats.md`.
+
+## Step 6 — Cleanup
+
+```bash
+rm -rf .pr-tmp
+```

--- a/.agents/skills/review-pr/references  /reply-formats.md
+++ b/.agents/skills/review-pr/references  /reply-formats.md
@@ -1,0 +1,43 @@
+# GitHub Reply Formats
+
+Use these templates when posting inline replies in Step 5.
+Always quote `comment_id` to prevent shell injection.
+All replies must be written in Korean.
+
+## VALID — fix succeeded
+
+```
+<abc1234> 에서 반영했습니다. (근거: <출처>)
+```
+
+## VALID — fix failed
+
+```
+지적 사항이 타당합니다. 직접 수정이 필요하여 별도 처리하겠습니다.
+```
+
+## INVALID
+
+```
+해당 지적은 이 프로젝트의 컨벤션과 다릅니다.
+근거: <출처> — "<규칙 인용>"
+현재 코드가 규칙을 올바르게 따르고 있어 변경하지 않겠습니다.
+```
+
+## PARTIAL — accepted
+
+```
+부분적으로 타당하다고 판단하여 <abc1234> 에서 반영했습니다.
+```
+
+## PARTIAL — rejected
+
+```
+검토 결과 이 방향으로는 적용하지 않기로 결정했습니다.
+```
+
+## PARTIAL — pending
+
+```
+검토 중입니다. 추후 답변드리겠습니다.
+```

--- a/.agents/skills/review-pr/scripts/get-pr-data.sh
+++ b/.agents/skills/review-pr/scripts/get-pr-data.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null)
+if [ -z "$PR_NUMBER" ]; then
+  echo "ERROR: No open PR found for current branch." >&2
+  exit 1
+fi
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+BASE=$(gh pr view "$PR_NUMBER" --json baseRefName -q .baseRefName)
+
+mkdir -p .pr-tmp
+
+gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+  --jq '[.[] | {id, path, line, body, user: .user.login}]' \
+  > .pr-tmp/pr_comments.json
+
+git log "origin/$BASE..HEAD" --pretty=format:"%H %h %s" > .pr-tmp/pr_commits.txt
+
+git diff "origin/$BASE...HEAD" --name-only > .pr-tmp/pr_changed_files.txt
+
+git diff "origin/$BASE...HEAD" > .pr-tmp/pr_diff.txt
+
+echo "PR #$PR_NUMBER | Repo: $REPO | Base: $BASE"
+echo "Comments: $(jq length .pr-tmp/pr_comments.json), Changed files: $(wc -l < .pr-tmp/pr_changed_files.txt | tr -d ' ')"

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: review-pr
+description: Collect PR review comments, critically assess each one against project conventions, auto-apply valid ones, post refutation replies for invalid ones, and prompt for partial ones. Replaces resolve-pr-comments.
+disable-model-invocation: true
+allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read
+---
+
+## Step 1 — Collect PR Data
+
+```bash
+bash "${CLAUDE_SKILL_DIR}/scripts/get-pr-data.sh"
+```
+
+Output files:
+- `.pr-tmp/pr_comments.json` — inline review comments (id, path, line, body, user)
+- `.pr-tmp/pr_changed_files.txt` — changed files
+- `.pr-tmp/pr_commits.txt` — commits in this PR
+- `.pr-tmp/pr_diff.txt` — full diff
+
+Also fetch repo and PR metadata:
+
+```bash
+gh repo view --json nameWithOwner -q .nameWithOwner
+gh pr view --json number,baseRefName -q '{number: .number, base: .baseRefName}'
+```
+
+## Step 2 — Load Rules and Assess Each Comment
+
+Before assessing any comment, discover and read all project convention files:
+
+```bash
+find .claude/rules -name "*.md" 2>/dev/null
+```
+
+Read each returned file in full. These are the authoritative rules for judging each review comment.
+
+**Rule priority**: `CLAUDE.md` > `.claude/rules/**` > `.gemini/styleguide.md` > `CONTRIBUTING.md`
+
+For each comment in `pr_comments.json`, apply the following **layered judgment criteria**:
+
+### Judgment criteria (priority order)
+
+1. **Project conventions** (primary): apply rules discovered above
+    - DTO annotation rules, commit scope, logging style, exception message format, etc.
+2. **Language/framework best practices** (secondary): Kotlin official guide, Spring Boot recommendations
+    - Apply only when no matching project rule exists
+
+### Verdicts
+
+- **VALID**: reviewer is correct → attempt auto code fix
+- **INVALID**: reviewer is wrong with a clear refutation → skip, post refutation reply
+- **PARTIAL**: intent is correct but application method or scope is ambiguous → confirm with AskUserQuestion
+
+Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`, `Kotlin: prefer val over var`).
+
+## Step 3 — Act on Each Verdict
+
+### VALID → Auto fix
+
+1. Read the target file with the Read tool
+2. Apply the reviewer's concern with the Edit tool
+3. If the changes have not been committed yet, commit them
+4. Record the short commit hash for use in Step 5:
+   ```bash
+   git rev-parse --short HEAD
+   ```
+
+On failure: record the reason and fall back to PARTIAL.
+
+### INVALID → Skip
+
+Do not modify any code. Record the refutation rationale for Step 5.
+
+### PARTIAL → Confirm with AskUserQuestion
+
+Use the AskUserQuestion tool to ask:
+
+```
+⚠️ PARTIAL: [file:line] (reviewer)
+Review: "..."
+Rationale: ...
+Accept? (y / n / s = skip for now)
+```
+
+- `y`: treat as VALID, attempt code fix
+- `n`: treat as INVALID, skip
+- `s` / other: record as PENDING
+
+## Step 4 — Print Report
+
+```
+## review-pr Results
+
+| # | Reviewer | File | Verdict | Rationale | Action |
+|---|----------|------|---------|-----------|--------|
+| 1 | alice | Foo.kt:12 | ✅ VALID | CLAUDE.md §Logging Style | Auto-fixed (abc1234) |
+| 2 | bob | Bar.kt:34 | ❌ INVALID | CLAUDE.md §Exception Message | Skipped |
+| 3 | alice | Baz.kt:56 | ⚠️ PARTIAL | - | PENDING |
+```
+
+## Step 5 — Post GitHub Replies
+
+Post an inline reply for each comment. Always quote `path` and `comment_id` to prevent shell injection.
+
+```bash
+gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
+  -f body="<reply_body>"
+```
+
+For reply body templates, read `${CLAUDE_SKILL_DIR}/references/reply-formats.md`.
+
+## Step 6 — Cleanup
+
+```bash
+rm -rf .pr-tmp
+```

--- a/.claude/skills/review-pr/references/reply-formats.md
+++ b/.claude/skills/review-pr/references/reply-formats.md
@@ -1,0 +1,43 @@
+# GitHub Reply Formats
+
+Use these templates when posting inline replies in Step 5.
+Always quote `comment_id` to prevent shell injection.
+All replies must be written in Korean.
+
+## VALID — fix succeeded
+
+```
+<abc1234> 에서 반영했습니다. (근거: <출처>)
+```
+
+## VALID — fix failed
+
+```
+지적 사항이 타당합니다. 직접 수정이 필요하여 별도 처리하겠습니다.
+```
+
+## INVALID
+
+```
+해당 지적은 이 프로젝트의 컨벤션과 다릅니다.
+근거: <출처> — "<규칙 인용>"
+현재 코드가 규칙을 올바르게 따르고 있어 변경하지 않겠습니다.
+```
+
+## PARTIAL — accepted
+
+```
+부분적으로 타당하다고 판단하여 <abc1234> 에서 반영했습니다.
+```
+
+## PARTIAL — rejected
+
+```
+검토 결과 이 방향으로는 적용하지 않기로 결정했습니다.
+```
+
+## PARTIAL — pending
+
+```
+검토 중입니다. 추후 답변드리겠습니다.
+```

--- a/.claude/skills/review-pr/scripts  /get-pr-data.sh
+++ b/.claude/skills/review-pr/scripts  /get-pr-data.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+PR_NUMBER=$(gh pr view --json number -q .number 2>/dev/null)
+if [ -z "$PR_NUMBER" ]; then
+  echo "ERROR: No open PR found for current branch." >&2
+  exit 1
+fi
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+BASE=$(gh pr view "$PR_NUMBER" --json baseRefName -q .baseRefName)
+
+mkdir -p .pr-tmp
+
+gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
+  --jq '[.[] | {id, path, line, body, user: .user.login}]' \
+  > .pr-tmp/pr_comments.json
+
+git log "origin/$BASE..HEAD" --pretty=format:"%H %h %s" > .pr-tmp/pr_commits.txt
+
+git diff "origin/$BASE...HEAD" --name-only > .pr-tmp/pr_changed_files.txt
+
+git diff "origin/$BASE...HEAD" > .pr-tmp/pr_diff.txt
+
+echo "PR #$PR_NUMBER | Repo: $REPO | Base: $BASE"
+echo "Comments: $(jq length .pr-tmp/pr_comments.json), Changed files: $(wc -l < .pr-tmp/pr_changed_files.txt | tr -d ' ')"


### PR DESCRIPTION
## 개요

PR 리뷰 댓글을 수집하고 프로젝트 컨벤션 기준으로 타당성을 평가하여, 유효한 댓글은 코드에 자동 반영하고 무효한 댓글은 반박 답글을 포스팅하는 `review-pr` 스킬을 추가하였습니다. `.agents/skills/` 및 `.claude/skills/` 양쪽에 동일하게 구성하였습니다.

## 본문

### 추가된 파일 구성

- `SKILL.md` — 스킬 실행 절차 정의 (6단계: 데이터 수집 → 판정 → 코드 수정 → 리포트 출력 → GitHub 답글 포스팅 → 임시 파일 정리)
- `scripts/get-pr-data.sh` — `gh` CLI를 사용하여 PR 인라인 댓글, 변경 파일 목록, 커밋 이력, diff를 `.pr-tmp/` 디렉토리에 수집하는 쉘 스크립트
- `references/reply-formats.md` — VALID / INVALID / PARTIAL 각 판정 결과에 따른 GitHub 인라인 답글 한국어 템플릿

### 판정 로직 개요

| 판정 | 조건 | 처리 |
|------|------|------|
| VALID | 리뷰어가 올바름 | 코드 자동 수정 후 커밋, 커밋 해시 답글 포스팅 |
| INVALID | 리뷰어가 틀림 (근거 명확) | 코드 미수정, 반박 근거 답글 포스팅 |
| PARTIAL | 의도는 맞으나 적용 방법이 모호 | 사용자에게 확인 후 VALID/INVALID로 처리 |

판정 기준 우선순위는 `CLAUDE.md` > `.claude/rules/**` > `CONTRIBUTING.md` > 언어·프레임워크 공식 가이드 순으로 적용됩니다.
