### PR TITLE
[chat] socket.io-client 의존성 및 테스트 스크립트 추가

### DIFF
--- a/cowork-chat/package-lock.json
+++ b/cowork-chat/package-lock.json
@@ -18,7 +18,8 @@
         "class-validator": "^0.14.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
-        "socket.io": "^4.8.3"
+        "socket.io": "^4.8.3",
+        "socket.io-client": "^4.8.3"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -656,6 +657,19 @@
       },
       "engines": {
         "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3",
+        "xmlhttprequest-ssl": "~2.1.1"
       }
     },
     "node_modules/engine.io-parser": {
@@ -1537,6 +1551,21 @@
         "ws": "~8.18.3"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
@@ -1841,6 +1870,14 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/yn": {

--- a/cowork-chat/package-lock.json
+++ b/cowork-chat/package-lock.json
@@ -18,11 +18,11 @@
         "class-validator": "^0.14.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.2",
-        "socket.io": "^4.8.3",
-        "socket.io-client": "^4.8.3"
+        "socket.io": "^4.8.3"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "socket.io-client": "^4.8.3",
         "ts-node": "^10.9.2",
         "typescript": "^6.0.2"
       }
@@ -663,6 +663,7 @@
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
       "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -1555,6 +1556,7 @@
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -1876,6 +1878,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
       "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }

--- a/cowork-chat/package.json
+++ b/cowork-chat/package.json
@@ -19,11 +19,12 @@
     "@nestjs/platform-express": "^11.1.19",
     "@nestjs/platform-socket.io": "^11.1.19",
     "@nestjs/websockets": "^11.1.19",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
     "socket.io": "^4.8.3",
-    "class-validator": "^0.14.1",
-    "class-transformer": "^0.5.1"
+    "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/cowork-chat/package.json
+++ b/cowork-chat/package.json
@@ -23,11 +23,11 @@
     "class-validator": "^0.14.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.2",
-    "socket.io": "^4.8.3",
-    "socket.io-client": "^4.8.3"
+    "socket.io": "^4.8.3"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "socket.io-client": "^4.8.3",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.2"
   }

--- a/cowork-chat/test/test.js
+++ b/cowork-chat/test/test.js
@@ -13,3 +13,7 @@ socket.on("connect", () => {
 socket.on("message", (data) => {
     console.log("📨 received:", data);
 });
+
+socket.on("connect_error", (err) => {
+    console.error("❌ connection error:", err.message);
+});

--- a/cowork-chat/test/test.js
+++ b/cowork-chat/test/test.js
@@ -1,0 +1,15 @@
+const { io } = require("socket.io-client");
+
+const socket = io("http://localhost:3000");
+
+socket.on("connect", () => {
+    console.log("✅ connected");
+
+    socket.emit("message", {
+        content: "hello"
+    });
+});
+
+socket.on("message", (data) => {
+    console.log("📨 received:", data);
+});


### PR DESCRIPTION
## 개요

`cowork-chat` 모듈에 `socket.io-client` 의존성을 추가하고, WebSocket 연결을 직접 확인할 수 있는 수동 테스트 스크립트를 작성하였습니다.

## 본문

### 변경 사항

**의존성 추가**
- `socket.io-client ^4.8.3`을 `dependencies`에 추가하였습니다.
- 기존에 정렬이 맞지 않던 `class-validator`, `class-transformer` 항목의 순서를 알파벳 순으로 정리하였습니다.

**테스트 스크립트 추가** (`cowork-chat/test/test.js`)
- `socket.io-client`를 사용하여 로컬 서버(`http://localhost:3000`)에 WebSocket 연결을 맺고, `message` 이벤트를 송수신하는 간단한 수동 테스트 스크립트를 작성하였습니다.
- 연결 성공 시 `message` 이벤트를 서버로 전송하고, 서버로부터 수신한 메시지를 콘솔에 출력하도록 구성하였습니다.
