### PR TITLE
[voice] 에러 핸들링 리팩토링 및 Swagger 명세 상세화

### DIFF
--- a/cowork-voice/docs/docs.go
+++ b/cowork-voice/docs/docs.go
@@ -43,25 +43,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_dto.JoinResponse"
+                            "$ref": "#/definitions/internal_domain_voice_room.JoinResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     },
                     "403": {
                         "description": "채널 멤버가 아님",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     }
                 }
@@ -95,13 +95,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     },
                     "404": {
                         "description": "활성 세션 없음",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     }
                 }
@@ -135,19 +135,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_dto.ParticipantsResponse"
+                            "$ref": "#/definitions/internal_domain_voice_room.ParticipantsResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     }
                 }
@@ -181,19 +181,19 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_dto.SessionResponse"
+                            "$ref": "#/definitions/internal_domain_voice_room.SessionResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     }
                 }
@@ -230,89 +230,103 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "github_com_cowork_cowork-voice_internal_apperror.AppError": {
+        "github_com_cowork_cowork-voice_internal_apperr.Error": {
             "description": "API 에러 응답",
             "type": "object",
             "properties": {
-                "code": {
-                    "type": "integer",
-                    "example": 404
+                "error": {
+                    "type": "string",
+                    "example": "NOT_FOUND"
                 },
                 "message": {
                     "type": "string",
                     "example": "session not found"
                 },
                 "status": {
-                    "type": "string",
-                    "example": "NOT_FOUND"
+                    "type": "integer",
+                    "example": 404
                 }
             }
         },
-        "github_com_cowork_cowork-voice_internal_dto.JoinResponse": {
+        "internal_domain_voice_room.JoinResponse": {
             "type": "object",
             "properties": {
                 "livekit_url": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "wss://livekit.example.com"
                 },
                 "room_name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "channel-42"
                 },
                 "session_id": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
                 },
                 "token": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "eyJhbGciOiJIUzI1NiJ9..."
                 }
             }
         },
-        "github_com_cowork_cowork-voice_internal_dto.ParticipantInfo": {
+        "internal_domain_voice_room.ParticipantResponse": {
             "type": "object",
             "properties": {
                 "joined_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2024-01-01T00:00:00Z"
                 },
                 "user_id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 1
                 }
             }
         },
-        "github_com_cowork_cowork-voice_internal_dto.ParticipantsResponse": {
+        "internal_domain_voice_room.ParticipantsResponse": {
             "type": "object",
             "properties": {
                 "channel_id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 42
                 },
                 "participants": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_dto.ParticipantInfo"
+                        "$ref": "#/definitions/internal_domain_voice_room.ParticipantResponse"
                     }
                 },
                 "room_name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "channel-42"
                 }
             }
         },
-        "github_com_cowork_cowork-voice_internal_dto.SessionResponse": {
+        "internal_domain_voice_room.SessionResponse": {
             "type": "object",
             "properties": {
                 "channel_id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 42
                 },
                 "ended_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2024-01-01T01:00:00Z"
                 },
                 "session_id": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
                 },
                 "started_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2024-01-01T00:00:00Z"
                 },
                 "status": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "active"
                 },
                 "team_id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 1
                 }
             }
         }

--- a/cowork-voice/docs/swagger.json
+++ b/cowork-voice/docs/swagger.json
@@ -37,25 +37,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_dto.JoinResponse"
+                            "$ref": "#/definitions/internal_domain_voice_room.JoinResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     },
                     "403": {
                         "description": "채널 멤버가 아님",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     }
                 }
@@ -89,13 +89,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     },
                     "404": {
                         "description": "활성 세션 없음",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     }
                 }
@@ -129,19 +129,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_dto.ParticipantsResponse"
+                            "$ref": "#/definitions/internal_domain_voice_room.ParticipantsResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     },
                     "403": {
                         "description": "Forbidden",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     }
                 }
@@ -175,19 +175,19 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_dto.SessionResponse"
+                            "$ref": "#/definitions/internal_domain_voice_room.SessionResponse"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError"
+                            "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error"
                         }
                     }
                 }
