### PR TITLE
[preference] API 문서 자동화 도입 및 서비스 라우팅 구성 개선

### DIFF
--- a/cowork-authorization/cmd/main.go
+++ b/cowork-authorization/cmd/main.go
@@ -1,7 +1,6 @@
 // @title           Cowork Authorization API
 // @version         1.0
 // @description     인증/인가 서비스 — Google OAuth2 로그인, JWT 액세스/리프레시 토큰 발급 및 갱신
-// @host            localhost:8080
 // @BasePath        /api
 // @securityDefinitions.apikey BearerAuth
 // @in              header

--- a/cowork-authorization/docs/docs.go
+++ b/cowork-authorization/docs/docs.go
@@ -242,7 +242,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
-	Host:             "localhost:8080",
+	Host:             "",
 	BasePath:         "/api",
 	Schemes:          []string{},
 	Title:            "Cowork Authorization API",

--- a/cowork-authorization/docs/swagger.json
+++ b/cowork-authorization/docs/swagger.json
@@ -6,7 +6,6 @@
         "contact": {},
         "version": "1.0"
     },
-    "host": "localhost:8080",
     "basePath": "/api",
     "paths": {
         "/auth/callback": {

--- a/cowork-authorization/docs/swagger.yaml
+++ b/cowork-authorization/docs/swagger.yaml
@@ -1,5 +1,4 @@
 basePath: /api
-host: localhost:8080
 info:
   contact: {}
   description: 인증/인가 서비스 — Google OAuth2 로그인, JWT 액세스/리프레시 토큰 발급 및 갱신

--- a/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
@@ -143,6 +143,13 @@ spring:
           filters:
             - RewritePath=/v3/api-docs/chat, /api-json
 
+        - id: preference-service-docs
+          uri: lb://cowork-preference
+          predicates:
+            - Path=/v3/api-docs/preference
+          filters:
+            - RewritePath=/v3/api-docs/preference, /swagger/doc.json
+
 # jwt.secret은 Vault secret/application 에서 주입됨 (여기서 정의하지 않음)
 
 resilience4j:

--- a/cowork-preference/src/main/kotlin/com/cowork/preference/router/PreferenceRouter.kt
+++ b/cowork-preference/src/main/kotlin/com/cowork/preference/router/PreferenceRouter.kt
@@ -17,6 +17,15 @@ fun buildRouter(
     val router = Router.router(vertx)
     router.route().handler(BodyHandler.create())
 
+    router.get("/swagger/doc.json").handler { ctx ->
+        val spec = object {}.javaClass.getResourceAsStream("/openapi.json")?.bufferedReader()?.readText()
+        if (spec != null) {
+            ctx.response().putHeader("Content-Type", "application/json").end(spec)
+        } else {
+            ctx.response().setStatusCode(404).end()
+        }
+    }
+
     // ACCOUNT
     router.get("/preferences/account/:id").handler(preferenceHandler.getSettings(ResourceType.ACCOUNT))
     router.put("/preferences/account/:id").handler(preferenceHandler.updateSettings(ResourceType.ACCOUNT))

--- a/cowork-preference/src/main/kotlin/com/cowork/preference/router/PreferenceRouter.kt
+++ b/cowork-preference/src/main/kotlin/com/cowork/preference/router/PreferenceRouter.kt
@@ -17,10 +17,10 @@ fun buildRouter(
     val router = Router.router(vertx)
     router.route().handler(BodyHandler.create())
 
+    val openapiSpec = object {}.javaClass.getResourceAsStream("/openapi.json")?.use { it.bufferedReader().readText() }
     router.get("/swagger/doc.json").handler { ctx ->
-        val spec = object {}.javaClass.getResourceAsStream("/openapi.json")?.bufferedReader()?.readText()
-        if (spec != null) {
-            ctx.response().putHeader("Content-Type", "application/json").end(spec)
+        if (openapiSpec != null) {
+            ctx.response().putHeader("Content-Type", "application/json").end(openapiSpec)
         } else {
             ctx.response().setStatusCode(404).end()
         }

--- a/cowork-preference/src/main/resources/openapi.json
+++ b/cowork-preference/src/main/resources/openapi.json
@@ -1,0 +1,371 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Cowork Preference API",
+    "description": "환경 설정 서비스 — 계정/팀/프로젝트/채널 설정 및 프로젝트 역할 관리",
+    "version": "1.0"
+  },
+  "servers": [
+    { "url": "http://localhost:8085", "description": "로컬" }
+  ],
+  "security": [{ "BearerAuth": [] }],
+  "tags": [
+    { "name": "preference", "description": "리소스별 설정 조회/수정" },
+    { "name": "project-role", "description": "프로젝트 역할 관리" },
+    { "name": "notification", "description": "채널 알림 설정" }
+  ],
+  "paths": {
+    "/preferences/account/{id}": {
+      "get": {
+        "tags": ["preference"],
+        "summary": "계정 설정 조회",
+        "parameters": [{ "$ref": "#/components/parameters/ResourceId" }],
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AccountSettings" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      },
+      "put": {
+        "tags": ["preference"],
+        "summary": "계정 설정 수정",
+        "parameters": [{ "$ref": "#/components/parameters/ResourceId" }],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AccountSettings" } } } },
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AccountSettings" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/preferences/team/{id}": {
+      "get": {
+        "tags": ["preference"],
+        "summary": "팀 설정 조회",
+        "parameters": [{ "$ref": "#/components/parameters/ResourceId" }],
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TeamSettings" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      },
+      "put": {
+        "tags": ["preference"],
+        "summary": "팀 설정 수정",
+        "parameters": [{ "$ref": "#/components/parameters/ResourceId" }],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TeamSettings" } } } },
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TeamSettings" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/preferences/project/{id}": {
+      "get": {
+        "tags": ["preference"],
+        "summary": "프로젝트 설정 조회",
+        "parameters": [{ "$ref": "#/components/parameters/ResourceId" }],
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "type": "object" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      },
+      "put": {
+        "tags": ["preference"],
+        "summary": "프로젝트 설정 수정",
+        "parameters": [{ "$ref": "#/components/parameters/ResourceId" }],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "type": "object" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/preferences/voice-channel/{id}": {
+      "get": {
+        "tags": ["preference"],
+        "summary": "음성 채널 설정 조회",
+        "parameters": [{ "$ref": "#/components/parameters/ResourceId" }],
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/VoiceChannelSettings" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      },
+      "put": {
+        "tags": ["preference"],
+        "summary": "음성 채널 설정 수정",
+        "parameters": [{ "$ref": "#/components/parameters/ResourceId" }],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/VoiceChannelSettings" } } } },
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/VoiceChannelSettings" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/preferences/text-channel/{id}": {
+      "get": {
+        "tags": ["preference"],
+        "summary": "텍스트 채널 설정 조회",
+        "parameters": [{ "$ref": "#/components/parameters/ResourceId" }],
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TextChannelSettings" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      },
+      "put": {
+        "tags": ["preference"],
+        "summary": "텍스트 채널 설정 수정",
+        "parameters": [{ "$ref": "#/components/parameters/ResourceId" }],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TextChannelSettings" } } } },
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TextChannelSettings" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/preferences/project/{projectId}/roles": {
+      "get": {
+        "tags": ["project-role"],
+        "summary": "프로젝트 역할 목록 조회",
+        "parameters": [{ "$ref": "#/components/parameters/ProjectId" }],
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/ProjectRole" } } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      },
+      "post": {
+        "tags": ["project-role"],
+        "summary": "프로젝트 역할 생성",
+        "parameters": [{ "$ref": "#/components/parameters/ProjectId" }],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreateRoleRequest" } } } },
+        "responses": {
+          "201": { "description": "Created", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ProjectRole" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "409": { "description": "역할 이름 중복", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/preferences/project/{projectId}/roles/{roleName}": {
+      "delete": {
+        "tags": ["project-role"],
+        "summary": "프로젝트 역할 삭제",
+        "parameters": [
+          { "$ref": "#/components/parameters/ProjectId" },
+          { "$ref": "#/components/parameters/RoleName" }
+        ],
+        "responses": {
+          "204": { "description": "삭제 성공" },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/preferences/project/{projectId}/roles/members": {
+      "get": {
+        "tags": ["project-role"],
+        "summary": "프로젝트 멤버 역할 목록 조회",
+        "parameters": [{ "$ref": "#/components/parameters/ProjectId" }],
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/MemberRole" } } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/preferences/project/{projectId}/roles/{roleName}/members": {
+      "post": {
+        "tags": ["project-role"],
+        "summary": "멤버에게 역할 부여",
+        "parameters": [
+          { "$ref": "#/components/parameters/ProjectId" },
+          { "$ref": "#/components/parameters/RoleName" }
+        ],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AssignRoleRequest" } } } },
+        "responses": {
+          "204": { "description": "부여 성공" },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/preferences/project/{projectId}/roles/{roleName}/members/{accountId}": {
+      "delete": {
+        "tags": ["project-role"],
+        "summary": "멤버 역할 제거",
+        "parameters": [
+          { "$ref": "#/components/parameters/ProjectId" },
+          { "$ref": "#/components/parameters/RoleName" },
+          { "name": "accountId", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" }, "description": "계정 ID" }
+        ],
+        "responses": {
+          "204": { "description": "제거 성공" },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    },
+    "/preferences/account/{accountId}/channels/{channelId}/notification": {
+      "get": {
+        "tags": ["notification"],
+        "summary": "채널 알림 설정 조회",
+        "parameters": [
+          { "name": "accountId", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" }, "description": "계정 ID" },
+          { "name": "channelId", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" }, "description": "채널 ID" }
+        ],
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NotificationSettings" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      },
+      "put": {
+        "tags": ["notification"],
+        "summary": "채널 알림 설정 수정",
+        "parameters": [
+          { "name": "accountId", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" }, "description": "계정 ID" },
+          { "name": "channelId", "in": "path", "required": true, "schema": { "type": "integer", "format": "int64" }, "description": "채널 ID" }
+        ],
+        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NotificationSettings" } } } },
+        "responses": {
+          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NotificationSettings" } } } },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "500": { "$ref": "#/components/responses/InternalServerError" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Bearer {access_token} 형식으로 입력하세요."
+      }
+    },
+    "parameters": {
+      "ResourceId": {
+        "name": "id", "in": "path", "required": true,
+        "schema": { "type": "integer", "format": "int64" },
+        "description": "리소스 ID"
+      },
+      "ProjectId": {
+        "name": "projectId", "in": "path", "required": true,
+        "schema": { "type": "integer", "format": "int64" },
+        "description": "프로젝트 ID"
+      },
+      "RoleName": {
+        "name": "roleName", "in": "path", "required": true,
+        "schema": { "type": "string" },
+        "description": "역할 이름"
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "잘못된 요청",
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+      },
+      "NotFound": {
+        "description": "리소스 없음",
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+      },
+      "InternalServerError": {
+        "description": "서버 오류",
+        "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } }
+      }
+    },
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string", "example": "Internal server error" }
+        }
+      },
+      "AccountSettings": {
+        "type": "object",
+        "properties": {
+          "status": { "type": "string", "enum": ["ONLINE", "DO_NOT_DISTURB"], "example": "ONLINE" },
+          "status_expires_at": { "type": "string", "format": "date-time", "example": "2026-04-20T12:00:00Z" },
+          "marketing_email": { "type": "boolean", "example": true },
+          "theme": { "type": "string", "enum": ["WHITE", "BLACK"], "example": "BLACK" },
+          "language": { "type": "string", "enum": ["KO", "EN"], "example": "KO" },
+          "time_format": { "type": "string", "enum": ["12H", "24H"], "example": "24H" },
+          "date_format": { "type": "string", "enum": ["YYYY_MM_DD", "MM_DD_YYYY", "DD_MM_YYYY", "YYYY_DD_MM", "DD_YYYY_MM", "MM_YYYY_DD"], "example": "YYYY_MM_DD" }
+        }
+      },
+      "TeamSettings": {
+        "type": "object",
+        "properties": {
+          "tag_spam_block": { "type": "boolean", "example": false }
+        }
+      },
+      "VoiceChannelSettings": {
+        "type": "object",
+        "properties": {
+          "bitrate": { "type": "integer", "example": 64000 },
+          "max_participants": { "type": "integer", "example": 20 }
+        }
+      },
+      "WebhookSettings": {
+        "type": "object",
+        "properties": {
+          "is_active": { "type": "boolean", "example": true },
+          "secret_key": { "type": "string", "example": "secret-abc" },
+          "retry_count": { "type": "integer", "example": 3 },
+          "retry_interval_ms": { "type": "integer", "example": 1000 }
+        }
+      },
+      "TextChannelSettings": {
+        "type": "object",
+        "properties": {
+          "webhook": { "$ref": "#/components/schemas/WebhookSettings" }
+        }
+      },
+      "ProjectRole": {
+        "type": "object",
+        "properties": {
+          "roleName": { "type": "string", "example": "DEVELOPER" },
+          "permissions": { "type": "object", "example": { "read": true, "write": false } }
+        }
+      },
+      "CreateRoleRequest": {
+        "type": "object",
+        "required": ["roleName"],
+        "properties": {
+          "roleName": { "type": "string", "example": "DEVELOPER" },
+          "permissions": { "type": "object", "example": { "read": true, "write": false } }
+        }
+      },
+      "MemberRole": {
+        "type": "object",
+        "properties": {
+          "accountId": { "type": "integer", "format": "int64", "example": 1 },
+          "roleName": { "type": "string", "example": "DEVELOPER" }
+        }
+      },
+      "AssignRoleRequest": {
+        "type": "object",
+        "required": ["accountId"],
+        "properties": {
+          "accountId": { "type": "integer", "format": "int64", "example": 1 }
+        }
+      },
+      "NotificationSettings": {
+        "type": "object",
+        "properties": {
+          "notification": { "type": "string", "enum": ["ALL", "MENTIONS", "NONE"], "example": "ALL" }
+        }
+      }
+    }
+  }
+}

--- a/cowork-preference/src/main/resources/openapi.json
+++ b/cowork-preference/src/main/resources/openapi.json
@@ -6,7 +6,7 @@
     "version": "1.0"
   },
   "servers": [
-    { "url": "http://localhost:8085", "description": "로컬" }
+    { "url": "/", "description": "현재 서버" }
   ],
   "security": [{ "BearerAuth": [] }],
   "tags": [

--- a/cowork-voice/cmd/server/main.go
+++ b/cowork-voice/cmd/server/main.go
@@ -1,7 +1,6 @@
 // @title           Cowork Voice API
 // @version         1.0
 // @description     음성 채널 서비스 — LiveKit 기반 음성 통화 세션 관리
-// @host            localhost:8080
 // @BasePath        /api
 // @securityDefinitions.apikey BearerAuth
 // @in              header

--- a/cowork-voice/docs/docs.go
+++ b/cowork-voice/docs/docs.go
@@ -344,7 +344,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
-	Host:             "localhost:8080",
+	Host:             "",
 	BasePath:         "/api",
 	Schemes:          []string{},
 	Title:            "Cowork Voice API",

--- a/cowork-voice/docs/swagger.json
+++ b/cowork-voice/docs/swagger.json
@@ -6,7 +6,6 @@
         "contact": {},
         "version": "1.0"
     },
-    "host": "localhost:8080",
     "basePath": "/api",
     "paths": {
         "/voice/channels/{channel_id}/join": {

--- a/cowork-voice/docs/swagger.yaml
+++ b/cowork-voice/docs/swagger.yaml
@@ -71,7 +71,6 @@ definitions:
         example: 1
         type: integer
     type: object
-host: localhost:8080
 info:
   contact: {}
   description: 음성 채널 서비스 — LiveKit 기반 음성 통화 세션 관리


### PR DESCRIPTION
## 개요

사용자 설정 서비스(`cowork-preference`)에 OpenAPI 명세서를 추가하고, 게이트웨이를 통해 통합 조회할 수 있도록 구성하였습니다.

## 본문

각 모듈별로 다음과 같은 개선 작업을 수행하였습니다.

- **cowork-preference**
    - `src/main/resources/openapi.json` 파일을 추가하여 사용자 설정 API의 명세를 정의하였습니다.
    - `PreferenceRouter`에 `/swagger/doc.json` 엔드포인트를 추가하여 해당 명세서를 JSON 형태로 서빙하도록 구현하였습니다.

- **cowork-gateway**
    - 개발 환경 설정(`cowork-gateway-dev.yml`)에 `preference-service-docs` 라우트를 추가하였습니다.
    - `/v3/api-docs/preference` 경로로 들어오는 요청을 `cowork-preference` 서비스의 `/swagger/doc.json`으로 라우팅하도록 설정하였습니다.
