### PR TITLE
[global] 프로젝트 언어 비중 그래프 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,7 @@
 
 광주소프트웨어마이스터고등학교 협업 관리 플랫폼
 
+![Language Stats](https://github-repository-language-graph-wi.vercel.app/api?username=team-cowork&repo=cowork-server&theme=white&langs_count=100)
+
 ---
 [LICENSE](LICENSE) | [CODE_OF_CONDUCT](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
## 개요

메인 `README.md`에 프로젝트의 언어 통계 배지를 추가하였습니다.

## 본문

프로젝트에서 사용 중인 기술 스택 비중을 시각적으로 확인할 수 있도록 GitHub 언어 통계 그래프를 추가하였습니다.
