### PR TITLE
[chat] tsconfig Node.js 타입 설정 및 DTO 필드 초기화 수정

### DIFF
--- a/cowork-chat/package-lock.json
+++ b/cowork-chat/package-lock.json
@@ -14,11 +14,14 @@
         "@nestjs/platform-express": "^11.1.19",
         "@nestjs/platform-socket.io": "^11.1.19",
         "@nestjs/websockets": "^11.1.19",
+        "class-transformer": "^0.5.1",
+        "class-validator": "^0.14.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
         "socket.io": "^4.8.3"
       },
       "devDependencies": {
+        "@types/node": "^22.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.2"
       }
@@ -301,13 +304,19 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/validator": {
+      "version": "13.15.10",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
+      "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -456,6 +465,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/class-validator": {
+      "version": "0.14.4",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.4.tgz",
+      "integrity": "sha512-AwNusCCam51q703dW82x95tOqQp6oC9HNUl724KxJJOfnKscI8dOloXFgyez7LbTTKWuRBA37FScqVbJEoq8Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/validator": "^13.15.3",
+        "libphonenumber-js": "^1.11.1",
+        "validator": "^13.15.22"
       }
     },
     "node_modules/concat-stream": {
@@ -1002,6 +1028,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.12.41",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.12.41.tgz",
+      "integrity": "sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==",
+      "license": "MIT"
     },
     "node_modules/load-esm": {
       "version": "1.0.3",
@@ -1739,9 +1771,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -1765,6 +1797,15 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/cowork-chat/package.json
+++ b/cowork-chat/package.json
@@ -26,6 +26,7 @@
     "class-transformer": "^0.5.1"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.2"
   }

--- a/cowork-chat/src/message-payload.dto.ts
+++ b/cowork-chat/src/message-payload.dto.ts
@@ -2,8 +2,8 @@ import { IsString } from 'class-validator';
 
 export class MessagePayload {
     @IsString()
-    channelId: string;
+    channelId!: string;
 
     @IsString()
-    content: string;
+    content!: string;
 }

--- a/cowork-chat/tsconfig.json
+++ b/cowork-chat/tsconfig.json
@@ -7,7 +7,6 @@
     "esModuleInterop": true,
     "strict": true,
     "outDir": "./dist",
-    "rootDir": "./src",
-    "types": ["node"]
+    "rootDir": "./src"
   }
 }

--- a/cowork-chat/tsconfig.json
+++ b/cowork-chat/tsconfig.json
@@ -7,6 +7,7 @@
     "esModuleInterop": true,
     "strict": true,
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "types": ["node"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "cowork-server",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "@types/node": "^25.6.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "devDependencies": {
+    "@types/node": "^25.6.0"
+  }
+}


### PR DESCRIPTION
## 개요

cowork-chat 모듈의 TypeScript 컴파일 오류를 해소하였습니다. tsconfig에 Node.js 타입 참조를 추가하고, strict 모드에서 발생하는 DTO 필드 초기화 오류를 definite assignment 연산자(`!`)로 해결하였습니다.

## 본문

**변경 사항**

- `cowork-chat/tsconfig.json`: `"types": ["node"]` 추가 — Node.js 내장 타입(`process.env` 등)을 TypeScript에서 인식할 수 있도록 설정하였습니다.
- `package.json` / `package-lock.json` (루트): `@types/node` devDependency를 추가하여 Node.js 타입 정의를 설치하였습니다.
- `cowork-chat/src/message-payload.dto.ts`: `strict` 모드의 definite assignment 검사를 통과하도록 `channelId`·`content` 필드에 `!` 연산자를 명시하였습니다.
