### PR TITLE
[gateway] 서비스 모니터링을 위한 헬스체크 엔드포인트 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,10 @@ MINIO_ROOT_PASSWORD=minioadmin
 
 # ── MinIO (S3 호환, production도 MinIO 사용) ────────────────────────────────
 # 이 값들이 "클라이언트(앱)가 접근 가능한 주소"여야 함.
+# - 로컬에서 앱(에뮬레이터/실기기)으로 테스트하면 Mac의 로컬 IP가 Wi-Fi 변경/재접속 등으로 바뀔 수 있음.
+# - 그 경우 presigned URL도 예전 IP로 발급되어 업로드가 timeout/실패함.
+# - 수동으로 IP를 매번 바꾸기 싫으면 아래처럼 `__LOCAL_IP__` 플레이스홀더를 써도 됨.
+#   (로컬 실행 스크립트가 시작 시점에 `__LOCAL_IP__`를 현재 IP로 치환)
 MINIO_REGION=ap-northeast-2
 MINIO_ACCESS_KEY=minioadmin
 MINIO_SECRET_KEY=minioadmin
@@ -47,9 +51,9 @@ MINIO_BUCKET=cowork-bucket
 # 서버(백엔드) 내부에서 MinIO로 붙는 주소 (내부 IP/내부 DNS 가능)
 MINIO_INTERNAL_ENDPOINT=http://localhost:9000
 # 클라이언트(앱/외부)가 접근 가능한 주소 (외부 도메인/URL)
-MINIO_PUBLIC_ENDPOINT=http://localhost:9000
+MINIO_PUBLIC_ENDPOINT=http://__LOCAL_IP__:9000
 # 팀 아이콘 등 "공개 URL"로 내려줄 base URL (클라이언트 접근 주소)
-MINIO_PUBLIC_BASE_URL=http://localhost:9000/cowork-bucket
+MINIO_PUBLIC_BASE_URL=http://__LOCAL_IP__:9000/cowork-bucket
 MINIO_PATH_STYLE_ACCESS_ENABLED=true
 
 # ── Grafana ─────────────────────────────────────────────────────────────────

--- a/cowork-config/src/main/resources/configs/cowork-notification-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-notification-local.yml
@@ -15,6 +15,12 @@ fcm:
 preference:
   service-url: http://localhost:9001
 
+team:
+  service-url: http://localhost:8085
+
+user:
+  service-url: http://localhost:8082
+
 eureka:
   server-url: http://localhost:8761/eureka
   app-name: cowork-notification

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
@@ -1,5 +1,6 @@
 package com.cowork.gateway.controller
 
+import com.cowork.gateway.health.ServiceStatus
 import com.cowork.gateway.response.CommonApiResponse
 import com.netflix.appinfo.InstanceInfo
 import io.swagger.v3.oas.annotations.Operation
@@ -55,16 +56,16 @@ class HealthCheckController(
         )]
     )
     @GetMapping
