### PR TITLE
[global] Gateway 필터 최적화 및 Kafka 기반 유저 데이터 동기화 기능 추가

### DIFF
--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/ApiResponseWrapperFilter.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/ApiResponseWrapperFilter.kt
@@ -50,23 +50,21 @@ class ApiResponseWrapperFilter(
                     return super.writeWith(body)
                 }
 
-                // 버퍼를 전부 수집한 뒤 크기를 판단 (Chunked 응답도 처리)
+                // 1단계: Content-Length가 명시된 경우 collectList 전에 조기 반환 (OOM 방지)
+                val contentLength = headers.contentLength
+                if (contentLength > maxWrappableBytes) {
+                    return super.writeWith(body)
+                }
+
+                // 2단계: 버퍼를 전부 수집한 뒤 실제 크기를 재검증 (Chunked 응답 대응)
                 val modifiedBody: Mono<DataBuffer> = Flux.from(body)
                     .collectList()
                     .flatMap { buffers ->
                         val totalSize = buffers.sumOf { it.readableByteCount() }
 
-                        // 임계값 초과 시 수집한 버퍼를 합쳐서 그대로 통과 (OOM 방지)
+                        // 수집 후에도 임계값 초과 시 버퍼를 그대로 합쳐 통과
                         if (totalSize > maxWrappableBytes) {
-                            val bytes = ByteArray(totalSize)
-                            var offset = 0
-                            buffers.forEach { buf ->
-                                val len = buf.readableByteCount()
-                                buf.read(bytes, offset, len)
-                                DataBufferUtils.release(buf)
-                                offset += len
-                            }
-                            return@flatMap Mono.just(bufferFactory().wrap(bytes))
+                            return@flatMap DataBufferUtils.join(Flux.fromIterable(buffers))
                         }
 
                         val bytes = ByteArray(totalSize)

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/ApiResponseWrapperFilter.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/ApiResponseWrapperFilter.kt
@@ -49,18 +49,26 @@ class ApiResponseWrapperFilter(
                 if (contentType == null || !contentType.isCompatibleWith(MediaType.APPLICATION_JSON)) {
                     return super.writeWith(body)
                 }
-                // Content-Length가 없거나(Chunked 등) 임계값을 초과하면 래핑 스킵 (OOM 방지)
-                // contentLength == -1: Content-Length 헤더 없음 → 전체 크기 불명 → 버퍼링 불가
-                val contentLength = headers.contentLength
-                if (contentLength < 0 || contentLength > maxWrappableBytes) {
-                    return super.writeWith(body)
-                }
 
+                // 버퍼를 전부 수집한 뒤 크기를 판단 (Chunked 응답도 처리)
                 val modifiedBody: Mono<DataBuffer> = Flux.from(body)
                     .collectList()
                     .flatMap { buffers ->
-                        // 미리 전체 크기를 계산해 단일 배열에 복사 (O(n) 보장)
                         val totalSize = buffers.sumOf { it.readableByteCount() }
+
+                        // 임계값 초과 시 수집한 버퍼를 합쳐서 그대로 통과 (OOM 방지)
+                        if (totalSize > maxWrappableBytes) {
+                            val bytes = ByteArray(totalSize)
+                            var offset = 0
+                            buffers.forEach { buf ->
+                                val len = buf.readableByteCount()
+                                buf.read(bytes, offset, len)
+                                DataBufferUtils.release(buf)
+                                offset += len
+                            }
+                            return@flatMap Mono.just(bufferFactory().wrap(bytes))
+                        }
+
                         val bytes = ByteArray(totalSize)
                         var offset = 0
                         buffers.forEach { buf ->
@@ -77,7 +85,7 @@ class ApiResponseWrapperFilter(
                         val wrapped = buildWrappedResponse(bytes, httpStatus)
                         val wrappedBytes = objectMapper.writeValueAsBytes(wrapped)
 
-                        // Content-Length 갱신
+                        // Content-Length 갱신 (Chunked였던 경우에도 명시)
                         headers.contentLength = wrappedBytes.size.toLong()
 
                         Mono.just(bufferFactory().wrap(wrappedBytes))

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/security/JwtServerAuthenticationConverter.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/security/JwtServerAuthenticationConverter.kt
@@ -4,7 +4,6 @@ import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
-import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.web.server.authentication.ServerAuthenticationConverter
 import org.springframework.stereotype.Component
 import org.springframework.web.server.ServerWebExchange
@@ -31,8 +30,8 @@ class JwtServerAuthenticationConverter(
                 .payload
 
             val userId = claims.subject
-            val role = claims.get("role", String::class.java) ?: "ROLE_USER"
-            val authorities = listOf(SimpleGrantedAuthority(role))
+            val role = claims.get("role", String::class.java) ?: "USER"
+            val authorities = listOf(RoleGrantedAuthority(role))
 
             val auth = UsernamePasswordAuthenticationToken(userId, token, authorities)
             auth.details = mapOf("userId" to userId, "role" to role)

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/security/RoleGrantedAuthority.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/security/RoleGrantedAuthority.kt
@@ -1,0 +1,9 @@
+package com.cowork.gateway.security
+
+import org.springframework.security.core.GrantedAuthority
+
+class RoleGrantedAuthority(private val role: String) : GrantedAuthority {
+
+    override fun getAuthority(): String =
+        if (role.startsWith("ROLE_")) role else "ROLE_$role"
+}

--- a/cowork-user/build.gradle.kts
+++ b/cowork-user/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation("org.flywaydb:flyway-mysql")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.github.themoment-team:the-sdk:1.5")
+    implementation("org.springframework.kafka:spring-kafka")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/cowork-user/src/main/kotlin/com/cowork/user/messaging/UserSyncConsumer.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/messaging/UserSyncConsumer.kt
@@ -1,0 +1,44 @@
+package com.cowork.user.messaging
+
+import com.cowork.user.domain.UserProfile
+import com.cowork.user.messaging.event.UserCreatedEvent
+import com.cowork.user.repository.UserProfileRepository
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class UserSyncConsumer(
+    private val userProfileRepository: UserProfileRepository,
+) {
+
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    @KafkaListener(topics = ["user.data.sync"], groupId = "cowork-user")
+    fun handleUserCreated(event: UserCreatedEvent) {
+        if (userProfileRepository.existsById(event.userId)) {
+            log.warn("UserProfile already exists, skipping. userId={}", event.userId)
+            return
+        }
+
+        val profile = UserProfile(
+            id = event.userId,
+            name = event.name,
+            email = event.email,
+            sex = event.sex,
+            grade = event.grade,
+            `class` = event.`class`,
+            classNum = event.classNum,
+            major = event.major,
+            role = event.role,
+            githubId = event.githubId,
+            specialty = null,
+            profileImageKey = null,
+        )
+
+        userProfileRepository.save(profile)
+        log.info("UserProfile created. userId={}", event.userId)
+    }
+}

--- a/cowork-user/src/main/kotlin/com/cowork/user/messaging/event/UserCreatedEvent.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/messaging/event/UserCreatedEvent.kt
@@ -1,0 +1,22 @@
+package com.cowork.user.messaging.event
+
+import com.cowork.user.domain.Major
+import com.cowork.user.domain.Role
+import com.cowork.user.domain.Sex
+
+/**
+ * authorization 서비스가 회원가입 완료 후 `user.data.sync` 토픽으로 발행하는 이벤트.
+ * UserProfile 생성에 필요한 최소 정보를 담는다.
+ */
+data class UserCreatedEvent(
+    val userId: Long,
+    val name: String,
+    val email: String,
+    val sex: Sex,
+    val grade: Byte?,
+    val `class`: Byte?,
+    val classNum: Byte?,
+    val major: Major,
+    val role: Role,
+    val githubId: String?,
+)

--- a/cowork-user/src/main/resources/application.yml
+++ b/cowork-user/src/main/resources/application.yml
@@ -19,6 +19,15 @@ spring:
   flyway:
     enabled: true
     locations: classpath:db/migration
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9094}
+    consumer:
+      group-id: cowork-user
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "com.cowork.user.messaging.event"
 
 eureka:
   client:


### PR DESCRIPTION
## 개요
Gateway의 응답 래핑 로직과 권한 변환 방식을 개선하고, User 서비스에 Kafka를 연동하여 유저 데이터 동기화 기능을 추가하였습니다.

## 본문
### Gateway
- `ApiResponseWrapperFilter`에서 Chunked 응답도 처리할 수 있도록 버퍼 수집 로직을 개선하였습니다.
- `JwtServerAuthenticationConverter`에서 권한을 생성할 때 `RoleGrantedAuthority`를 사용하도록 변경하여 `ROLE_` 접두사 처리를 자동화하였습니다.

### User
- Kafka 의존성을 추가하고 `application.yml`에 관련 설정을 구성하였습니다.
- `authorization` 서비스로부터 유저 생성 이벤트를 수신하여 `UserProfile`을 자동으로 생성하는 `UserSyncConsumer`를 구현하였습니다.