### PR TITLE
[global] review-pr 스킬 VALID 처리 시 push 누락 수정

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -48,7 +48,12 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
 
 1. Read the target file with the Read tool
 2. Apply the reviewer's concern with the Edit tool
-3. If the changes have not been committed yet, commit them
+3. Commit and push the changes:
+   ```bash
+   git add <file>
+   git commit -m "<message>"
+   git push
+   ```
 4. Record the short commit hash for use in Step 5:
    ```bash
    git rev-parse --short HEAD

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: review-pr
 description: Collect PR review comments, critically assess each one against project conventions, auto-apply valid ones, post refutation replies for invalid ones, and prompt for partial ones. Replaces resolve-pr-comments.
 disable-model-invocation: true
-allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read
+allowed-tools: Bash(bash *get-pr-data.sh:*), Bash(gh api:*), Bash(gh pr view:*), Bash(gh repo:*), Bash(git add:*), Bash(git commit:*), Bash(git log:*), Bash(git push:*), Bash(git rev-parse:*), Bash(rm:*), Edit, Read
 ---
 
 ## Step 1 — Collect PR Data

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -59,7 +59,12 @@ Always cite a specific source in the rationale (e.g. `CLAUDE.md §Logging Style`
 
 1. Read the target file with the Read tool
 2. Apply the reviewer's concern with the Edit tool
-3. If the changes have not been committed yet, commit them
+3. Commit and push the changes:
+   ```bash
+   git add <file>
+   git commit -m "<message>"
+   git push
+   ```
 4. Record the short commit hash for use in Step 5:
    ```bash
    git rev-parse --short HEAD


### PR DESCRIPTION
## 개요

`review-pr` 스킬의 VALID 판정 처리 절차에서 커밋 후 `git push`가 누락되어 있던 문제를 수정하였습니다.

## 본문

기존 Step 3 VALID 처리에서는 코드 수정 후 커밋만 수행하고 원격 브랜치에 push하지 않아, GitHub 답글에 기록되는 커밋 해시가 원격에 반영되지 않은 상태에서 포스팅되는 문제가 있었습니다.

`git commit` 이후 `git push`까지 포함하도록 절차를 수정하였습니다. `.agents/skills/` 및 `.claude/skills/` 양쪽 SKILL.md에 동일하게 반영하였습니다.
