### PR TITLE
[ci/cd] 리뷰어 지정 방식 팀 단위 변경 및 스코프 명칭 업데이트

### DIFF
--- a/.github/workflows/cowork-prod-ci.yml
+++ b/.github/workflows/cowork-prod-ci.yml
@@ -76,11 +76,6 @@ jobs:
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-label "waiting for review:검토 대기"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-assignee "$PR_AUTHOR"
-          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan-O,hongjm0912,snowykte0426"
-          REVIEWERS=$(echo "$ALL_REVIEWERS" | tr ',' '\n' | grep -v "^${PR_AUTHOR}$" | tr '\n' ',' | sed 's/,$//')
-          if [ -n "$REVIEWERS" ]; then
-            gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "$REVIEWERS"
-          fi
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "team-cowork/cowork-server"
 
   build-and-test:

--- a/.github/workflows/cowork-stage-ci.yml
+++ b/.github/workflows/cowork-stage-ci.yml
@@ -28,9 +28,9 @@ jobs:
             const title = context.payload.pull_request.title;
             const prNumber = context.payload.pull_request.number;
             const allowedScopes = [
-              'global', 'account', 'auth', 'client', 'club',
-              'neis', 'oauth', 'project', 'student', 'utility',
-              'web', 'oauth', 'openapi', 'ci/cd', 'application'
+              'global', 'gateway', 'authorization', 'user',
+              'team', 'project', 'channel', 'chat', 'voice',
+              'config', 'ci/cd'
             ];
 
             const versionPattern = /^v\d{8}\.\d+$/;
@@ -76,11 +76,7 @@ jobs:
           PR_AUTHOR="${{ github.event.pull_request.user.login }}"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-label "waiting for review:검토 대기"
           gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-assignee "$PR_AUTHOR"
-          ALL_REVIEWERS="wwwcomcomcomcom,ZaMan-O,hongjm0912,snowykte0426"
-          REVIEWERS=$(echo "$ALL_REVIEWERS" | tr ',' '\n' | grep -v "^${PR_AUTHOR}$" | tr '\n' ',' | sed 's/,$//')
-          if [ -n "$REVIEWERS" ]; then
-            gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "$REVIEWERS"
-          fi
+          gh pr edit $PR_NUMBER --repo ${{ github.repository }} --add-reviewer "team-cowork/cowork-server"
 
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 개요
CI/CD 워크플로우에서 리뷰어를 개별적으로 지정하던 로직을 팀 단위 지정으로 간소화하고, 변경된 프로젝트 구조에 맞춰 허용되는 스코프 목록을 업데이트하였습니다.

## 본문
- 개별 사용자 ID를 나열하여 리뷰어를 지정하던 방식을 `team-cowork/cowork-server` 팀 전체를 지정하는 방식으로 변경하여 유지보수성을 높였습니다.
- `cowork-stage-ci.yml` 워크플로우에서 PR 제목 검증 시 사용되는 `allowedScopes` 목록을 실제 프로젝트 모듈 구조(`gateway`, `user`, `team` 등)에 맞게 최신화하였습니다.
- 불필요한 리뷰어 필터링 쉘 스크립트 로직을 제거하여 워크플로우의 가독성을 개선하였습니다.