@@ -224,89 +224,103 @@
         }
     },
     "definitions": {
-        "github_com_cowork_cowork-voice_internal_apperror.AppError": {
+        "github_com_cowork_cowork-voice_internal_apperr.Error": {
             "description": "API 에러 응답",
             "type": "object",
             "properties": {
-                "code": {
-                    "type": "integer",
-                    "example": 404
+                "error": {
+                    "type": "string",
+                    "example": "NOT_FOUND"
                 },
                 "message": {
                     "type": "string",
                     "example": "session not found"
                 },
                 "status": {
-                    "type": "string",
-                    "example": "NOT_FOUND"
+                    "type": "integer",
+                    "example": 404
                 }
             }
         },
-        "github_com_cowork_cowork-voice_internal_dto.JoinResponse": {
+        "internal_domain_voice_room.JoinResponse": {
             "type": "object",
             "properties": {
                 "livekit_url": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "wss://livekit.example.com"
                 },
                 "room_name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "channel-42"
                 },
                 "session_id": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
                 },
                 "token": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "eyJhbGciOiJIUzI1NiJ9..."
                 }
             }
         },
-        "github_com_cowork_cowork-voice_internal_dto.ParticipantInfo": {
+        "internal_domain_voice_room.ParticipantResponse": {
             "type": "object",
             "properties": {
                 "joined_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2024-01-01T00:00:00Z"
                 },
                 "user_id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 1
                 }
             }
         },
-        "github_com_cowork_cowork-voice_internal_dto.ParticipantsResponse": {
+        "internal_domain_voice_room.ParticipantsResponse": {
             "type": "object",
             "properties": {
                 "channel_id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 42
                 },
                 "participants": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/github_com_cowork_cowork-voice_internal_dto.ParticipantInfo"
+                        "$ref": "#/definitions/internal_domain_voice_room.ParticipantResponse"
                     }
                 },
                 "room_name": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "channel-42"
                 }
             }
         },
-        "github_com_cowork_cowork-voice_internal_dto.SessionResponse": {
+        "internal_domain_voice_room.SessionResponse": {
             "type": "object",
             "properties": {
                 "channel_id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 42
                 },
                 "ended_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2024-01-01T01:00:00Z"
                 },
                 "session_id": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "550e8400-e29b-41d4-a716-446655440000"
                 },
                 "started_at": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "2024-01-01T00:00:00Z"
                 },
                 "status": {
-                    "type": "string"
+                    "type": "string",
+                    "example": "active"
                 },
                 "team_id": {
-                    "type": "integer"
+                    "type": "integer",
+                    "example": 1
                 }
             }
         }

--- a/cowork-voice/docs/swagger.yaml
+++ b/cowork-voice/docs/swagger.yaml
@@ -1,60 +1,74 @@
 basePath: /api
 definitions:
-  github_com_cowork_cowork-voice_internal_apperror.AppError:
+  github_com_cowork_cowork-voice_internal_apperr.Error:
     description: API 에러 응답
     properties:
-      code:
-        example: 404
-        type: integer
+      error:
+        example: NOT_FOUND
+        type: string
       message:
         example: session not found
         type: string
       status:
-        example: NOT_FOUND
-        type: string
-    type: object
-  github_com_cowork_cowork-voice_internal_dto.JoinResponse:
-    properties:
-      livekit_url:
-        type: string
-      room_name:
-        type: string
-      session_id:
-        type: string
-      token:
-        type: string
-    type: object
-  github_com_cowork_cowork-voice_internal_dto.ParticipantInfo:
-    properties:
-      joined_at:
-        type: string
-      user_id:
+        example: 404
         type: integer
     type: object
-  github_com_cowork_cowork-voice_internal_dto.ParticipantsResponse:
+  internal_domain_voice_room.JoinResponse:
+    properties:
+      livekit_url:
+        example: wss://livekit.example.com
+        type: string
+      room_name:
+        example: channel-42
+        type: string
+      session_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
+        type: string
+      token:
+        example: eyJhbGciOiJIUzI1NiJ9...
+        type: string
+    type: object
+  internal_domain_voice_room.ParticipantResponse:
+    properties:
+      joined_at:
+        example: "2024-01-01T00:00:00Z"
+        type: string
+      user_id:
+        example: 1
+        type: integer
+    type: object
+  internal_domain_voice_room.ParticipantsResponse:
     properties:
       channel_id:
+        example: 42
         type: integer
       participants:
         items:
-          $ref: '#/definitions/github_com_cowork_cowork-voice_internal_dto.ParticipantInfo'
+          $ref: '#/definitions/internal_domain_voice_room.ParticipantResponse'
         type: array
       room_name:
+        example: channel-42
         type: string
     type: object
-  github_com_cowork_cowork-voice_internal_dto.SessionResponse:
+  internal_domain_voice_room.SessionResponse:
     properties:
       channel_id:
