### PR TITLE
[authorization] JWT 만료 정책 변경 및 설정 파일 최신화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,10 +16,6 @@ MONGO_ROOT_PASSWORD=
 
 # ── JWT ────────────────────────────────────────────────────────────────────
 JWT_SECRET=
-JWT_ACCESS_EXPIRATION_MS=1800000
-JWT_REFRESH_EXPIRATION_MS=7776000000
-
-# authorization 서비스가 실제로 사용하는 값, Go time.ParseDuration 형식
 JWT_ACCESS_EXPIRE=30m
 JWT_REFRESH_EXPIRE=2160h
 

--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,12 @@ MONGO_ROOT_PASSWORD=
 
 # ── JWT ────────────────────────────────────────────────────────────────────
 JWT_SECRET=
-JWT_ACCESS_EXPIRATION_MS=3600000
-JWT_REFRESH_EXPIRATION_MS=2592000000
+JWT_ACCESS_EXPIRATION_MS=1800000
+JWT_REFRESH_EXPIRATION_MS=7776000000
+
+# authorization 서비스가 실제로 사용하는 값, Go time.ParseDuration 형식
+JWT_ACCESS_EXPIRE=30m
+JWT_REFRESH_EXPIRE=2160h
 
 # ── OAuth2 ─────────────────────────────────────────────────────────────────
 OAUTH2_GOOGLE_CLIENT_ID=

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ POSTGRES_PASSWORD=
 MONGO_ROOT_USERNAME=root
 MONGO_ROOT_PASSWORD=
 
+# ── Kafka ──────────────────────────────────────────────────────────────────
+# 호스트(로컬)에서 접근할 때는 docker-compose 기준 9094 사용
+KAFKA_BOOTSTRAP_SERVERS=localhost:9094
+
 # ── JWT ────────────────────────────────────────────────────────────────────
 JWT_SECRET=
 JWT_ACCESS_EXPIRE=30m
@@ -50,6 +54,12 @@ MINIO_PATH_STYLE_ACCESS_ENABLED=true
 
 # ── Grafana ─────────────────────────────────────────────────────────────────
 GRAFANA_ADMIN_PASSWORD=admin
+
+# ── Vault (Config Server dev/prod에서 사용) ────────────────────────────────
+VAULT_HOST=localhost
+VAULT_PORT=8200
+VAULT_SCHEME=http
+VAULT_TOKEN=dev-root-token
 
 # ── LiveKit ──────────────────────────────────────────────────────────────────
 LIVEKIT_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ ehthumbs.db
 *.log
 logs/
 .run/
