### PR TITLE
[team] API 문서 자동화 도입 및 서비스 라우팅 구성 개선

### DIFF
--- a/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
@@ -150,6 +150,13 @@ spring:
           filters:
             - RewritePath=/v3/api-docs/preference, /swagger/doc.json
 
+        - id: team-service-docs
+          uri: lb://cowork-team
+          predicates:
+            - Path=/v3/api-docs/team
+          filters:
+            - RewritePath=/v3/api-docs/team, /v3/api-docs
+
 # jwt.secret은 Vault secret/application 에서 주입됨 (여기서 정의하지 않음)
 
 resilience4j:

--- a/cowork-team/build.gradle.kts
+++ b/cowork-team/build.gradle.kts
@@ -19,14 +19,9 @@ repositories {
     maven { url = uri("https://jitpack.io") }
 }
 
-val springdocVersion = libs.versions.springdoc.webmvc.get()
-
 dependencyManagement {
     imports {
         mavenBom(libs.spring.cloud.dependencies.get().toString())
-    }
-    dependencies {
-        dependency("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
     }
 }
 

--- a/cowork-team/build.gradle.kts
+++ b/cowork-team/build.gradle.kts
@@ -19,9 +19,14 @@ repositories {
     maven { url = uri("https://jitpack.io") }
 }
 
+val springdocVersion = libs.versions.springdoc.webmvc.get()
+
 dependencyManagement {
     imports {
         mavenBom(libs.spring.cloud.dependencies.get().toString())
+    }
+    dependencies {
+        dependency("org.springdoc:springdoc-openapi-starter-webmvc-ui:$springdocVersion")
     }
 }
 
@@ -36,6 +41,7 @@ dependencies {
     implementation("org.flywaydb:flyway-mysql")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.github.themoment-team:the-sdk:1.5")
+    implementation(libs.springdoc.openapi.webmvc.ui)
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamController.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamController.kt
@@ -5,46 +5,77 @@ import com.cowork.team.dto.TeamResponse
 import com.cowork.team.dto.TeamSummaryResponse
 import com.cowork.team.dto.UpdateTeamRequest
 import com.cowork.team.service.TeamService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
+@Tag(name = "팀", description = "팀 생성/수정/삭제 API")
 @RestController
 @RequestMapping("/teams")
 class TeamController(
     private val teamService: TeamService,
 ) {
 
+    @Operation(summary = "팀 생성", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "팀 생성 성공"),
+        ApiResponse(responseCode = "400", description = "잘못된 요청"),
+    )
     @PostMapping
     fun createTeam(
-        @RequestHeader("X-User-Id") userId: Long,
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @RequestBody request: CreateTeamRequest,
     ): ResponseEntity<TeamResponse> =
         ResponseEntity.status(HttpStatus.CREATED).body(teamService.createTeam(userId, request))
 
+    @Operation(summary = "내 팀 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping
     fun getMyTeams(
-        @RequestHeader("X-User-Id") userId: Long,
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
     ): ResponseEntity<List<TeamSummaryResponse>> =
         ResponseEntity.ok(teamService.getMyTeams(userId))
 
+    @Operation(summary = "팀 상세 조회", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "404", description = "팀 없음"),
+    )
     @GetMapping("/{teamId}")
     fun getTeam(
         @PathVariable teamId: Long,
     ): ResponseEntity<TeamResponse> =
         ResponseEntity.ok(teamService.getTeam(teamId))
 
+    @Operation(summary = "팀 정보 수정", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "수정 성공"),
+        ApiResponse(responseCode = "403", description = "권한 없음"),
+        ApiResponse(responseCode = "404", description = "팀 없음"),
+    )
     @PatchMapping("/{teamId}")
     fun updateTeam(
-        @RequestHeader("X-User-Id") userId: Long,
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @RequestBody request: UpdateTeamRequest,
     ): ResponseEntity<TeamResponse> =
         ResponseEntity.ok(teamService.updateTeam(userId, teamId, request))
 
+    @Operation(summary = "팀 삭제", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "삭제 성공"),
+        ApiResponse(responseCode = "403", description = "권한 없음"),
+        ApiResponse(responseCode = "404", description = "팀 없음"),
+    )
     @DeleteMapping("/{teamId}")
     fun deleteTeam(
-        @RequestHeader("X-User-Id") userId: Long,
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
     ): ResponseEntity<Void> {
         teamService.deleteTeam(userId, teamId)

--- a/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamMemberController.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamMemberController.kt
@@ -4,34 +4,55 @@ import com.cowork.team.dto.ChangeRoleRequest
 import com.cowork.team.dto.InviteMembersRequest
 import com.cowork.team.dto.TeamMemberResponse
 import com.cowork.team.service.TeamMemberService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
+@Tag(name = "팀 멤버", description = "팀 멤버 초대/조회/역할 변경/추방 API")
 @RestController
 @RequestMapping("/teams/{teamId}/members")
 class TeamMemberController(
     private val teamMemberService: TeamMemberService,
 ) {
 
+    @Operation(summary = "멤버 초대", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "초대 성공"),
+        ApiResponse(responseCode = "403", description = "권한 없음"),
+        ApiResponse(responseCode = "404", description = "팀 없음"),
+    )
     @PostMapping
     fun inviteMembers(
-        @RequestHeader("X-User-Id") userId: Long,
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @RequestBody request: InviteMembersRequest,
     ): ResponseEntity<List<TeamMemberResponse>> =
         ResponseEntity.status(HttpStatus.CREATED)
             .body(teamMemberService.inviteMembers(userId, teamId, request))
 
+    @Operation(summary = "멤버 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping
     fun getMembers(
         @PathVariable teamId: Long,
     ): ResponseEntity<List<TeamMemberResponse>> =
         ResponseEntity.ok(teamMemberService.getMembers(teamId))
 
+    @Operation(summary = "멤버 역할 변경", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "변경 성공"),
+        ApiResponse(responseCode = "403", description = "권한 없음"),
+        ApiResponse(responseCode = "404", description = "멤버 없음"),
+    )
     @PatchMapping("/{targetUserId}/role")
     fun changeRole(
-        @RequestHeader("X-User-Id") userId: Long,
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @PathVariable targetUserId: Long,
         @RequestBody request: ChangeRoleRequest,
@@ -40,9 +61,15 @@ class TeamMemberController(
         return ResponseEntity.ok().build()
     }
 
+    @Operation(summary = "멤버 추방 / 탈퇴", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "추방/탈퇴 성공"),
+        ApiResponse(responseCode = "403", description = "권한 없음 또는 OWNER 탈퇴 시도"),
+        ApiResponse(responseCode = "404", description = "멤버 없음"),
+    )
     @DeleteMapping("/{targetUserId}")
     fun removeMember(
-        @RequestHeader("X-User-Id") userId: Long,
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @PathVariable targetUserId: Long,
     ): ResponseEntity<Void> {

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/ChangeRoleRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/ChangeRoleRequest.kt
@@ -1,7 +1,9 @@
 package com.cowork.team.dto
 
 import com.cowork.team.domain.TeamRole
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class ChangeRoleRequest(
+    @Schema(description = "변경할 역할", example = "ADMIN", allowableValues = ["ADMIN", "MEMBER"], required = true)
     val role: TeamRole,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/CreateTeamRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/CreateTeamRequest.kt
@@ -1,7 +1,12 @@
 package com.cowork.team.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class CreateTeamRequest(
+    @Schema(description = "팀 이름", example = "코워크팀", required = true)
     val name: String,
+    @Schema(description = "팀 설명", example = "협업 서비스 개발팀")
     val description: String?,
+    @Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
     val iconUrl: String?,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/InviteMembersRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/InviteMembersRequest.kt
@@ -1,5 +1,8 @@
 package com.cowork.team.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class InviteMembersRequest(
+    @Schema(description = "초대할 사용자 ID 목록", example = "[2, 3, 4]", required = true)
     val userIds: List<Long>,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamMemberResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamMemberResponse.kt
@@ -1,12 +1,17 @@
 package com.cowork.team.dto
 
 import com.cowork.team.domain.TeamMember
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class TeamMemberResponse(
+    @Schema(description = "멤버 레코드 ID", example = "1")
     val id: Long,
+    @Schema(description = "사용자 ID", example = "42")
     val userId: Long,
+    @Schema(description = "역할", example = "MEMBER", allowableValues = ["OWNER", "ADMIN", "MEMBER"])
     val role: String,
+    @Schema(description = "가입 일시")
     val joinedAt: LocalDateTime,
 ) {
     companion object {

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamResponse.kt
@@ -1,15 +1,23 @@
 package com.cowork.team.dto
 
 import com.cowork.team.domain.Team
+import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class TeamResponse(
+    @Schema(description = "팀 ID", example = "1")
     val id: Long,
+    @Schema(description = "팀 이름", example = "코워크팀")
     val name: String,
+    @Schema(description = "팀 설명", example = "협업 서비스 개발팀")
     val description: String?,
+    @Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
     val iconUrl: String?,
+    @Schema(description = "팀 소유자 ID", example = "1")
     val ownerId: Long,
+    @Schema(description = "생성 일시")
     val createdAt: LocalDateTime,
+    @Schema(description = "수정 일시")
     val updatedAt: LocalDateTime,
 ) {
     companion object {

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamSummaryResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamSummaryResponse.kt
@@ -2,11 +2,16 @@ package com.cowork.team.dto
 
 import com.cowork.team.domain.Team
 import com.cowork.team.domain.TeamRole
+import io.swagger.v3.oas.annotations.media.Schema
 
 data class TeamSummaryResponse(
+    @Schema(description = "팀 ID", example = "1")
     val id: Long,
+    @Schema(description = "팀 이름", example = "코워크팀")
     val name: String,
+    @Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
     val iconUrl: String?,
+    @Schema(description = "내 역할", example = "MEMBER", allowableValues = ["OWNER", "ADMIN", "MEMBER"])
     val myRole: String,
 ) {
     companion object {

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/UpdateTeamRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/UpdateTeamRequest.kt
@@ -1,7 +1,12 @@
 package com.cowork.team.dto
 
+import io.swagger.v3.oas.annotations.media.Schema
+
 data class UpdateTeamRequest(
+    @Schema(description = "팀 이름", example = "코워크팀")
     val name: String?,
+    @Schema(description = "팀 설명", example = "협업 서비스 개발팀")
     val description: String?,
+    @Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
     val iconUrl: String?,
 )

--- a/cowork-team/src/main/resources/application.yml
+++ b/cowork-team/src/main/resources/application.yml
@@ -35,3 +35,9 @@ eureka:
       defaultZone: http://localhost:8761/eureka/
   instance:
     prefer-ip-address: true
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html


### PR DESCRIPTION
## 개요

팀 관리 서비스(`cowork-team`)에 SpringDoc Swagger를 도입하여 API 문서를 자동화하고, 게이트웨이를 통해 이를 통합 조회할 수 있도록 설정하였습니다.

## 본문

팀 서비스의 API 명세를 명확히 하기 위해 다음과 같은 작업을 수행하였습니다.

- **cowork-team**
    - `build.gradle.kts`에 SpringDoc OpenAPI 의존성을 추가하였습니다.
    - `TeamController` 및 `TeamMemberController`에 `@Tag`, `@Operation` 등의 애노테이션을 적용하여 상세한 API 설명을 작성하였습니다.
    - DTO 클래스들에 필드 설명을 위한 `@Schema` 애노테이션을 추가하였습니다.
    - `application.yml`에 Swagger UI 및 API docs 관련 경로를 구성하였습니다.

- **cowork-gateway**
    - 개발 환경 설정(`cowork-gateway-dev.yml`)에 팀 서비스의 API 문서를 통합하여 볼 수 있도록 `/v3/api-docs/team` 라우팅 경로를 추가하였습니다.
