### PR TITLE
[global] 에이전트 규칙 문서 체계화

### DIFF
--- a/.claude/rules/config.md
+++ b/.claude/rules/config.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - "**/application*.yml"
+  - "**/application*.yaml"
+  - "**/bootstrap*.yml"
+---
+
+# Configuration Rules
+
+- Sensitive values (DB credentials, JWT secrets): inject via environment variables or GitHub Secrets.
+- General service config: manage via `cowork-config` Config Server.
+- Local-only config: `application-local.yml` (must be in `.gitignore`).
+
+## Required Flyway Config for All Spring Boot Services
+
+```yaml
+spring:
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+```
+
+## Service Startup Order
+
+```
+1. cowork-config   (Eureka + Config Server — start first)
+2. cowork-gateway  (start after Config Server is ready)
+3. Business services  (authorization, user, team, project, channel — order doesn't matter)
+```

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -1,0 +1,21 @@
+---
+paths:
+  - "**/db/migration/**/*.sql"
+  - "**/*Entity.java"
+  - "**/*Repository.java"
+---
+
+# Database Rules
+
+- Never modify committed Flyway migration files (`V{n}__*.sql`). Add a new version file instead.
+- All table names require the `tb_` prefix.
+  - Index: `idx_tb_{table}_{column}`
+  - Unique key: `uq_tb_{table}_{column}`
+  - FK column: `fk_tb_{table}_{target}`
+- Never add real FK constraints across services. Reference another service's ID via a column `COMMENT` indicating the source.
+  ```sql
+  -- correct
+  team_id BIGINT NOT NULL COMMENT 'cowork-team의 tb_teams.id'
+  ```
+- Flyway migration file naming: `V{n}__{snake_case_description}.sql` (e.g. `V2__add_github_id.sql`)
+- MongoDB services (`cowork-chat`, `cowork-voice`) do not use Flyway. Manage schema definitions in each service's `schema/` directory.

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -11,7 +11,7 @@ paths:
 - All table names require the `tb_` prefix.
   - Index: `idx_tb_{table}_{column}`
   - Unique key: `uq_tb_{table}_{column}`
-  - FK column: `fk_tb_{table}_{target}`
+  - FK constraint: `fk_tb_{table}_{target}`
 - Never add real FK constraints across services. Reference another service's ID via a column `COMMENT` indicating the source.
   ```sql
   -- correct
@@ -19,3 +19,5 @@ paths:
   ```
 - Flyway migration file naming: `V{n}__{snake_case_description}.sql` (e.g. `V2__add_github_id.sql`)
 - MongoDB services (`cowork-chat`, `cowork-voice`) do not use Flyway. Manage schema definitions in each service's `schema/` directory.
+- Do not remove or transform the `_id` field from Mongoose documents sent to the client.
+- Set `versionKey: false` in the schema to exclude the `__v` key.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - "**/*.java"
+  - "**/application*.yml"
+  - "**/application*.yaml"
+  - "**/bootstrap*.yml"
+  - "**/bootstrap*.yaml"
+---
+
+# Security Rules
+
+- Never hardcode sensitive values (DB credentials, JWT secrets, API keys). Always inject via environment variables.
+  ```yaml
+  # correct
+  password: ${DB_PASSWORD}
+
+  # wrong — never commit
+  password: mypassword123
+  ```
+- Never parse JWT in downstream services. Gateway validates the token and forwards user info via headers.
+- Downstream services must trust `X-User-Id` (Long) and `X-User-Role` (String: ADMIN | MEMBER) headers from Gateway.
+- Block direct calls that bypass Gateway in production environments.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -20,3 +20,4 @@ paths:
 - Never parse JWT in downstream services. Gateway validates the token and forwards user info via headers.
 - Downstream services must trust `X-User-Id` (Long) and `X-User-Role` (String: ADMIN | MEMBER) headers from Gateway.
 - Block direct calls that bypass Gateway in production environments.
+- Handle CORS consistently at the gateway level (`cowork-gateway`) and avoid duplicating service-level CORS configuration unless a service has a documented exception.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,8 @@
+developer_instructions = """
+Write responses in Korean.
+Only include Git-related guidance when the user explicitly asks for it.
+"""
+
+model_reasoning_effort = "medium"
+approval_policy = "on-request"
+sandbox_mode = "workspace-write"

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,6 @@ PR_BODY.md
 SPEC.md
 .pr-tmp/
 /.claude/command.log
-.codex
 
 ### Docs ###
 docs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# Cowork Server