+        example: 42
         type: integer
       ended_at:
+        example: "2024-01-01T01:00:00Z"
         type: string
       session_id:
+        example: 550e8400-e29b-41d4-a716-446655440000
         type: string
       started_at:
+        example: "2024-01-01T00:00:00Z"
         type: string
       status:
+        example: active
         type: string
       team_id:
+        example: 1
         type: integer
     type: object
 host: localhost:8080
@@ -79,19 +93,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_dto.JoinResponse'
+            $ref: '#/definitions/internal_domain_voice_room.JoinResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError'
+            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error'
         "403":
           description: 채널 멤버가 아님
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError'
+            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError'
+            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error'
       security:
       - BearerAuth: []
       summary: 음성 채널 입장
@@ -112,11 +126,11 @@ paths:
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError'
+            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error'
         "404":
           description: 활성 세션 없음
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError'
+            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error'
       security:
       - BearerAuth: []
       summary: 음성 채널 퇴장
@@ -137,15 +151,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_dto.ParticipantsResponse'
+            $ref: '#/definitions/internal_domain_voice_room.ParticipantsResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError'
+            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error'
         "403":
           description: Forbidden
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError'
+            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error'
       security:
       - BearerAuth: []
       summary: 채널 참여자 목록 조회
@@ -166,15 +180,15 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_dto.SessionResponse'
+            $ref: '#/definitions/internal_domain_voice_room.SessionResponse'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError'
+            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperror.AppError'
+            $ref: '#/definitions/github_com_cowork_cowork-voice_internal_apperr.Error'
       security:
       - BearerAuth: []
       summary: 세션 조회

--- a/cowork-voice/internal/apperr/error.go
+++ b/cowork-voice/internal/apperr/error.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 )
 
