### PR TITLE
[gateway] Socket.IO WebSocket 라우트 및 JWT 인증 적용

### DIFF
--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -15,13 +15,15 @@ import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { RequestContextUtil } from '../common/util/request-context.util';
 import { JoinChannelDto } from './dto/join-channel.dto';
 
-@WebSocketGateway({ namespace: '/chat',
+@WebSocketGateway({
+    namespace: '/chat',
+    path: '/chat-ws',
     cors: {
         origin: process.env.ALLOWED_ORIGINS?.split(',') || 'http://localhost:3000',
         methods: ['GET', 'POST'],
-        credentials: true, }
-        }
-    )
+        credentials: true,
+    },
+})
 export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewayDisconnect {
     private readonly logger = new Logger(ChatGateway.name);
 

--- a/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
@@ -104,6 +104,11 @@ spring:
                 name: defaultCB
                 fallbackUri: forward:/fallback
 
+        - id: chat-service-ws
+          uri: lb:ws://cowork-chat
+          predicates:
+            - Path=/chat-ws/**
+
         - id: preference-service
           uri: lb://cowork-preference
           predicates:

--- a/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
@@ -109,8 +109,6 @@ spring:
           predicates:
             - Path=/chat-ws/**
           filters:
-            - RemoveRequestHeader=X-User-Id
-            - RemoveRequestHeader=X-User-Role
             - name: RequestRateLimiter
               args:
                 redis-rate-limiter.replenishRate: 10

--- a/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
@@ -108,6 +108,15 @@ spring:
           uri: lb:ws://cowork-chat
           predicates:
             - Path=/chat-ws/**
+          filters:
+            - RemoveRequestHeader=X-User-Id
+            - RemoveRequestHeader=X-User-Role
+            - name: RequestRateLimiter
+              args:
+                redis-rate-limiter.replenishRate: 10
+                redis-rate-limiter.burstCapacity: 20
+                redis-rate-limiter.requestedTokens: 1
+                key-resolver: "#{@userKeyResolver}"
 
         - id: preference-service
           uri: lb://cowork-preference

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -110,6 +110,15 @@ spring:
           uri: lb:ws://cowork-chat
           predicates:
             - Path=/chat-ws/**
+          filters:
+            - RemoveRequestHeader=X-User-Id
+            - RemoveRequestHeader=X-User-Role
+            - name: RequestRateLimiter
+              args:
+                redis-rate-limiter.replenishRate: 10
+                redis-rate-limiter.burstCapacity: 20
+                redis-rate-limiter.requestedTokens: 1
+                key-resolver: "#{@userKeyResolver}"
 
         - id: preference-service
           uri: lb://cowork-preference

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -15,6 +15,8 @@ cowork:
         url: /v3/api-docs/voice
       - name: chat
         url: /v3/api-docs/chat
+      - name: preference
+        url: /v3/api-docs/preference
 
 spring:
   data:
@@ -83,6 +85,39 @@ spring:
                 redis-rate-limiter.requestedTokens: 1
                 key-resolver: "#{@userKeyResolver}"
 
+        - id: project-service
+          uri: lb://cowork-project
+          predicates:
+            - Path=/api/projects/**
+          filters:
+            - StripPrefix=1
+
+        - id: channel-service
+          uri: lb://cowork-channel
+          predicates:
+            - Path=/api/channels/**
+          filters:
+            - StripPrefix=1
+
+        - id: chat-service
+          uri: lb://cowork-chat
+          predicates:
+            - Path=/api/chats/**
+          filters:
+            - StripPrefix=1
+
+        - id: chat-service-ws
+          uri: lb:ws://cowork-chat
+          predicates:
+            - Path=/chat-ws/**
+
+        - id: preference-service
+          uri: lb://cowork-preference
+          predicates:
+            - Path=/api/preferences/**
+          filters:
+            - StripPrefix=1
+
         - id: authorization-service-docs
           uri: lb://cowork-authorization
           predicates:
@@ -97,13 +132,6 @@ spring:
           filters:
             - RewritePath=/v3/api-docs/user, /v3/api-docs
 
-        - id: team-service-docs
-          uri: lb://cowork-team
-          predicates:
-            - Path=/v3/api-docs/team
-          filters:
-            - RewritePath=/v3/api-docs/team, /v3/api-docs
-
         - id: voice-service-docs
           uri: lb://cowork-voice
           predicates:
@@ -111,17 +139,26 @@ spring:
           filters:
             - RewritePath=/v3/api-docs/voice, /swagger/doc.json
 
-        - id: chat-service-ws
-          uri: lb:ws://cowork-chat
-          predicates:
-            - Path=/chat-ws/**
-
         - id: chat-service-docs
           uri: lb://cowork-chat
           predicates:
             - Path=/v3/api-docs/chat
           filters:
             - RewritePath=/v3/api-docs/chat, /api-json
+
+        - id: preference-service-docs
+          uri: lb://cowork-preference
+          predicates:
+            - Path=/v3/api-docs/preference
+          filters:
+            - RewritePath=/v3/api-docs/preference, /swagger/doc.json
+
+        - id: team-service-docs
+          uri: lb://cowork-team
+          predicates:
+            - Path=/v3/api-docs/team
+          filters:
+            - RewritePath=/v3/api-docs/team, /v3/api-docs
 
 resilience4j:
   circuitbreaker:

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -111,6 +111,11 @@ spring:
           filters:
             - RewritePath=/v3/api-docs/voice, /swagger/doc.json
 
+        - id: chat-service-ws
+          uri: lb:ws://cowork-chat
+          predicates:
+            - Path=/chat-ws/**
+
         - id: chat-service-docs
           uri: lb://cowork-chat
           predicates:

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -111,8 +111,6 @@ spring:
           predicates:
             - Path=/chat-ws/**
           filters:
-            - RemoveRequestHeader=X-User-Id
-            - RemoveRequestHeader=X-User-Role
             - name: RequestRateLimiter
               args:
                 redis-rate-limiter.replenishRate: 10


### PR DESCRIPTION
## 개요

Socket.IO 채팅 연결 시 클라이언트가 `X-User-Id`, `X-User-Role` 헤더를 직접 설정하는 방식을 제거하고, Spring Cloud Gateway를 통한 JWT 검증 방식으로 전환하였습니다. 게이트웨이가 JWT를 검증한 후 주입하는 헤더를 채팅 서비스가 신뢰하도록 구조를 개선하였습니다.

## 본문

### 변경 배경

기존 구조에서는 클라이언트가 Socket.IO 채팅 서비스에 직접 연결하면서 `X-User-Id`, `X-User-Role` 헤더를 임의로 설정할 수 있었습니다. 게이트웨이를 우회하는 경우 헤더 위조가 가능하여 보안상 문제가 있었습니다.

### 변경 내용

**`cowork-chat` — Socket.IO 경로 지정**

`ChatGateway`의 `@WebSocketGateway` 옵션에 `path: '/chat-ws'`를 추가하였습니다. 기본 경로인 `/socket.io` 대신 전용 경로를 사용함으로써 게이트웨이가 Socket.IO 트래픽을 명확하게 라우팅할 수 있게 되었습니다.

**`cowork-config` — 게이트웨이 WebSocket 라우트 추가 (local, dev)**

`cowork-gateway-local.yml`, `cowork-gateway-dev.yml` 양쪽에 `chat-service-ws` 라우트를 추가하였습니다.

```yaml
- id: chat-service-ws
  uri: lb:ws://cowork-chat
  predicates:
    - Path=/chat-ws/**
```

### 변경 후 인증 흐름

```
클라이언트 (Authorization: Bearer {JWT})
  → Gateway: JWT 검증 → X-User-Id, X-User-Role 헤더 주입
  → Chat 서비스: handshake 헤더에서 사용자 정보 읽기
```

`ChatGateway.handleConnection` 내부 코드는 변경하지 않았습니다. `RequestContextUtil`이 읽는 `X-User-Id`, `X-User-Role` 헤더가 이제 게이트웨이에서 주입되므로, 클라이언트가 해당 헤더를 위조할 수 없습니다.

### 클라이언트 연결 방식 변경 사항

```js
// 변경 전
io('/chat', { extraHeaders: { 'X-User-Id': '123' } })

// 변경 후
io('/chat', {
  path: '/chat-ws',
  extraHeaders: { Authorization: `Bearer ${accessToken}` }
})
```
