### PR TITLE
[preference] 팀 닉네임 형식 설정 추가

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -128,6 +128,7 @@ Flyway를 사용하지 않습니다. 스키마 정의는 각 서비스의 `schem
 |---|---|---|---|
 | `chat.message` | cowork-chat | cowork-chat | 메시지 저장 |
 | `notification.trigger` | 모든 서비스 | notification 서비스 | 알림 발송 |
+| `preference.team.setting.changed` | cowork-preference | 관련 서비스 | 팀 설정 변경 |
 | `voice.session.event` | cowork-voice | cowork-voice | 음성 세션 상태 |
 | `user.data.sync` | cowork-user | 관련 서비스 | 유저 데이터 동기화 |
 

--- a/cowork-preference/src/main/kotlin/com/cowork/preference/domain/SettingSchema.kt
+++ b/cowork-preference/src/main/kotlin/com/cowork/preference/domain/SettingSchema.kt
@@ -7,7 +7,7 @@ import java.time.format.DateTimeParseException
 object SettingSchema {
 
     private val ACCOUNT_KEYS = setOf("status", "status_expires_at", "marketing_email", "theme", "language", "time_format", "date_format")
-    private val TEAM_KEYS = setOf("tag_spam_block")
+    private val TEAM_KEYS = setOf("tag_spam_block", "nickname_format_enforced", "nickname_format_example")
     private val PROJECT_KEYS = emptySet<String>() // TODO: 추후 확장 시 사용
     private val VOICE_CHANNEL_KEYS = setOf("bitrate", "max_participants")
     private val TEXT_CHANNEL_KEYS = setOf("webhook")
@@ -44,9 +44,15 @@ object SettingSchema {
         return result
     }
 
-    fun validate(type: ResourceType, settings: JsonObject): String? {
-        if (type != ResourceType.ACCOUNT) return null
+    fun validate(type: ResourceType, settings: JsonObject): String? = when (type) {
+        ResourceType.ACCOUNT -> validateAccount(settings)
+        ResourceType.TEAM -> validateTeam(settings)
+        ResourceType.PROJECT,
+        ResourceType.VOICE_CHANNEL,
+        ResourceType.TEXT_CHANNEL -> null
+    }
 
+    private fun validateAccount(settings: JsonObject): String? {
         settings.getString("status")?.let { status ->
             if (status !in ACCOUNT_STATUS_VALUES) return "status must be one of $ACCOUNT_STATUS_VALUES"
         }
@@ -66,6 +72,16 @@ object SettingSchema {
             try { Instant.parse(expiresAt) } catch (_: DateTimeParseException) {
                 return "status_expires_at must be a valid ISO-8601 datetime (e.g. 2026-04-19T12:00:00Z)"
             }
+        }
+        return null
+    }
+
+    private fun validateTeam(settings: JsonObject): String? {
+        if (settings.containsKey("nickname_format_enforced") && settings.getValue("nickname_format_enforced") !is Boolean) {
+            return "nickname_format_enforced must be a boolean"
+        }
+        if (settings.containsKey("nickname_format_example") && settings.getValue("nickname_format_example") !is String) {
+            return "nickname_format_example must be a string"
         }
         return null
     }

--- a/cowork-preference/src/main/kotlin/com/cowork/preference/domain/SettingSchema.kt
+++ b/cowork-preference/src/main/kotlin/com/cowork/preference/domain/SettingSchema.kt
@@ -80,8 +80,13 @@ object SettingSchema {
         if (settings.containsKey("nickname_format_enforced") && settings.getValue("nickname_format_enforced") !is Boolean) {
             return "nickname_format_enforced must be a boolean"
         }
-        if (settings.containsKey("nickname_format_example") && settings.getValue("nickname_format_example") !is String) {
-            return "nickname_format_example must be a string"
+        if (settings.containsKey("nickname_format_example")) {
+            val example = settings.getValue("nickname_format_example")
+            if (example !is String) return "nickname_format_example must be a string"
+            if (example.isBlank()) return "nickname_format_example cannot be blank"
+        }
+        if (settings.getBoolean("nickname_format_enforced") == true && settings.getString("nickname_format_example").isNullOrBlank()) {
+            return "nickname_format_example is required when nickname_format_enforced is true"
         }
         return null
     }

--- a/cowork-preference/src/main/kotlin/com/cowork/preference/messaging/PreferenceProducer.kt
+++ b/cowork-preference/src/main/kotlin/com/cowork/preference/messaging/PreferenceProducer.kt
@@ -29,7 +29,27 @@ class PreferenceProducer(private val producer: KafkaProducer<String, String>) {
         producer.send(record).coAwait()
     }
 
+    suspend fun publishTeamSettingsChanged(
+        teamId: Long,
+        changedSettings: JsonObject,
+        settings: JsonObject,
+    ) {
+        val payload = JsonObject()
+            .put("teamId", teamId)
+            .put("changedSettings", changedSettings)
+            .put("settings", settings)
+            .put("timestamp", Instant.now().toString())
+
+        val record = KafkaProducerRecord.create<String, String>(
+            TOPIC_TEAM_SETTING_CHANGED,
+            teamId.toString(),
+            payload.encode(),
+        )
+        producer.send(record).coAwait()
+    }
+
     companion object {
         const val TOPIC_STATUS_CHANGED = "preference.status.changed"
+        const val TOPIC_TEAM_SETTING_CHANGED = "preference.team.setting.changed"
     }
 }

--- a/cowork-preference/src/main/kotlin/com/cowork/preference/service/PreferenceService.kt
+++ b/cowork-preference/src/main/kotlin/com/cowork/preference/service/PreferenceService.kt
@@ -38,7 +38,33 @@ class PreferenceService(
                 reason = "MANUAL",
             )
         }
+        if (resourceType == ResourceType.TEAM) {
+            val changedNicknameSettings = nicknameFormatSettings(filtered)
+            if (changedNicknameSettings.size() > 0) {
+                producer.publishTeamSettingsChanged(
+                    teamId = resourceId,
+                    changedSettings = changedNicknameSettings,
+                    settings = updated,
+                )
+            }
+        }
 
         return Result.success(updated)
+    }
+
+    private fun nicknameFormatSettings(settings: JsonObject): JsonObject {
+        val result = JsonObject()
+        if (settings.containsKey(NICKNAME_FORMAT_ENFORCED)) {
+            result.put(NICKNAME_FORMAT_ENFORCED, settings.getValue(NICKNAME_FORMAT_ENFORCED))
+        }
+        if (settings.containsKey(NICKNAME_FORMAT_EXAMPLE)) {
+            result.put(NICKNAME_FORMAT_EXAMPLE, settings.getValue(NICKNAME_FORMAT_EXAMPLE))
+        }
+        return result
+    }
+
+    companion object {
+        private const val NICKNAME_FORMAT_ENFORCED = "nickname_format_enforced"
+        private const val NICKNAME_FORMAT_EXAMPLE = "nickname_format_example"
     }
 }

--- a/cowork-preference/src/main/kotlin/com/cowork/preference/service/PreferenceService.kt
+++ b/cowork-preference/src/main/kotlin/com/cowork/preference/service/PreferenceService.kt
@@ -22,7 +22,8 @@ class PreferenceService(
 
     suspend fun updateSettings(resourceType: ResourceType, resourceId: Long, raw: JsonObject): Result<JsonObject> {
         val filtered = SettingSchema.filter(resourceType, raw)
-        val validationError = SettingSchema.validate(resourceType, filtered)
+        val validationTarget = validationTarget(resourceType, resourceId, filtered)
+        val validationError = SettingSchema.validate(resourceType, validationTarget)
         if (validationError != null) return Result.failure(IllegalArgumentException(validationError))
 
         val needPrevStatus = resourceType == ResourceType.ACCOUNT && filtered.containsKey("status")
@@ -62,6 +63,16 @@ class PreferenceService(
         }
         return result
     }
+
+    private suspend fun validationTarget(resourceType: ResourceType, resourceId: Long, filtered: JsonObject): JsonObject {
+        if (resourceType != ResourceType.TEAM || !containsNicknameFormatSettings(filtered)) return filtered
+        val merged = getSettings(resourceType, resourceId).copy()
+        filtered.forEach { entry -> merged.put(entry.key, entry.value) }
+        return merged
+    }
+
+    private fun containsNicknameFormatSettings(settings: JsonObject): Boolean =
+        settings.containsKey(NICKNAME_FORMAT_ENFORCED) || settings.containsKey(NICKNAME_FORMAT_EXAMPLE)
 
     companion object {
         private const val NICKNAME_FORMAT_ENFORCED = "nickname_format_enforced"

--- a/cowork-preference/src/main/resources/openapi.json
+++ b/cowork-preference/src/main/resources/openapi.json
@@ -306,7 +306,9 @@
       "TeamSettings": {
         "type": "object",
         "properties": {
-          "tag_spam_block": { "type": "boolean", "example": false }
+          "tag_spam_block": { "type": "boolean", "example": false },
+          "nickname_format_enforced": { "type": "boolean", "example": true },
+          "nickname_format_example": { "type": "string", "example": "홍길동 / 프론트엔드" }
         }
       },
       "VoiceChannelSettings": {

--- a/cowork-preference/src/main/resources/openapi.json
+++ b/cowork-preference/src/main/resources/openapi.json
@@ -308,7 +308,7 @@
         "properties": {
           "tag_spam_block": { "type": "boolean", "example": false },
           "nickname_format_enforced": { "type": "boolean", "example": true },
-          "nickname_format_example": { "type": "string", "example": "홍길동 / 프론트엔드" }
+          "nickname_format_example": { "type": "string", "minLength": 1, "example": "홍길동 / 프론트엔드" }
         }
       },
       "VoiceChannelSettings": {


### PR DESCRIPTION
## 개요

팀 설정에 닉네임 형식 강제 여부와 형식 예시 값을 추가하였습니다.
팀 닉네임 형식 설정이 변경될 때 다른 서비스가 구독할 수 있는 Kafka 이벤트를 발행하도록 추가하였습니다.

## 본문

팀 리소스 설정에서 `nickname_format_enforced`와 `nickname_format_example` 키를 허용하도록 추가하였습니다.
`nickname_format_enforced`는 boolean 타입으로 검증하며, `nickname_format_example`은 string 타입으로 검증하도록 분리된 팀 설정 검증 로직을 추가하였습니다.

팀 설정 PUT 요청에 닉네임 형식 관련 필드가 포함된 경우 `preference.team.setting.changed` 토픽으로 이벤트를 발행하도록 추가하였습니다.
이벤트에는 `teamId`, `changedSettings`, `settings`, `timestamp`가 포함됩니다.

OpenAPI의 `TeamSettings` 스키마에도 신규 필드를 반영하여 클라이언트가 팀 닉네임 형식 설정 값을 조회하고 수정할 수 있도록 문서화하였습니다.
Kafka 토픽 표에도 신규 팀 설정 변경 토픽을 문서화하였습니다.