+// Error godoc
+// @Description API 에러 응답
 type Error struct {
-	HTTPStatus int
-	Code       string
-	Message    string
+	HTTPStatus int    `json:"status"  example:"404"`
+	Code       string `json:"error"   example:"NOT_FOUND"`
+	Message    string `json:"message" example:"session not found"`
 }
 
 func (e *Error) Error() string {
@@ -44,9 +46,5 @@ func Internal(msg string) *Error {
 func WriteResponse(w http.ResponseWriter, err *Error) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(err.HTTPStatus)
-	json.NewEncoder(w).Encode(map[string]any{
-		"error":   err.Code,
-		"status":  err.HTTPStatus,
-		"message": err.Message,
-	})
+	json.NewEncoder(w).Encode(err)
 }

--- a/cowork-voice/internal/domain/voice_room/handler.go
+++ b/cowork-voice/internal/domain/voice_room/handler.go
@@ -19,6 +19,18 @@ func NewHandler(svc Service) *Handler {
 	return &Handler{svc: svc}
 }
 
+// Join godoc
+// @Summary      음성 채널 입장
+// @Description  채널에 입장합니다. LiveKit 토큰과 연결 URL을 반환합니다. 기존 세션이 없으면 새로 생성됩니다.
+// @Tags         voice
+// @Security     BearerAuth
+// @Produce      json
+// @Param        channel_id  path      int  true  "채널 ID"
+// @Success      200  {object}  JoinResponse
+// @Failure      401  {object}  apperr.Error
+// @Failure      403  {object}  apperr.Error  "채널 멤버가 아님"
+// @Failure      500  {object}  apperr.Error
+// @Router       /voice/channels/{channel_id}/join [post]
 func (h *Handler) Join(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	userID, ok := middleware.GetUserID(ctx)
@@ -42,6 +54,16 @@ func (h *Handler) Join(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// Leave godoc
+// @Summary      음성 채널 퇴장
+// @Description  채널에서 퇴장합니다. 마지막 참여자가 나가면 방이 자동으로 삭제됩니다.
+// @Tags         voice
+// @Security     BearerAuth
+// @Param        channel_id  path      int  true  "채널 ID"
+// @Success      204  "퇴장 성공"
+// @Failure      401  {object}  apperr.Error
+// @Failure      404  {object}  apperr.Error  "활성 세션 없음"
+// @Router       /voice/channels/{channel_id}/leave [post]
 func (h *Handler) Leave(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	userID, ok := middleware.GetUserID(ctx)
@@ -64,6 +86,17 @@ func (h *Handler) Leave(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// Participants godoc
+// @Summary      채널 참여자 목록 조회
+// @Description  현재 음성 채널에 참여 중인 사용자 목록을 반환합니다.
+// @Tags         voice
+// @Security     BearerAuth
+// @Produce      json
+// @Param        channel_id  path      int  true  "채널 ID"
+// @Success      200  {object}  ParticipantsResponse
+// @Failure      401  {object}  apperr.Error
+// @Failure      403  {object}  apperr.Error
+// @Router       /voice/channels/{channel_id}/participants [get]
 func (h *Handler) Participants(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	userID, ok := middleware.GetUserID(ctx)
@@ -87,6 +120,17 @@ func (h *Handler) Participants(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, resp)
 }
 
+// GetSession godoc
+// @Summary      세션 조회
+// @Description  session_id로 음성 세션 정보를 조회합니다.
+// @Tags         voice
+// @Security     BearerAuth
+// @Produce      json
+// @Param        session_id  path      string  true  "세션 ID"
+// @Success      200  {object}  SessionResponse
+// @Failure      401  {object}  apperr.Error
+// @Failure      404  {object}  apperr.Error
+// @Router       /voice/sessions/{session_id} [get]
 func (h *Handler) GetSession(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	userID, ok := middleware.GetUserID(ctx)

--- a/cowork-voice/internal/domain/voice_room/responses.go
+++ b/cowork-voice/internal/domain/voice_room/responses.go
@@ -1,28 +1,28 @@
 package room
 
 type JoinResponse struct {
-	Token      string `json:"token"`
-	LiveKitURL string `json:"livekit_url"`
-	SessionID  string `json:"session_id"`
-	RoomName   string `json:"room_name"`
+	Token      string `json:"token"       example:"eyJhbGciOiJIUzI1NiJ9..."`
+	LiveKitURL string `json:"livekit_url" example:"wss://livekit.example.com"`
+	SessionID  string `json:"session_id"  example:"550e8400-e29b-41d4-a716-446655440000"`
+	RoomName   string `json:"room_name"   example:"channel-42"`
 }
 
 type ParticipantResponse struct {
-	UserID   int64  `json:"user_id"`
-	JoinedAt string `json:"joined_at"`
+	UserID   int64  `json:"user_id"   example:"1"`
+	JoinedAt string `json:"joined_at" example:"2024-01-01T00:00:00Z"`
 }
 
 type ParticipantsResponse struct {
-	ChannelID    int64                 `json:"channel_id"`
-	RoomName     string                `json:"room_name"`
+	ChannelID    int64                 `json:"channel_id"   example:"42"`
+	RoomName     string                `json:"room_name"    example:"channel-42"`
 	Participants []ParticipantResponse `json:"participants"`
 }
 
 type SessionResponse struct {
-	SessionID string  `json:"session_id"`
-	ChannelID int64   `json:"channel_id"`
-	TeamID    int64   `json:"team_id"`
-	Status    string  `json:"status"`
-	StartedAt string  `json:"started_at"`
-	EndedAt   *string `json:"ended_at"`
+	SessionID string  `json:"session_id" example:"550e8400-e29b-41d4-a716-446655440000"`
+	ChannelID int64   `json:"channel_id" example:"42"`
+	TeamID    int64   `json:"team_id"    example:"1"`
+	Status    string  `json:"status"     example:"active"`
+	StartedAt string  `json:"started_at" example:"2024-01-01T00:00:00Z"`
+	EndedAt   *string `json:"ended_at"   example:"2024-01-01T01:00:00Z"`
 }


### PR DESCRIPTION
## 개요

음성 채널 서비스의 에러 처리 로직을 개선하고 Swagger(OpenAPI) 문서의 상세 예제를 보완하였습니다.

## 본문

음성 서비스의 완성도를 높이기 위해 다음과 같은 개선 작업을 수행하였습니다.

- **에러 처리 로직 개선**
    - `internal/apperr` 패키지의 에러 구조체를 `json` 태그 기반으로 직접 직렬화하도록 리팩토링하여 중복 코드를 제거하였습니다.
    - 에러 응답 필드명을 API 관례에 맞게 조정하였습니다 (`error`, `status`, `message`).

- **Swagger 문서화 상세화**
    - `voice_room` 도메인의 핸들러에 Swagger 주석을 추가하여 API 명세를 상세화하였습니다.
    - 요청 및 응답 DTO(`JoinResponse`, `SessionResponse` 등)에 `example` 태그를 추가하여 Swagger UI에서 실제 데이터 예시를 확인할 수 있도록 개선하였습니다.
    - 자동 생성된 `docs` 파일들을 업데이트하여 최신 API 명세를 반영하였습니다.
