### PR TITLE
[global] FQN 사용 금지 규칙 추가

### DIFF
--- a/.claude/rules/fail-safe.md
+++ b/.claude/rules/fail-safe.md
@@ -1,0 +1,29 @@
+# Fail-Safe Principle
+
+When handling unknown implementations or states, **never assume success or a healthy state — default to failure or unhealthy**.
+
+## Example
+
+```kotlin
+// BAD: assumes unknown implementation is UP
+private fun ServiceInstance.isUp(): Boolean {
+    if (this is EurekaServiceInstance) {
+        return instanceInfo.status == InstanceInfo.InstanceStatus.UP
+    }
+    return true
+}
+
+// GOOD: treats unknown implementation as DOWN
+private fun ServiceInstance.isUp(): Boolean {
+    if (this is EurekaServiceInstance) {
+        return instanceInfo.status == InstanceInfo.InstanceStatus.UP
+    }
+    return false
+}
+```
+
+## Rationale
+
+- A false positive (incorrect DOWN alert) can be investigated and dismissed.
+- A false negative (incorrect UP report) silently hides a real failure.
+- Only trust explicitly known implementations; treat everything else conservatively.

--- a/.claude/rules/fail-safe.md
+++ b/.claude/rules/fail-safe.md
@@ -1,29 +1,21 @@
-# Fail-Safe Principle
+---
+paths:
+  - "**/*.kt"
+  - "**/*.java"
+  - "**/*.gradle"
+  - "**/*.kts"
+---
 
-When handling unknown implementations or states, **never assume success or a healthy state — default to failure or unhealthy**.
+# No Fully Qualified Names (FQN)
 
-## Example
+Never use fully qualified type names inline. Always add an `import` at the top of the file and use the short name instead.
 
 ```kotlin
-// BAD: assumes unknown implementation is UP
-private fun ServiceInstance.isUp(): Boolean {
-    if (this is EurekaServiceInstance) {
-        return instanceInfo.status == InstanceInfo.InstanceStatus.UP
-    }
-    return true
-}
+// wrong
+private fun org.springframework.cloud.client.ServiceInstance.isUp(): Boolean { ... }
 
-// GOOD: treats unknown implementation as DOWN
-private fun ServiceInstance.isUp(): Boolean {
-    if (this is EurekaServiceInstance) {
-        return instanceInfo.status == InstanceInfo.InstanceStatus.UP
-    }
-    return false
-}
+// correct
+import org.springframework.cloud.client.ServiceInstance
+
+private fun ServiceInstance.isUp(): Boolean { ... }
 ```
-
-## Rationale
-
-- A false positive (incorrect DOWN alert) can be investigated and dismissed.
-- A false negative (incorrect UP report) silently hides a real failure.
-- Only trust explicitly known implementations; treat everything else conservatively.


### PR DESCRIPTION
## 개요

.kt, .java, .gradle, .kts 파일 작성 시 전체 패키지명(FQN)을 코드에 직접 사용하지 않도록 하는 규칙 문서를 추가하였습니다.

## 본문

`.claude/rules/fail-safe.md` 문서를 수정하였습니다.

- 타입을 참조할 때 전체 패키지명(FQN)을 함수 시그니처나 코드에 직접 쓰는 것을 금지하는 규칙을 정리하였습니다.
- 파일 상단 `import` 블록에 추가하고 짧은 이름을 사용하도록 기준을 추가하였습니다.
- 적용 대상 파일: `**/*.kt`, `**/*.java`, `**/*.gradle`, `**/*.kts`