-    fun checkAll(): Mono<ResponseEntity<CommonApiResponse<Map<String, String>>>> {
+    fun checkAll(): Mono<ResponseEntity<CommonApiResponse<Map<String, ServiceStatus>>>> {
         return discoveryClient.services
             .flatMap { serviceId ->
                 discoveryClient.getInstances(serviceId)
                     .collectList()
                     .map { instances ->
                         val status = when {
-                            instances.isEmpty() || instances.none { it.isUp() } -> "DOWN"
-                            instances.all { it.isUp() } -> "UP"
-                            else -> "DEGRADED"
+                            instances.isEmpty() || instances.none { it.isUp() } -> ServiceStatus.DOWN
+                            instances.all { it.isUp() } -> ServiceStatus.UP
+                            else -> ServiceStatus.DEGRADED
                         }
                         serviceId to status
                     }

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
@@ -1,0 +1,44 @@
+package com.cowork.gateway.controller
+
+import com.cowork.gateway.response.CommonApiResponse
+import com.netflix.appinfo.InstanceInfo
+import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient
+import org.springframework.cloud.netflix.eureka.EurekaServiceInstance
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import reactor.core.publisher.Mono
+
+@RestController
+@RequestMapping("/api/health")
+class HealthCheckController(
+    private val discoveryClient: ReactiveDiscoveryClient
+) {
+
+    @GetMapping
+    fun checkAll(): Mono<ResponseEntity<CommonApiResponse<Map<String, String>>>> {
+        return discoveryClient.services
+            .flatMap { serviceId ->
+                discoveryClient.getInstances(serviceId)
+                    .collectList()
+                    .map { instances ->
+                        val status = when {
+                            instances.isEmpty() -> "DOWN"
+                            instances.all { it.isUp() } -> "UP"
+                            else -> "DEGRADED"
+                        }
+                        serviceId to status
+                    }
+            }
+            .collectMap({ it.first }, { it.second })
+            .map { ResponseEntity.ok(CommonApiResponse.success(it)) }
+    }
+
+    private fun org.springframework.cloud.client.ServiceInstance.isUp(): Boolean {
+        if (this is EurekaServiceInstance) {
+            return instanceInfo.status == InstanceInfo.InstanceStatus.UP
+        }
+        return true
+    }
+}

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
@@ -2,20 +2,58 @@ package com.cowork.gateway.controller
 
 import com.cowork.gateway.response.CommonApiResponse
 import com.netflix.appinfo.InstanceInfo
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient
 import org.springframework.cloud.netflix.eureka.EurekaServiceInstance
+import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Mono
 
+@Tag(name = "Health", description = "서비스 헬스 체크 API")
 @RestController
 @RequestMapping("/api/health")
 class HealthCheckController(
     private val discoveryClient: ReactiveDiscoveryClient
 ) {
 
+    @Operation(
+        summary = "전체 서비스 상태 조회",
+        description = """Eureka에 등록된 모든 서비스의 인스턴스 상태를 집계하여 반환합니다.
+
+- **UP**: 모든 인스턴스가 정상
+- **DEGRADED**: 일부 인스턴스가 비정상 (부분 장애)
+- **DOWN**: 등록된 인스턴스 없음""",
+    )
+    @ApiResponse(
+        responseCode = "200",
+        description = "서비스 상태 목록",
+        content = [Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = Schema(implementation = CommonApiResponse::class),
+            examples = [ExampleObject(
+                value = """
+                {
+                  "status": "OK",
+                  "code": 200,
+                  "message": "OK",
+                  "data": {
+                    "cowork-user": "UP",
+                    "cowork-team": "UP",
+                    "cowork-authorization": "DEGRADED",
+                    "cowork-chat": "DOWN"
+                  }
+                }"""
+            )]
+        )]
+    )
     @GetMapping
     fun checkAll(): Mono<ResponseEntity<CommonApiResponse<Map<String, String>>>> {
         return discoveryClient.services

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.ExampleObject
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.cloud.client.ServiceInstance
 import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient
 import org.springframework.cloud.gateway.route.RouteLocator
 import org.springframework.cloud.netflix.eureka.EurekaServiceInstance
@@ -92,10 +93,10 @@ class HealthCheckController(
             .map { ResponseEntity.ok(CommonApiResponse.success(it)) }
     }
 
-    private fun org.springframework.cloud.client.ServiceInstance.isUp(): Boolean {
+    private fun ServiceInstance.isUp(): Boolean {
         if (this is EurekaServiceInstance) {
             return instanceInfo.status == InstanceInfo.InstanceStatus.UP
         }
-        return true
+        return false
     }
 }

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.cloud.client.discovery.ReactiveDiscoveryClient
+import org.springframework.cloud.gateway.route.RouteLocator
 import org.springframework.cloud.netflix.eureka.EurekaServiceInstance
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -22,16 +23,17 @@ import reactor.core.publisher.Mono
 @RestController
 @RequestMapping("/api/health")
 class HealthCheckController(
-    private val discoveryClient: ReactiveDiscoveryClient
+    private val discoveryClient: ReactiveDiscoveryClient,
+    private val routeLocator: RouteLocator,
 ) {
 
     @Operation(
         summary = "전체 서비스 상태 조회",
-        description = """Eureka에 등록된 모든 서비스의 인스턴스 상태를 집계하여 반환합니다.
+        description = """게이트웨이 라우트에 등록된 모든 서비스의 상태를 반환합니다.
 
 - **UP**: 모든 인스턴스가 정상
 - **DEGRADED**: 일부 인스턴스가 비정상 (부분 장애)
-- **DOWN**: 등록된 인스턴스 없음""",
+- **DOWN**: Eureka 미등록 또는 모든 인스턴스 비정상""",
     )
     @ApiResponse(
         responseCode = "200",
@@ -57,18 +59,34 @@ class HealthCheckController(
     )
     @GetMapping
     fun checkAll(): Mono<ResponseEntity<CommonApiResponse<Map<String, ServiceStatus>>>> {
-        return discoveryClient.services
-            .flatMap { serviceId ->
-                discoveryClient.getInstances(serviceId)
-                    .collectList()
-                    .map { instances ->
-                        val status = when {
-                            instances.isEmpty() || instances.none { it.isUp() } -> ServiceStatus.DOWN
-                            instances.all { it.isUp() } -> ServiceStatus.UP
-                            else -> ServiceStatus.DEGRADED
-                        }
-                        serviceId to status
+        return routeLocator.routes
+            .map { route -> route.uri }
+            .filter { it.scheme == "lb" }
+            .map { it.host.lowercase() }
+            .distinct()
+            .collectList()
+            .flatMap { serviceIds ->
+                discoveryClient.services.collectList().map { registeredIds ->
+                    serviceIds to registeredIds.map { it.lowercase() }.toSet()
+                }
+            }
+            .flatMapMany { (serviceIds, registeredIds) ->
+                reactor.core.publisher.Flux.fromIterable(serviceIds).flatMap { serviceId ->
+                    if (serviceId !in registeredIds) {
+                        Mono.just(serviceId to ServiceStatus.DOWN)
+                    } else {
+                        discoveryClient.getInstances(serviceId)
+                            .collectList()
+                            .map { instances ->
+                                val status = when {
+                                    instances.isEmpty() || instances.none { it.isUp() } -> ServiceStatus.DOWN
+                                    instances.all { it.isUp() } -> ServiceStatus.UP
+                                    else -> ServiceStatus.DEGRADED
+                                }
+                                serviceId to status
+                            }
                     }
+                }
             }
             .collectMap({ it.first }, { it.second })
             .map { ResponseEntity.ok(CommonApiResponse.success(it)) }

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
@@ -62,7 +62,7 @@ class HealthCheckController(
                     .collectList()
                     .map { instances ->
                         val status = when {
-                            instances.isEmpty() -> "DOWN"
+                            instances.isEmpty() || instances.none { it.isUp() } -> "DOWN"
                             instances.all { it.isUp() } -> "UP"
                             else -> "DEGRADED"
                         }

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/health/ServiceStatus.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/health/ServiceStatus.kt
@@ -1,0 +1,7 @@
+package com.cowork.gateway.health
+
+enum class ServiceStatus {
+    UP,
+    DEGRADED,
+    DOWN,
+}

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/security/SecurityConfig.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/security/SecurityConfig.kt
@@ -44,6 +44,7 @@ class SecurityConfig(
                     .pathMatchers(HttpMethod.GET, "/api/auth/signin", "/api/auth/callback").permitAll()
                     .pathMatchers(HttpMethod.POST, "/api/auth/token", "/api/auth/refresh").permitAll()
                     .pathMatchers("/actuator/**").permitAll()
+                    .pathMatchers("/api/health").permitAll()
                     .pathMatchers("/fallback").permitAll()
                     .pathMatchers("/swagger-ui.html", "/swagger-ui/**", "/webjars/**").permitAll()
                     .pathMatchers("/v3/api-docs/**").permitAll()

--- a/scripts/run/local/_service.sh
+++ b/scripts/run/local/_service.sh
@@ -15,6 +15,44 @@ load_env() {
   set -a
   source "$PROJECT_ROOT/.env"
   set +a
+
+  # Some endpoints must be reachable from external clients (mobile app/emulator).
+  # Local IP can change frequently; allow using __LOCAL_IP__ placeholder in .env.
+  local ip
+  ip="$(detect_local_ip || true)"
+  if [ -n "$ip" ]; then
+    if [ -n "${MINIO_PUBLIC_ENDPOINT:-}" ] && [[ "$MINIO_PUBLIC_ENDPOINT" == *"__LOCAL_IP__"* ]]; then
+      export MINIO_PUBLIC_ENDPOINT="${MINIO_PUBLIC_ENDPOINT/__LOCAL_IP__/$ip}"
+    fi
+    if [ -n "${MINIO_PUBLIC_BASE_URL:-}" ] && [[ "$MINIO_PUBLIC_BASE_URL" == *"__LOCAL_IP__"* ]]; then
+      export MINIO_PUBLIC_BASE_URL="${MINIO_PUBLIC_BASE_URL/__LOCAL_IP__/$ip}"
+    fi
+  else
+    if [ -n "${MINIO_PUBLIC_ENDPOINT:-}" ] && [[ "$MINIO_PUBLIC_ENDPOINT" == *"__LOCAL_IP__"* ]]; then
+      echo "WARN: failed to detect local IP; MINIO_PUBLIC_ENDPOINT still contains __LOCAL_IP__"
+    fi
+    if [ -n "${MINIO_PUBLIC_BASE_URL:-}" ] && [[ "$MINIO_PUBLIC_BASE_URL" == *"__LOCAL_IP__"* ]]; then
+      echo "WARN: failed to detect local IP; MINIO_PUBLIC_BASE_URL still contains __LOCAL_IP__"
+    fi
+  fi
+}
+
+detect_local_ip() {
+  local ip=""
+
+  # macOS: en0 is typically Wi-Fi, but can vary.
+  if command -v ipconfig >/dev/null 2>&1; then
+    ip="$(ipconfig getifaddr en0 2>/dev/null || true)"
+    if [ -z "$ip" ]; then
+      ip="$(ipconfig getifaddr en1 2>/dev/null || true)"
+    fi
+  fi
+
+  if [ -z "$ip" ] && command -v ifconfig >/dev/null 2>&1; then
+    ip="$(ifconfig | awk '/inet / && $2 != "127.0.0.1" {print $2; exit}')"
+  fi
+
+  echo "$ip"
 }
 
 pid_file() {


### PR DESCRIPTION
## 개요

게이트웨이에서 전체 마이크로서비스의 상태를 통합하여 확인할 수 있는 헬스체크 API를 구현하고, 로컬 개발 환경의 편의성을 개선하였습니다.

## 본문

### 게이트웨이 서비스 (cowork-gateway)
- Eureka에 등록된 모든 서비스의 인스턴스 상태를 수집하여 반환하는 `/api/health` 엔드포인트를 추가하였습니다.
- 각 서비스의 인스턴스 가용성에 따라 UP, DEGRADED, DOWN 상태를 반환하도록 로직을 구현하였습니다.
- 해당 API를 인증 없이 접근할 수 있도록 Security 설정을 업데이트하였습니다.
- Swagger(OpenAPI)를 통해 API 스펙 및 반환값 예시를 문서화하였습니다.

### 인프라 및 로컬 실행 환경 개선
- 로컬 개발 시 모바일 앱이나 에뮬레이터에서 서버에 접속할 때 가변적인 Mac의 로컬 IP를 자동으로 처리할 수 있도록 `__LOCAL_IP__` 플레이스홀더 기능을 추가하였습니다.
- `_service.sh` 스크립트가 실행 시점에 실제 로컬 IP를 감지하여 `.env` 파일의 플레이스홀더를 치환하도록 개선하였습니다.
- `.env.example`에 관련 설정 예시와 설명을 추가하였습니다.
