### PR TITLE
[gateway] SecurityConfig 내 토큰 발급 경로 permitAll 설정

### DIFF
--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/security/SecurityConfig.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/security/SecurityConfig.kt
@@ -42,7 +42,7 @@ class SecurityConfig(
                 exchanges
                     .pathMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                     .pathMatchers(HttpMethod.GET, "/api/auth/signin", "/api/auth/callback").permitAll()
-                    .pathMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
+                    .pathMatchers(HttpMethod.POST, "/api/auth/token", "/api/auth/refresh").permitAll()
                     .pathMatchers("/actuator/**").permitAll()
                     .pathMatchers("/fallback").permitAll()
                     .pathMatchers("/swagger-ui.html", "/swagger-ui/**", "/webjars/**").permitAll()


### PR DESCRIPTION
## 개요

게이트웨이의 보안 설정에 토큰 발급 API를 인증 예외 경로로 추가하였습니다.

## 본문

- cowork-gateway의 SecurityConfig에서 `/api/auth/token` 경로를 인증 없이 접근 가능한 permitAll 대상으로 설정하였습니다.
- 이를 통해 클라이언트가 인증 전 토큰을 정상적으로 발급받을 수 있도록 개선하였습니다.