+screenlog.*
 
 ### LLM Outputs ###
 PR_BODY.md

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -254,3 +254,19 @@ MSA 서비스 간 의존성이 있으므로 아래 순서로 기동합니다.
 2. cowork-gateway  (Config Server에 등록 후 기동)
 3. 비즈니스 서비스  (authorization, user, team, project, channel — 순서 무관)
 ```
+
+---
+
+## Swagger / 모니터링
+
+### Swagger (Gateway 경유)
+
+Gateway는 서비스별 OpenAPI 문서를 아래 경로로 프록시합니다.
+
+- `/v3/api-docs/{service}` (예: `/v3/api-docs/channel`)
+
+로컬에서 Swagger UI는 `cowork-gateway`에서 확인합니다.
+
+### Prometheus / Grafana
+
+`docker-compose.yml`에서 Prometheus/Grafana가 함께 기동되며, Prometheus는 `cowork-monitoring/prometheus/prometheus.yml`에 정의된 타겟을 스크랩합니다.

--- a/cowork-authorization/.env.example
+++ b/cowork-authorization/.env.example
@@ -11,8 +11,8 @@ DATAGSM_USERINFO_URL=https://oauth.resource.datagsm.kr/userinfo
 
 # JWT (HS256, cowork-gateway와 동일한 값 사용)
 JWT_SECRET=your_jwt_secret_shared_with_gateway
-JWT_ACCESS_EXPIRE=15m
-JWT_REFRESH_EXPIRE=168h
+JWT_ACCESS_EXPIRE=30m
+JWT_REFRESH_EXPIRE=2160h
 
 # Eureka
 EUREKA_SERVER_URL=http://cowork-config:8761/eureka

--- a/cowork-authorization/internal/config/config.go
+++ b/cowork-authorization/internal/config/config.go
@@ -7,6 +7,11 @@ import (
 	"time"
 )
 
+const (
+	defaultJWTAccessExpire  = "30m"
+	defaultJWTRefreshExpire = "2160h"
+)
+
 type AppConfig struct {
 	Port string
 
@@ -29,12 +34,12 @@ type AppConfig struct {
 }
 
 func Load() (*AppConfig, error) {
-	accessExpire, err := time.ParseDuration(getEnvOrDefault("JWT_ACCESS_EXPIRE", "30m"))
+	accessExpire, err := time.ParseDuration(getEnvOrDefault("JWT_ACCESS_EXPIRE", defaultJWTAccessExpire))
 	if err != nil {
 		return nil, fmt.Errorf("invalid JWT_ACCESS_EXPIRE: %w", err)
 	}
 
-	refreshExpire, err := time.ParseDuration(getEnvOrDefault("JWT_REFRESH_EXPIRE", "2160h"))
+	refreshExpire, err := time.ParseDuration(getEnvOrDefault("JWT_REFRESH_EXPIRE", defaultJWTRefreshExpire))
 	if err != nil {
 		return nil, fmt.Errorf("invalid JWT_REFRESH_EXPIRE: %w", err)
 	}

--- a/cowork-authorization/internal/config/config.go
+++ b/cowork-authorization/internal/config/config.go
@@ -29,12 +29,12 @@ type AppConfig struct {
 }
 
 func Load() (*AppConfig, error) {
-	accessExpire, err := time.ParseDuration(getEnvOrDefault("JWT_ACCESS_EXPIRE", "15m"))
+	accessExpire, err := time.ParseDuration(getEnvOrDefault("JWT_ACCESS_EXPIRE", "30m"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid JWT_ACCESS_EXPIRE: %w", err)
 	}
 
-	refreshExpire, err := time.ParseDuration(getEnvOrDefault("JWT_REFRESH_EXPIRE", "168h"))
+	refreshExpire, err := time.ParseDuration(getEnvOrDefault("JWT_REFRESH_EXPIRE", "2160h"))
 	if err != nil {
 		return nil, fmt.Errorf("invalid JWT_REFRESH_EXPIRE: %w", err)
 	}

--- a/cowork-channel/build.gradle.kts
+++ b/cowork-channel/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
     implementation("org.springframework.cloud:spring-cloud-starter-config")
+    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
 
     implementation("com.mysql:mysql-connector-j")
     implementation("org.flywaydb:flyway-core")

--- a/cowork-channel/build.gradle.kts
+++ b/cowork-channel/build.gradle.kts
@@ -1,0 +1,61 @@
+plugins {
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.kotlin.jpa)
+}
+
+group = "com.cowork"
+version = "20260420.0"
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+repositories {
+    maven { url = uri("https://jitpack.io") }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom(libs.spring.cloud.dependencies.get().toString())
+    }
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(libs.micrometer.registry.prometheus)
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
+    implementation("org.springframework.cloud:spring-cloud-starter-config")
+
+    implementation("com.mysql:mysql-connector-j")
+    implementation("org.flywaydb:flyway-core")
+    implementation("org.flywaydb:flyway-mysql")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    implementation(libs.the.sdk) {
+        exclude(group = "org.springframework.boot")
+        exclude(group = "org.springframework.cloud")
+        exclude(group = "org.springdoc")
+    }
+    implementation(libs.springdoc.openapi.webmvc.ui)
+    implementation(libs.logstash.logback.encoder)
+
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xjsr305=strict")
+    }
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/CoworkChannelApplication.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/CoworkChannelApplication.kt
@@ -3,9 +3,11 @@ package com.cowork.channel
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableFeignClients
 class CoworkChannelApplication
 
 fun main(args: Array<String>) {

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/CoworkChannelApplication.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/CoworkChannelApplication.kt
@@ -1,0 +1,14 @@
+package com.cowork.channel
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+@ConfigurationPropertiesScan
+class CoworkChannelApplication
+
+fun main(args: Array<String>) {
+    runApplication<CoworkChannelApplication>(*args)
+}
+

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/api/ChannelResponse.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/api/ChannelResponse.kt
@@ -1,0 +1,21 @@
+package com.cowork.channel.api
+
+import com.cowork.channel.channel.ChannelEntity
+
+data class ChannelResponse(
+    val id: Long,
+    val name: String,
+    val type: String,
+    val notice: String?,
+) {
+    companion object {
+        fun from(entity: ChannelEntity): ChannelResponse =
+            ChannelResponse(
+                id = entity.id,
+                name = entity.name,
+                type = entity.type.name.lowercase(),
+                notice = entity.notice,
+            )
+    }
+}
+

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
@@ -1,6 +1,6 @@
 package com.cowork.channel.api
 
-import com.cowork.channel.channel.TeamChannelService
+import com.cowork.channel.channel.ListTeamChannelsService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/teams")
 class TeamChannelController(
-    private val teamChannelService: TeamChannelService,
+    private val listTeamChannelsService: ListTeamChannelsService,
 ) {
 
     @Operation(summary = "팀 채널 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
@@ -30,5 +30,5 @@ class TeamChannelController(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
     ): List<ChannelResponse> =
-        teamChannelService.listByTeam(userId, teamId).map(ChannelResponse::from)
+        listTeamChannelsService.execute(userId, teamId).map(ChannelResponse::from)
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
@@ -1,0 +1,22 @@
+package com.cowork.channel.api
+
+import com.cowork.channel.channel.ChannelService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/teams")
+class TeamChannelController(
+    private val channelService: ChannelService,
+) {
+
+    @GetMapping("/{teamId}/channels")
+    fun listTeamChannels(
+        @PathVariable teamId: Long,
+    ): List<ChannelResponse> =
+        channelService.listByTeam(teamId)
+            .map(ChannelResponse::from)
+}
+

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
@@ -1,29 +1,22 @@
 package com.cowork.channel.api
 
 import com.cowork.channel.channel.ChannelService
-import com.cowork.channel.client.TeamClient
-import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import team.themoment.sdk.exception.ExpectedException
 
 @RestController
 @RequestMapping("/teams")
 class TeamChannelController(
     private val channelService: ChannelService,
-    private val teamClient: TeamClient,
 ) {
 
     @GetMapping("/{teamId}/channels")
     fun listTeamChannels(
         @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
-    ): List<ChannelResponse> {
-        val isMember = teamClient.getMembers(teamId).any { it.userId == userId }
-        if (!isMember) throw ExpectedException("해당 팀의 멤버가 아닙니다.", HttpStatus.FORBIDDEN)
-        return channelService.listByTeam(teamId).map(ChannelResponse::from)
-    }
+    ): List<ChannelResponse> =
+        channelService.listByTeam(userId, teamId).map(ChannelResponse::from)
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
@@ -1,21 +1,33 @@
 package com.cowork.channel.api
 
 import com.cowork.channel.channel.ChannelService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
+@Tag(name = "채널", description = "팀 채널 조회 API")
 @RestController
 @RequestMapping("/teams")
 class TeamChannelController(
     private val channelService: ChannelService,
 ) {
 
+    @Operation(summary = "팀 채널 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "403", description = "해당 팀의 멤버가 아님"),
+    )
     @GetMapping("/{teamId}/channels")
     fun listTeamChannels(
-        @RequestHeader("X-User-Id") userId: Long,
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
     ): List<ChannelResponse> =
         channelService.listByTeam(userId, teamId).map(ChannelResponse::from)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
@@ -1,22 +1,29 @@
 package com.cowork.channel.api
 
 import com.cowork.channel.channel.ChannelService
+import com.cowork.channel.client.TeamClient
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
+import team.themoment.sdk.exception.ExpectedException
 
 @RestController
 @RequestMapping("/teams")
 class TeamChannelController(
     private val channelService: ChannelService,
+    private val teamClient: TeamClient,
 ) {
 
     @GetMapping("/{teamId}/channels")
     fun listTeamChannels(
+        @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
-    ): List<ChannelResponse> =
-        channelService.listByTeam(teamId)
-            .map(ChannelResponse::from)
+    ): List<ChannelResponse> {
+        val isMember = teamClient.getMembers(teamId).any { it.userId == userId }
+        if (!isMember) throw ExpectedException("해당 팀의 멤버가 아닙니다.", HttpStatus.FORBIDDEN)
+        return channelService.listByTeam(teamId).map(ChannelResponse::from)
+    }
 }
-

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/api/TeamChannelController.kt
@@ -1,6 +1,6 @@
 package com.cowork.channel.api
 
-import com.cowork.channel.channel.ChannelService
+import com.cowork.channel.channel.TeamChannelService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/teams")
 class TeamChannelController(
-    private val channelService: ChannelService,
+    private val teamChannelService: TeamChannelService,
 ) {
 
     @Operation(summary = "팀 채널 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
@@ -30,5 +30,5 @@ class TeamChannelController(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
     ): List<ChannelResponse> =
-        channelService.listByTeam(userId, teamId).map(ChannelResponse::from)
+        teamChannelService.listByTeam(userId, teamId).map(ChannelResponse::from)
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelEntity.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelEntity.kt
@@ -1,0 +1,39 @@
+package com.cowork.channel.channel
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "tb_channels")
+class ChannelEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(name = "team_id", nullable = false)
+    val teamId: Long,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    val type: ChannelType,
+
+    @Column(name = "name", nullable = false, length = 100)
+    val name: String,
+
+    @Column(name = "notice", length = 500)
+    val notice: String? = null,
+
+    @Column(name = "created_at", nullable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = LocalDateTime.now(),
+)
+

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelEntity.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelEntity.kt
@@ -34,6 +34,6 @@ class ChannelEntity(
     val createdAt: LocalDateTime = LocalDateTime.now(),
 
     @Column(name = "updated_at", nullable = false)
-    val updatedAt: LocalDateTime = LocalDateTime.now(),
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
 )
 

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelRepository.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelRepository.kt
@@ -1,0 +1,8 @@
+package com.cowork.channel.channel
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ChannelRepository : JpaRepository<ChannelEntity, Long> {
+    fun findAllByTeamIdOrderByIdAsc(teamId: Long): List<ChannelEntity>
+}
+

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelService.kt
@@ -8,19 +8,7 @@ class ChannelService(
     private val channelRepository: ChannelRepository,
 ) {
 
-    @Transactional
-    fun listByTeam(teamId: Long): List<ChannelEntity> {
-        val existing = channelRepository.findAllByTeamIdOrderByIdAsc(teamId)
-        if (existing.isNotEmpty()) return existing
-
-        // Local-first UX: existing teams may not have channels yet. Seed minimal defaults.
-        channelRepository.saveAll(
-            listOf(
-                ChannelEntity(teamId = teamId, type = ChannelType.TEXT, name = "general"),
-                ChannelEntity(teamId = teamId, type = ChannelType.VOICE, name = "voice"),
-            ),
-        )
-
-        return channelRepository.findAllByTeamIdOrderByIdAsc(teamId)
-    }
+    @Transactional(readOnly = true)
+    fun listByTeam(teamId: Long): List<ChannelEntity> =
+        channelRepository.findAllByTeamIdOrderByIdAsc(teamId)
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelService.kt
@@ -1,14 +1,21 @@
 package com.cowork.channel.channel
 
+import com.cowork.channel.client.TeamClient
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import team.themoment.sdk.exception.ExpectedException
 
 @Service
 class ChannelService(
     private val channelRepository: ChannelRepository,
+    private val teamClient: TeamClient,
 ) {
 
     @Transactional(readOnly = true)
-    fun listByTeam(teamId: Long): List<ChannelEntity> =
-        channelRepository.findAllByTeamIdOrderByIdAsc(teamId)
+    fun listByTeam(userId: Long, teamId: Long): List<ChannelEntity> {
+        val isMember = teamClient.isMember(teamId, userId)["isMember"] == true
+        if (!isMember) throw ExpectedException("해당 팀의 멤버가 아닙니다.", HttpStatus.FORBIDDEN)
+        return channelRepository.findAllByTeamIdOrderByIdAsc(teamId)
+    }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelService.kt
@@ -1,0 +1,15 @@
+package com.cowork.channel.channel
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class ChannelService(
+    private val channelRepository: ChannelRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun listByTeam(teamId: Long): List<ChannelEntity> =
+        channelRepository.findAllByTeamIdOrderByIdAsc(teamId)
+}
+

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelService.kt
@@ -8,8 +8,19 @@ class ChannelService(
     private val channelRepository: ChannelRepository,
 ) {
 
-    @Transactional(readOnly = true)
-    fun listByTeam(teamId: Long): List<ChannelEntity> =
-        channelRepository.findAllByTeamIdOrderByIdAsc(teamId)
-}
+    @Transactional
+    fun listByTeam(teamId: Long): List<ChannelEntity> {
+        val existing = channelRepository.findAllByTeamIdOrderByIdAsc(teamId)
+        if (existing.isNotEmpty()) return existing
 
+        // Local-first UX: existing teams may not have channels yet. Seed minimal defaults.
+        channelRepository.saveAll(
+            listOf(
+                ChannelEntity(teamId = teamId, type = ChannelType.TEXT, name = "general"),
+                ChannelEntity(teamId = teamId, type = ChannelType.VOICE, name = "voice"),
+            ),
+        )
+
+        return channelRepository.findAllByTeamIdOrderByIdAsc(teamId)
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelType.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelType.kt
@@ -1,0 +1,7 @@
+package com.cowork.channel.channel
+
+enum class ChannelType {
+    TEXT,
+    VOICE,
+}
+

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ListTeamChannelsService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ListTeamChannelsService.kt
@@ -7,13 +7,13 @@ import org.springframework.transaction.annotation.Transactional
 import team.themoment.sdk.exception.ExpectedException
 
 @Service
-class TeamChannelService(
+class ListTeamChannelsService(
     private val channelRepository: ChannelRepository,
     private val teamClient: TeamClient,
 ) {
 
     @Transactional(readOnly = true)
-    fun listByTeam(userId: Long, teamId: Long): List<ChannelEntity> {
+    fun execute(userId: Long, teamId: Long): List<ChannelEntity> {
         val isMember = teamClient.isMember(teamId, userId)["isMember"] == true
         if (!isMember) throw ExpectedException("해당 팀의 멤버가 아닙니다.", HttpStatus.FORBIDDEN)
         return channelRepository.findAllByTeamIdOrderByIdAsc(teamId)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/TeamChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/TeamChannelService.kt
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional
 import team.themoment.sdk.exception.ExpectedException
 
 @Service
-class ChannelService(
+class TeamChannelService(
     private val channelRepository: ChannelRepository,
     private val teamClient: TeamClient,
 ) {

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/client/TeamClient.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/client/TeamClient.kt
@@ -7,12 +7,6 @@ import org.springframework.web.bind.annotation.PathVariable
 @FeignClient(name = "cowork-team")
 interface TeamClient {
 
-    @GetMapping("/teams/{teamId}/members")
-    fun getMembers(@PathVariable teamId: Long): List<TeamMemberDto>
+    @GetMapping("/teams/{teamId}/members/{userId}/exists")
+    fun isMember(@PathVariable teamId: Long, @PathVariable userId: Long): Map<String, Boolean>
 }
-
-data class TeamMemberDto(
-    val id: Long,
-    val userId: Long,
-    val role: String,
-)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/client/TeamClient.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/client/TeamClient.kt
@@ -1,0 +1,18 @@
+package com.cowork.channel.client
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+
+@FeignClient(name = "cowork-team")
+interface TeamClient {
+
+    @GetMapping("/teams/{teamId}/members")
+    fun getMembers(@PathVariable teamId: Long): List<TeamMemberDto>
+}
+
+data class TeamMemberDto(
+    val id: Long,
+    val userId: Long,
+    val role: String,
+)

--- a/cowork-channel/src/main/resources/application.yml
+++ b/cowork-channel/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   config:
     import: "optional:configserver:http://localhost:8761"
   datasource:
-    url: jdbc:mysql://localhost:3306/cowork_channel?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/cowork_channel?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul}
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_USER:cowork}
     password: ${MYSQL_PASSWORD:}

--- a/cowork-channel/src/main/resources/application.yml
+++ b/cowork-channel/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   config:
     import: "optional:configserver:http://localhost:8761"
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/cowork_channel?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul}
+    url: ${SPRING_DATASOURCE_URL}
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_USER:cowork}
     password: ${MYSQL_PASSWORD:}

--- a/cowork-channel/src/main/resources/application.yml
+++ b/cowork-channel/src/main/resources/application.yml
@@ -1,0 +1,59 @@
+server:
+  port: 8083
+
+spring:
+  application:
+    name: cowork-channel
+  config:
+    import: "optional:configserver:http://localhost:8761"
+  datasource:
+    url: jdbc:mysql://localhost:3306/cowork_channel?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${MYSQL_USER:cowork}
+    password: ${MYSQL_PASSWORD:}
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+
+eureka:
+  client:
+    service-url:
+      defaultZone: http://localhost:8761/eureka/
+  instance:
+    prefer-ip-address: true
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+
+sdk:
+  logging:
+    enabled: true
+    not-logging-urls:
+      - "/actuator/**"
+      - "/v3/api-docs/**"
+      - "/swagger-ui/**"
+  response:
+    not-wrapping-urls:
+      - "/actuator/**"
+      - "/v3/api-docs/**"
+      - "/v3/api-docs"
+      - "/swagger-ui/**"
+  swagger:
+    enabled: true
+    title: "cowork-channel API"
+    description: "cowork-channel 채널 관리 서비스 API"
+    version: "v1"
+    group: "channel"
+    paths-to-match:
+      - "/teams/**"
+

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -47,6 +47,12 @@ spring:
             - Path=/api/channels/**, /api/teams/*/channels/**, /api/teams/*/channels
           filters:
             - StripPrefix=1
+            - name: RequestRateLimiter
+              args:
+                redis-rate-limiter.replenishRate: 20
+                redis-rate-limiter.burstCapacity: 40
+                redis-rate-limiter.requestedTokens: 1
+                key-resolver: "#{@userKeyResolver}"
 
         - id: authorization-service
           uri: lb://cowork-authorization

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -44,7 +44,7 @@ spring:
         - id: channel-service
           uri: lb://cowork-channel
           predicates:
-            - Path=/api/teams/*/channels/**, /api/teams/*/channels
+            - Path=/api/channels/**, /api/teams/*/channels/**, /api/teams/*/channels
           filters:
             - StripPrefix=1
 
@@ -100,13 +100,6 @@ spring:
           uri: lb://cowork-project
           predicates:
             - Path=/api/projects/**
-          filters:
-            - StripPrefix=1
-
-        - id: channel-service
-          uri: lb://cowork-channel
-          predicates:
-            - Path=/api/channels/**
           filters:
             - StripPrefix=1
 
@@ -177,6 +170,13 @@ spring:
             - Path=/v3/api-docs/team
           filters:
             - RewritePath=/v3/api-docs/team, /v3/api-docs
+
+        - id: channel-service-docs
+          uri: lb://cowork-channel
+          predicates:
+            - Path=/v3/api-docs/channel
+          filters:
+            - RewritePath=/v3/api-docs/channel, /v3/api-docs
 
         - id: notification-service-docs
           uri: lb://cowork-notification

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -11,6 +11,8 @@ cowork:
         url: /v3/api-docs/user
       - name: team
         url: /v3/api-docs/team
+      - name: channel
+        url: /v3/api-docs/channel
       - name: voice
         url: /v3/api-docs/voice
       - name: chat
@@ -39,6 +41,13 @@ spring:
             maxAge: 3600
 
       routes:
+        - id: channel-service
+          uri: lb://cowork-channel
+          predicates:
+            - Path=/api/teams/*/channels/**, /api/teams/*/channels
+          filters:
+            - StripPrefix=1
+
         - id: authorization-service
           uri: lb://cowork-authorization
           predicates:

--- a/cowork-config/src/main/resources/configs/cowork-notification-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-notification-local.yml
@@ -15,6 +15,12 @@ fcm:
 preference:
   service-url: http://localhost:9001
 
+team:
+  service-url: http://localhost:8085
+
+user:
+  service-url: http://localhost:8082
+
 eureka:
   server-url: http://localhost:8761/eureka
   app-name: cowork-notification

--- a/cowork-config/src/main/resources/vault/vault-init.sh
+++ b/cowork-config/src/main/resources/vault/vault-init.sh
@@ -25,13 +25,19 @@ echo ""
 echo "=== cowork-user 시크릿 ==="
 vault kv put secret/cowork-user \
   spring.datasource.password="user-db-password" \
-  spring.datasource.url="jdbc:postgresql://localhost:5432/cowork_user"
+  spring.datasource.url="jdbc:mysql://localhost:3306/cowork_user?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul"
 
 echo ""
-echo "=== cowork-authorization 시크릿 ==="
-vault kv put secret/cowork-authorization \
-  spring.datasource.password="auth-db-password" \
-  spring.datasource.url="jdbc:postgresql://localhost:5432/cowork_auth"
+echo "=== cowork-team 시크릿 ==="
+vault kv put secret/cowork-team \
+  spring.datasource.password="team-db-password" \
+  spring.datasource.url="jdbc:mysql://localhost:3306/cowork_team?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul"
+
+echo ""
+echo "=== cowork-channel 시크릿 ==="
+vault kv put secret/cowork-channel \
+  spring.datasource.password="channel-db-password" \
+  spring.datasource.url="jdbc:mysql://localhost:3306/cowork_channel?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul"
 
 echo ""
 echo "=== cowork-notification 시크릿 ==="

--- a/cowork-monitoring/grafana/dashboards/cowork-channel.json
+++ b/cowork-monitoring/grafana/dashboards/cowork-channel.json
@@ -1,0 +1,142 @@
+{
+  "title": "cowork-channel",
+  "uid": "cowork-channel",
+  "tags": ["cowork", "service", "channel"],
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "title": "서비스 상태",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "up{job=\"cowork-channel\"}",
+          "legendFormat": "channel",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" }
+        }
+      ],
+      "options": { "reduceOptions": { "calcs": ["lastNotNull"] }, "colorMode": "background", "graphMode": "none" },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "value": 0, "color": "red" }, { "value": 1, "color": "green" }] }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "HTTP 요청 Rate (req/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [
+        {
+          "expr": "sum by (uri) (rate(http_server_requests_seconds_count{application=\"cowork-channel\"}[1m]))",
+          "legendFormat": "{{uri}}",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" }
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP 응답 시간 P99 (ms)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, uri) (rate(http_server_requests_seconds_bucket{application=\"cowork-channel\"}[5m]))) * 1000",
+          "legendFormat": "P99 {{uri}}",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" }
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, uri) (rate(http_server_requests_seconds_bucket{application=\"cowork-channel\"}[5m]))) * 1000",
+          "legendFormat": "P95 {{uri}}",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 4,
+      "title": "HTTP 5xx 에러율 (%)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "targets": [
+        {
+          "expr": "sum(rate(http_server_requests_seconds_count{application=\"cowork-channel\", status=~\"5..\"}[1m])) / sum(rate(http_server_requests_seconds_count{application=\"cowork-channel\"}[1m])) * 100",
+          "legendFormat": "5xx 에러율",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percent" } }
+    },
+    {
+      "id": 5,
+      "title": "JVM 힙 메모리",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{application=\"cowork-channel\", area=\"heap\"}",
+          "legendFormat": "Used {{id}}",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" }
+        },
+        {
+          "expr": "jvm_memory_max_bytes{application=\"cowork-channel\", area=\"heap\"}",
+          "legendFormat": "Max {{id}}",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    },
+    {
+      "id": 6,
+      "title": "JVM GC Pause (ms/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "targets": [
+        {
+          "expr": "rate(jvm_gc_pause_seconds_sum{application=\"cowork-channel\"}[1m]) * 1000",
+          "legendFormat": "{{action}} {{cause}}",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" }
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ms" } }
+    },
+    {
+      "id": 7,
+      "title": "JVM 스레드",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "targets": [
+        {
+          "expr": "jvm_threads_live_threads{application=\"cowork-channel\"}",
+          "legendFormat": "Live",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" }
+        },
+        {
+          "expr": "jvm_threads_daemon_threads{application=\"cowork-channel\"}",
+          "legendFormat": "Daemon",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" }
+        }
+      ]
+    }
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "hide": 0,
+        "label": "Datasource"
+      }
+    ]
+  }
+}
+

--- a/cowork-monitoring/prometheus/prometheus.yml
+++ b/cowork-monitoring/prometheus/prometheus.yml
@@ -37,6 +37,13 @@ scrape_configs:
         labels:
           service: team
 
+  - job_name: cowork-channel
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['host.docker.internal:8083']
+        labels:
+          service: channel
+
   - job_name: cowork-notification
     metrics_path: /actuator/prometheus
     static_configs:

--- a/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamMemberController.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamMemberController.kt
@@ -44,6 +44,17 @@ class TeamMemberController(
     ): ResponseEntity<List<TeamMemberResponse>> =
         ResponseEntity.ok(teamMemberService.getMembers(teamId))
 
+    @Operation(summary = "멤버 여부 확인", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "멤버 여부 반환"),
+    )
+    @GetMapping("/{userId}/exists")
+    fun isMember(
+        @PathVariable teamId: Long,
+        @PathVariable userId: Long,
+    ): ResponseEntity<Map<String, Boolean>> =
+        ResponseEntity.ok(mapOf("isMember" to teamMemberService.isMember(teamId, userId)))
+
     @Operation(summary = "멤버 역할 변경", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "변경 성공"),

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamMemberService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamMemberService.kt
@@ -64,6 +64,9 @@ class TeamMemberService(
     fun getMembers(teamId: Long): List<TeamMemberResponse> =
         teamMemberRepository.findAllByTeamId(teamId).map { TeamMemberResponse.of(it) }
 
+    fun isMember(teamId: Long, userId: Long): Boolean =
+        teamMemberRepository.existsByTeamIdAndUserId(teamId, userId)
+
     @Transactional
     fun changeRole(actorId: Long, teamId: Long, targetUserId: Long, request: ChangeRoleRequest) {
         requireRole(teamId, actorId, TeamRole.OWNER)

--- a/cowork-team/src/main/resources/application.yml
+++ b/cowork-team/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   config:
     import: "optional:configserver:http://localhost:8761"
   datasource:
-    url: jdbc:mysql://localhost:3306/cowork_team?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    url: ${SPRING_DATASOURCE_URL}
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_USER:cowork}
     password: ${MYSQL_PASSWORD:}

--- a/cowork-user/src/main/kotlin/com/cowork/user/service/S3Service.kt
+++ b/cowork-user/src/main/kotlin/com/cowork/user/service/S3Service.kt
@@ -5,7 +5,9 @@ import io.awspring.cloud.s3.S3Template
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
 import software.amazon.awssdk.services.s3.model.NoSuchKeyException
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
@@ -50,12 +52,20 @@ class S3Service(
         return s3Presigner.presignPutObject(presignRequest).url().toString()
     }
 
-    fun generateGetPresignedUrl(objectKey: String): String =
-        s3Template.createSignedGetURL(
-            minioProperties.bucket,
-            objectKey,
-            Duration.ofMinutes(minioProperties.presignedGetExpiryMinutes),
-        ).toString()
+    fun generateGetPresignedUrl(objectKey: String): String {
+        val getObjectRequest = GetObjectRequest.builder()
+            .bucket(minioProperties.bucket)
+            .key(objectKey)
+            .build()
+
+        val presignRequest = GetObjectPresignRequest.builder()
+            .signatureDuration(Duration.ofMinutes(minioProperties.presignedGetExpiryMinutes))
+            .getObjectRequest(getObjectRequest)
+            .build()
+
+        // @Primary로 등록된 presigner가 public endpoint로 서명하도록 구성돼 있어야 한다.
+        return s3Presigner.presignGetObject(presignRequest).url().toString()
+    }
 
     fun verifyUpload(userId: Long, objectKey: String) {
         if (!objectKey.startsWith("profiles/$userId/")) {

--- a/cowork-user/src/main/resources/application.yml
+++ b/cowork-user/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   config:
     import: "optional:configserver:http://localhost:8761"
   datasource:
-    url: jdbc:mysql://localhost:3306/cowork_user?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    url: ${SPRING_DATASOURCE_URL}
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${MYSQL_USER:cowork}
     password: ${MYSQL_PASSWORD:}

--- a/scripts/run/local/channel.sh
+++ b/scripts/run/local/channel.sh
@@ -6,7 +6,10 @@ source "$SCRIPT_DIR/_service.sh"
 
 SERVICE_NAME="cowork-channel"
 SERVICE_WORKDIR="$PROJECT_ROOT"
-SERVICE_COMMAND=("$PROJECT_ROOT/gradlew" ":cowork-channel:bootRun")
+SERVICE_COMMAND=(
+  bash -lc
+  'export SPRING_DATASOURCE_URL="${SPRING_DATASOURCE_URL:-jdbc:mysql://localhost:3306/cowork_channel?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul}"
+   exec ./gradlew :cowork-channel:bootRun'
+)
 
 run_managed_service "${1:-start}"
-

--- a/scripts/run/local/channel.sh
+++ b/scripts/run/local/channel.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_service.sh"
+
+SERVICE_NAME="cowork-channel"
+SERVICE_WORKDIR="$PROJECT_ROOT"
+SERVICE_COMMAND=("$PROJECT_ROOT/gradlew" ":cowork-channel:bootRun")
+
+run_managed_service "${1:-start}"
+

--- a/scripts/run/local/notification.sh
+++ b/scripts/run/local/notification.sh
@@ -6,6 +6,18 @@ source "$SCRIPT_DIR/_service.sh"
 
 SERVICE_NAME="cowork-notification"
 SERVICE_WORKDIR="$PROJECT_ROOT/cowork-notification"
-SERVICE_COMMAND=(env APP_CONFIG_URL=http://localhost:8761 APP_PROFILE=local go run ./cmd/server/)
+SERVICE_COMMAND=(
+  bash -lc
+  'export APP_CONFIG_URL="http://localhost:8761"
+   export APP_PROFILE="local"
+   export DB_DSN="${DB_DSN:-${MYSQL_USER}:${MYSQL_PASSWORD}@tcp(localhost:3306)/cowork_notification?charset=utf8mb4&parseTime=True&loc=Local}"
+   export TEAM_SERVICE_URL="${TEAM_SERVICE_URL:-http://localhost:8085}"
+   export USER_SERVICE_URL="${USER_SERVICE_URL:-http://localhost:8082}"
+   export PREFERENCE_SERVICE_URL="${PREFERENCE_SERVICE_URL:-http://localhost:9001}"
+   export KAFKA_BROKERS="${KAFKA_BROKERS:-${KAFKA_BOOTSTRAP_SERVERS:-localhost:9094}}"
+   export KAFKA_TOPIC_NOTIFICATION="${KAFKA_TOPIC_NOTIFICATION:-notification.trigger}"
+   export KAFKA_GROUP_ID="${KAFKA_GROUP_ID:-cowork-notification}"
+   exec go run ./cmd/server/'
+)
 
 run_managed_service "${1:-start}"

--- a/scripts/run/local/team.sh
+++ b/scripts/run/local/team.sh
@@ -6,6 +6,10 @@ source "$SCRIPT_DIR/_service.sh"
 
 SERVICE_NAME="cowork-team"
 SERVICE_WORKDIR="$PROJECT_ROOT"
-SERVICE_COMMAND=("$PROJECT_ROOT/gradlew" ":cowork-team:bootRun")
+SERVICE_COMMAND=(
+  bash -lc
+  'export SPRING_DATASOURCE_URL="${SPRING_DATASOURCE_URL:-jdbc:mysql://localhost:3306/cowork_team?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul}"
+   exec ./gradlew :cowork-team:bootRun'
+)
 
 run_managed_service "${1:-start}"

--- a/scripts/run/local/user.sh
+++ b/scripts/run/local/user.sh
@@ -6,6 +6,10 @@ source "$SCRIPT_DIR/_service.sh"
 
 SERVICE_NAME="cowork-user"
 SERVICE_WORKDIR="$PROJECT_ROOT"
-SERVICE_COMMAND=("$PROJECT_ROOT/gradlew" ":cowork-user:bootRun")
+SERVICE_COMMAND=(
+  bash -lc
+  'export SPRING_DATASOURCE_URL="${SPRING_DATASOURCE_URL:-jdbc:mysql://localhost:3306/cowork_user?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul}"
+   exec ./gradlew :cowork-user:bootRun'
+)
 
 run_managed_service "${1:-start}"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,7 @@ include("cowork-config")
 
 // 비즈니스 서비스 모듈 — 스택 확정 후 include 추가
 include("cowork-user")
-// include("cowork-channel")
+include("cowork-channel")
 // include("cowork-project")
 // include("cowork-team")
 include("cowork-preference")


### PR DESCRIPTION
## 개요

JWT 만료 시간 연장, 채널 서비스 초기 설정 및 S3 Presigned URL 생성 로직을 개선하였습니다.

## 본문

### 인증 서비스 (cowork-authorization)
- JWT Access Token 만료 시간을 15분에서 30분으로 연장하였습니다.
- JWT Refresh Token 만료 시간을 7일에서 90일로 연장하였습니다.
- Go 서비스의 `time.ParseDuration` 형식을 사용하는 환경 변수(`JWT_ACCESS_EXPIRE`, `JWT_REFRESH_EXPIRE`)를 추가 및 업데이트하였습니다.

### 채널 서비스 (cowork-channel)
- 새로운 마이크로서비스인 채널 서비스를 추가하고 기본 설정을 완료하였습니다.
- 팀별 채널 조회 API 및 기본적인 JPA 엔티티 구성을 완료하였습니다.
- 게이트웨이 및 스웨거 설정에 채널 서비스를 연동하였습니다.

### S3 및 인프라 개선
- 사용자 서비스(`cowork-user`)의 S3 조회용 Presigned URL 생성 시, `s3Template` 대신 `s3Presigner`를 직접 사용하도록 수정하여 퍼블릭 엔드포인트 서명을 더 정확하게 처리할 수 있도록 개선하였습니다.
- `.gitignore`에 `screenlog.*` 파일을 추가하여 로컬 개발 환경의 로그 파일이 추적되지 않도록 하였습니다.
- 루트 경로의 `.env.example`을 최신 설정에 맞춰 동기화하고 불필요한 중복 설정을 제거하였습니다.
