### PR TITLE
[global] review-pr 스킬 gh api 및 스크립트 경로 수정

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -7,7 +7,7 @@ compatibility: Requires git, gh (GitHub CLI), and jq
 ## Step 1 — Collect PR Data
 
 ```bash
-bash scripts/get-pr-data.sh
+bash .agents/skills/review-pr/scripts/get-pr-data.sh
 ```
 
 Output files:
@@ -92,10 +92,11 @@ Accept? (y / n / s = skip for now)
 Post an inline reply for each comment. Always quote `path` and `comment_id` to prevent shell injection.
 
 ```bash
-gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
-  -f body="<reply_body>"
+gh api "repos/$REPO/pulls/$PR_NUMBER/comments/<comment_id>/replies" \
+  --field body=@- <<EOF
+<reply_body>
+EOF
 ```
-
 For reply body templates, read `references/reply-formats.md`.
 
 ## Step 6 — Cleanup

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -93,7 +93,7 @@ Post an inline reply for each comment. Always quote `path` and `comment_id` to p
 
 ```bash
 gh api "repos/$REPO/pulls/$PR_NUMBER/comments/<comment_id>/replies" \
-  --field body=@- <<EOF
+  --field body=@- <<'EOF'
 <reply_body>
 EOF
 ```

--- a/.agents/skills/review-pr/scripts/get-pr-data.sh
+++ b/.agents/skills/review-pr/scripts/get-pr-data.sh
@@ -12,9 +12,9 @@ BASE=$(gh pr view "$PR_NUMBER" --json baseRefName -q .baseRefName)
 
 mkdir -p .pr-tmp
 
-gh api "repos/$REPO/pulls/$PR_NUMBER/comments" \
-  --jq '[.[] | {id, path, line, body, user: .user.login}]' \
-  > .pr-tmp/pr_comments.json
+gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/comments" \
+  --jq '.[] | {id, path, line, body, user: .user.login}' \
+  | jq -s '.' > .pr-tmp/pr_comments.json
 
 git log "origin/$BASE..HEAD" --pretty=format:"%H %h %s" > .pr-tmp/pr_commits.txt
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -104,7 +104,7 @@ Post an inline reply for each comment. Always quote `path` and `comment_id` to p
 
 ```bash
 gh api "repos/$REPO/pulls/$PR_NUMBER/comments/<comment_id>/replies" \
-  --field body=@- <<EOF
+  --field body=@- <<'EOF'
 <reply_body>
 EOF
 ```

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -103,8 +103,10 @@ Accept? (y / n / s = skip for now)
 Post an inline reply for each comment. Always quote `path` and `comment_id` to prevent shell injection.
 
 ```bash
-gh api "repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies" \
-  -f body="<reply_body>"
+gh api "repos/$REPO/pulls/$PR_NUMBER/comments/<comment_id>/replies" \
+  --field body=@- <<EOF
+<reply_body>
+EOF
 ```
 
 For reply body templates, read `${CLAUDE_SKILL_DIR}/references/reply-formats.md`.


### PR DESCRIPTION
## 개요

`review-pr` 스킬의 스크립트 경로 오류 및 `gh api` 명령 사용 방식을 수정하였습니다.

## 본문

### 수정 사항

**스크립트 경로 수정** (`.agents/skills/review-pr/SKILL.md`)

- `bash scripts/get-pr-data.sh` → `bash .agents/skills/review-pr/scripts/get-pr-data.sh`
- 작업 디렉토리에 관계없이 스크립트를 올바르게 실행할 수 있도록 절대 경로 기준으로 수정하였습니다.

**`gh api` 페이지네이션 처리** (`scripts/get-pr-data.sh`)

- `gh api` → `gh api --paginate` 로 변경하여 댓글이 30개를 초과하는 경우에도 전체 댓글을 수집할 수 있도록 수정하였습니다.
- `--jq '[.[] | ...]'` 방식에서 `--jq '.[] | ...' | jq -s '.'` 방식으로 변경하여 페이지네이션과의 호환성을 확보하였습니다.

**`gh api` 답글 포스팅 방식 수정** (`.agents/`, `.claude/` SKILL.md)

- `-f body="<reply_body>"` → `--field body=@- <<EOF` heredoc 방식으로 변경하였습니다.
- 답글 본문에 특수문자나 줄바꿈이 포함되어도 안전하게 전달할 수 있도록 개선하였습니다.