+
+## Overview
+
+Team collaboration platform backend monorepo based on microservices.
+
+- Core stack: Spring Boot, Spring Cloud Gateway, Eureka, OpenFeign, Kafka, Flyway, MySQL, MongoDB
+- Main services: `cowork-config`, `cowork-gateway`, `cowork-authorization`, `cowork-user`, `cowork-team`, `cowork-project`, `cowork-channel`, `cowork-chat`, `cowork-voice`, `cowork-preference`, `cowork-notification`
+
+## Agent Working Rules
+
+Apply the following rules whenever editing code, configuration, or database artifacts in this repository.
+
+## Security
+
+- Never hardcode secrets such as DB credentials, JWT secrets, or API keys.
+- Always inject sensitive values via environment variables or secret management.
+- In YAML config, prefer placeholders such as `${DB_PASSWORD}` instead of literal values.
+- Do not implement JWT parsing or validation in downstream services.
+- The Gateway is the single place that validates JWT and forwards trusted identity headers.
+- Downstream services must trust these Gateway-provided headers:
+  - `X-User-Id`: `Long`
+  - `X-User-Role`: `String` with values `ADMIN` or `MEMBER`
+- In production-oriented code or config, prevent direct service access that bypasses the Gateway.
+
+## Database
+
+- Never modify an already committed Flyway migration file named `V{n}__*.sql`.
+- If schema changes are needed, add a new Flyway migration version instead.
+- Flyway migration files must follow this naming format:
+  - `V{n}__{snake_case_description}.sql`
+  - Example: `V2__add_github_id.sql`
+- All relational table names must use the `tb_` prefix.
+- Use these database naming conventions:
+  - Index: `idx_tb_{table}_{column}`
+  - Unique key: `uq_tb_{table}_{column}`
+  - FK-like column name: `fk_tb_{table}_{target}`
+- Never create real foreign key constraints across services.
+- When referencing another service's resource, store the ID as a normal column and document the source in the column `COMMENT`.
+- Example:
+
+```sql
+team_id BIGINT NOT NULL COMMENT 'cowork-team의 tb_teams.id'
+```
+
+- MongoDB-based services such as `cowork-chat` and `cowork-voice` do not use Flyway.
+- For MongoDB services, manage schema-related definitions inside each service's `schema/` directory.
+
+## Configuration
+
+- General shared service configuration must be managed through `cowork-config` Config Server.
+- Local-only overrides belong in `application-local.yml`, and that file must stay ignored by Git.
+- For Spring Boot services using relational DB migrations, ensure Flyway is enabled with:
+
+```yaml
+spring:
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+```
+
+## Service Startup Order
+
+Start services in this order when bringing up the platform locally or validating environment setup:
+
+1. `cowork-config` because it provides Eureka and Config Server
+2. `cowork-gateway` after Config Server is ready
+3. Business services such as `authorization`, `user`, `team`, `project`, and `channel` in any order
+
+## Scope Notes
+
+- These rules are especially relevant when editing:
+  - Java sources
+  - Spring `application*.yml` and `bootstrap*.yml`
+  - Flyway SQL files under `db/migration/`
+  - JPA entities and repositories
+- When there is a conflict between convenience and these rules, follow these rules.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Apply the following rules whenever editing code, configuration, or database arti
 - Use these database naming conventions:
   - Index: `idx_tb_{table}_{column}`
   - Unique key: `uq_tb_{table}_{column}`
-  - FK-like column name: `fk_tb_{table}_{target}`
+  - FK-like constraint name: `fk_tb_{table}_{target}`
 - Never create real foreign key constraints across services.
 - When referencing another service's resource, store the ID as a normal column and document the source in the column `COMMENT`.
 - Example:
@@ -46,6 +46,8 @@ team_id BIGINT NOT NULL COMMENT 'cowork-team의 tb_teams.id'
 
 - MongoDB-based services such as `cowork-chat` and `cowork-voice` do not use Flyway.
 - For MongoDB services, manage schema-related definitions inside each service's `schema/` directory.
+- Do not remove or transform the `_id` field from Mongoose documents sent to the client.
+- Set `versionKey: false` in the schema to exclude the `__v` key.
 
 ## Configuration
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Apply the following rules whenever editing code, configuration, or database arti
   - `X-User-Id`: `Long`
   - `X-User-Role`: `String` with values `ADMIN` or `MEMBER`
 - In production-oriented code or config, prevent direct service access that bypasses the Gateway.
+- Handle CORS consistently at the gateway level (`cowork-gateway`) and avoid redundant service-level CORS configuration unless a service has a documented exception.
 
 ## Database
 

--- a/AGNETS.md
+++ b/AGNETS.md
@@ -1,7 +1,0 @@
-# Cowork Server
-
-## Project Structure
-
-This project is a microservices architecture with multiple tech.
-
-A `docker-compose.yml` is located at the root, and each service is organized as an independent module directory. The main modules are cowork-gateway, cowork-authorization, cowork-user, cowork-team, cowork-project, cowork-channel, cowork-chat, cowork-voice, and cowork-config.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,6 @@
 # Cowork Server
 
-## Project Structure
+## Overview
 
-This project is a microservices architecture with multiple tech.
-
-A `docker-compose.yml` is located at the root, and each service is organized as an independent module directory. The main modules are cowork-gateway, cowork-authorization, cowork-user, cowork-team, cowork-project, cowork-channel, cowork-chat, cowork-voice, and cowork-config.
+Team collaboration platform backend. MSA monorepo based on Spring Boot.  
+Tech stack: Spring Cloud Gateway, Eureka, OpenFeign, Kafka, Flyway, MySQL, MongoDB


### PR DESCRIPTION
## 개요

에이전트 작업 기준 문서를 저장소 루트와 `.claude/rules` 하위로 정리하였습니다.
보안, 데이터베이스, 설정 규칙을 분리하여 참조 기준이 명확해지도록 구성하였습니다.

## 본문

- 저장소 전반의 작업 원칙과 서비스 개요를 `AGENTS.md`에 정리하였습니다.
- 보안, 데이터베이스, 설정 규칙을 `.claude/rules/config.md`, `.claude/rules/database.md`, `.claude/rules/security.md`로 분리하였습니다.
- 기존 오기 문서인 `AGNETS.md`를 제거하였고, `CLAUDE.md`의 개요를 현재 저장소 기준에 맞게 보완하였습니다.
