### PR TITLE
[notification] SSE 기반 데스크톱 실시간 알림 채널 추가

### DIFF
--- a/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
@@ -162,6 +162,26 @@ spring:
           filters:
             - RewritePath=/v3/api-docs/preference, /swagger/doc.json
 
+        - id: notification-service-sse
+          uri: lb://cowork-notification
+          predicates:
+            - Path=/api/notifications/stream
+          filters:
+            - StripPrefix=1
+          metadata:
+            response-timeout: -1  # SSE는 타임아웃 없음
+
+        - id: notification-service
+          uri: lb://cowork-notification
+          predicates:
+            - Path=/api/notifications/**
+          filters:
+            - StripPrefix=1
+            - name: CircuitBreaker
+              args:
+                name: defaultCB
+                fallbackUri: forward:/fallback
+
         - id: notification-service-docs
           uri: lb://cowork-notification
           predicates:

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -184,6 +184,22 @@ spring:
           filters:
             - RewritePath=/v3/api-docs/channel, /v3/api-docs
 
+        - id: notification-service-sse
+          uri: lb://cowork-notification
+          predicates:
+            - Path=/api/notifications/stream
+          filters:
+            - StripPrefix=1
+          metadata:
+            response-timeout: -1  # SSE는 타임아웃 없음
+
+        - id: notification-service
+          uri: lb://cowork-notification
+          predicates:
+            - Path=/api/notifications/**
+          filters:
+            - StripPrefix=1
+
         - id: notification-service-docs
           uri: lb://cowork-notification
           predicates:

--- a/cowork-notification/cmd/server/main.go
+++ b/cowork-notification/cmd/server/main.go
@@ -27,6 +27,7 @@ import (
 	kafkainfra "github.com/cowork/cowork-notification/internal/infra/kafka"
 	mysqlinfra "github.com/cowork/cowork-notification/internal/infra/mysql"
 	"github.com/cowork/cowork-notification/internal/infra/preference"
+	sseinfra "github.com/cowork/cowork-notification/internal/infra/sse"
 	"github.com/cowork/cowork-notification/internal/infra/team"
 	"github.com/cowork/cowork-notification/internal/infra/user"
 	"github.com/cowork/cowork-notification/internal/middleware"
@@ -66,7 +67,8 @@ func main() {
 	svc := tokendomain.NewService(repo, fcmSender, prefClient)
 	handler := tokendomain.NewHandler(svc)
 
-	consumer := kafkainfra.NewConsumer(cfg.KafkaBrokers, cfg.KafkaTopicNotify, cfg.KafkaGroupID, svc, teamClient, userClient)
+	sseHub := sseinfra.NewHub()
+	consumer := kafkainfra.NewConsumer(cfg.KafkaBrokers, cfg.KafkaTopicNotify, cfg.KafkaGroupID, svc, teamClient, userClient, sseHub)
 
 	eurekaClient := eureka.New(cfg)
 	if err := eurekaClient.Register(cfg); err != nil {
@@ -85,6 +87,7 @@ func main() {
 		r.Use(middleware.ExtractAuthUser)
 		r.Post("/notifications/tokens", handler.RegisterToken)
 		r.Delete("/notifications/tokens/{token}", handler.DeleteToken)
+		r.Get("/notifications/stream", sseinfra.Handler(sseHub))
 	})
 
 	srv := &http.Server{

--- a/cowork-notification/docs/docs.go
+++ b/cowork-notification/docs/docs.go
@@ -35,6 +35,48 @@ const docTemplate = `{
                 }
             }
         },
+        "/notifications/stream": {
+            "get": {
+                "description": "인증된 사용자의 실시간 알림 이벤트를 Server-Sent Events(SSE)로 스트리밍합니다. 30초마다 keepalive ping을 전송합니다.",
+                "produces": [
+                    "text/event-stream"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "SSE 알림 스트림 구독",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "사용자 ID (Gateway 주입)",
+                        "name": "X-User-Id",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "data: {type, title, body, channelId, teamId}",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "인증 실패",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "SSE not supported",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/notifications/tokens": {
             "post": {
                 "description": "사용자의 디바이스 FCM 토큰을 등록합니다",
@@ -60,7 +102,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_domain_token.registerTokenRequest"
+                            "$ref": "#/definitions/token.registerTokenRequest"
                         }
                     }
                 ],
@@ -146,7 +188,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "internal_domain_token.registerTokenRequest": {
+        "token.registerTokenRequest": {
             "type": "object",
             "properties": {
                 "platform": {

--- a/cowork-notification/docs/swagger.json
+++ b/cowork-notification/docs/swagger.json
@@ -6,7 +6,6 @@
         "contact": {},
         "version": "1.0"
     },
-    "host": "",
     "basePath": "/",
     "paths": {
         "/health": {
@@ -22,6 +21,48 @@
                 "responses": {
                     "200": {
                         "description": "ok",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/notifications/stream": {
+            "get": {
+                "description": "인증된 사용자의 실시간 알림 이벤트를 Server-Sent Events(SSE)로 스트리밍합니다. 30초마다 keepalive ping을 전송합니다.",
+                "produces": [
+                    "text/event-stream"
+                ],
+                "tags": [
+                    "notifications"
+                ],
+                "summary": "SSE 알림 스트림 구독",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "format": "int64",
+                        "description": "사용자 ID (Gateway 주입)",
+                        "name": "X-User-Id",
+                        "in": "header",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "data: {type, title, body, channelId, teamId}",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "인증 실패",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "SSE not supported",
                         "schema": {
                             "type": "string"
                         }
@@ -54,7 +95,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/internal_domain_token.registerTokenRequest"
+                            "$ref": "#/definitions/token.registerTokenRequest"
                         }
                     }
                 ],
@@ -140,7 +181,7 @@
         }
     },
     "definitions": {
-        "internal_domain_token.registerTokenRequest": {
+        "token.registerTokenRequest": {
             "type": "object",
             "properties": {
                 "platform": {

--- a/cowork-notification/docs/swagger.yaml
+++ b/cowork-notification/docs/swagger.yaml
@@ -1,13 +1,12 @@
 basePath: /
 definitions:
-  internal_domain_token.registerTokenRequest:
+  token.registerTokenRequest:
     properties:
       platform:
         type: string
       token:
         type: string
     type: object
-host: ""
 info:
   contact: {}
   description: FCM 디바이스 토큰 관리 및 푸시 알림 서비스
@@ -27,6 +26,35 @@ paths:
       summary: 헬스 체크
       tags:
       - system
+  /notifications/stream:
+    get:
+      description: 인증된 사용자의 실시간 알림 이벤트를 Server-Sent Events(SSE)로 스트리밍합니다. 30초마다 keepalive
+        ping을 전송합니다.
+      parameters:
+      - description: 사용자 ID (Gateway 주입)
+        format: int64
+        in: header
+        name: X-User-Id
+        required: true
+        type: integer
+      produces:
+      - text/event-stream
+      responses:
+        "200":
+          description: 'data: {type, title, body, channelId, teamId}'
+          schema:
+            type: string
+        "401":
+          description: 인증 실패
+          schema:
+            type: string
+        "500":
+          description: SSE not supported
+          schema:
+            type: string
+      summary: SSE 알림 스트림 구독
+      tags:
+      - notifications
   /notifications/tokens:
     post:
       consumes:
@@ -44,7 +72,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/internal_domain_token.registerTokenRequest'
+          $ref: '#/definitions/token.registerTokenRequest'
       responses:
         "201":
           description: Created

--- a/cowork-notification/internal/infra/kafka/consumer.go
+++ b/cowork-notification/internal/infra/kafka/consumer.go
@@ -118,8 +118,10 @@ func (c *Consumer) handle(ctx context.Context, msg segkafka.Message) {
 			"channelId": channelID,
 			"teamId":    extractInt64(event.Data, "teamId"),
 		})
-		if err == nil {
-			c.sseBroadcaster.Broadcast(event.TargetUserIDs, ssePayload)
+		if err != nil {
+			slog.Error("SSE 페이로드 직렬화 실패", "err", err, "type", event.Type)
+		} else {
+			c.sseBroadcaster.Broadcast(mergeUserIDs(event.TargetUserIDs, event.ForcedUserIDs), ssePayload)
 		}
 	}
 }
@@ -177,6 +179,19 @@ func formatTime(iso string) string {
 	}
 	kst := t.In(time.FixedZone("KST", 9*60*60))
 	return kst.Format("2006-01-02 15:04")
+}
+
+// mergeUserIDs는 두 슬라이스를 합치되 중복을 제거합니다.
+func mergeUserIDs(a, b []int64) []int64 {
+	seen := make(map[int64]struct{}, len(a)+len(b))
+	result := make([]int64, 0, len(a)+len(b))
+	for _, id := range append(a, b...) {
+		if _, ok := seen[id]; !ok {
+			seen[id] = struct{}{}
+			result = append(result, id)
+		}
+	}
+	return result
 }
 
 func extractInt64(data map[string]any, key string) int64 {

--- a/cowork-notification/internal/infra/kafka/consumer.go
+++ b/cowork-notification/internal/infra/kafka/consumer.go
@@ -30,23 +30,30 @@ type UserNameResolver interface {
 	GetDisplayName(ctx context.Context, userID int64) (string, error)
 }
 
+// SSEBroadcaster는 SSE Hub의 Broadcast 메서드 인터페이스입니다.
+type SSEBroadcaster interface {
+	Broadcast(userIDs []int64, payload []byte)
+}
+
 type Consumer struct {
 	reader     *segkafka.Reader
 	svc        NotificationService
 	teamClient TeamNameResolver
 	userClient UserNameResolver
+	sseBroadcaster SSEBroadcaster
 }
 
-func NewConsumer(brokers, topic, groupID string, svc NotificationService, teamClient TeamNameResolver, userClient UserNameResolver) *Consumer {
+func NewConsumer(brokers, topic, groupID string, svc NotificationService, teamClient TeamNameResolver, userClient UserNameResolver, sseBroadcaster SSEBroadcaster) *Consumer {
 	return &Consumer{
 		reader: segkafka.NewReader(segkafka.ReaderConfig{
 			Brokers: strings.Split(brokers, ","),
 			Topic:   topic,
 			GroupID: groupID,
 		}),
-		svc:        svc,
-		teamClient: teamClient,
-		userClient: userClient,
+		svc:            svc,
+		teamClient:     teamClient,
+		userClient:     userClient,
+		sseBroadcaster: sseBroadcaster,
 	}
 }
 
@@ -100,6 +107,20 @@ func (c *Consumer) handle(ctx context.Context, msg segkafka.Message) {
 	channelID := extractInt64(event.Data, "channelId")
 	if err := c.svc.Notify(ctx, event.TargetUserIDs, event.ForcedUserIDs, title, body, channelID); err != nil {
 		slog.Error("notification failed", "err", err, "type", event.Type)
+	}
+
+	// 데스크톱 앱(SSE)으로 알림 이벤트 브로드캐스트
+	if c.sseBroadcaster != nil {
+		ssePayload, err := json.Marshal(map[string]any{
+			"type":      event.Type,
+			"title":     title,
+			"body":      body,
+			"channelId": channelID,
+			"teamId":    extractInt64(event.Data, "teamId"),
+		})
+		if err == nil {
+			c.sseBroadcaster.Broadcast(event.TargetUserIDs, ssePayload)
+		}
 	}
 }
 

--- a/cowork-notification/internal/infra/sse/handler.go
+++ b/cowork-notification/internal/infra/sse/handler.go
@@ -1,0 +1,64 @@
+package sse
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/cowork/cowork-notification/internal/middleware"
+)
+
+// Handler는 GET /notifications/stream SSE 엔드포인트를 처리합니다.
+func Handler(hub *Hub) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "SSE를 지원하지 않는 클라이언트입니다", http.StatusInternalServerError)
+			return
+		}
+
+		userID, ok := middleware.AccountIDFromContext(r.Context())
+		if !ok {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Connection", "keep-alive")
+		w.Header().Set("X-Accel-Buffering", "no") // nginx 버퍼링 비활성화
+
+		ch, unsubscribe := hub.Subscribe(userID)
+		defer unsubscribe()
+
+		slog.Info("SSE 클라이언트 연결", "userID", userID)
+
+		// 연결 확인용 초기 이벤트
+		fmt.Fprintf(w, "event: connected\ndata: {}\n\n")
+		flusher.Flush()
+
+		ticker := time.NewTicker(30 * time.Second)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case payload, open := <-ch:
+				if !open {
+					return
+				}
+				fmt.Fprintf(w, "data: %s\n\n", payload)
+				flusher.Flush()
+
+			case <-ticker.C:
+				// keepalive: 연결 유지용 주석 이벤트
+				fmt.Fprintf(w, ": ping\n\n")
+				flusher.Flush()
+
+			case <-r.Context().Done():
+				slog.Info("SSE 클라이언트 연결 종료", "userID", userID)
+				return
+			}
+		}
+	}
+}

--- a/cowork-notification/internal/infra/sse/handler.go
+++ b/cowork-notification/internal/infra/sse/handler.go
@@ -11,6 +11,19 @@ import (
 
 const keepaliveInterval = 30 * time.Second
 
+// streamHandler godoc
+//
+//	@Summary		SSE 알림 스트림 구독
+//	@Description	인증된 사용자의 실시간 알림 이벤트를 Server-Sent Events(SSE)로 스트리밍합니다. 30초마다 keepalive ping을 전송합니다.
+//	@Tags			notifications
+//	@Produce		text/event-stream
+//	@Param			X-User-Id	header	int64	true	"사용자 ID (Gateway 주입)"
+//	@Success		200	{string}	string	"data: {type, title, body, channelId, teamId}"
+//	@Failure		401	{string}	string	"인증 실패"
+//	@Failure		500	{string}	string	"SSE not supported"
+//	@Router			/notifications/stream [get]
+func streamHandler(w http.ResponseWriter, r *http.Request) {} //nolint:unused
+
 // Handler는 GET /notifications/stream SSE 엔드포인트를 처리합니다.
 func Handler(hub *Hub) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {

--- a/cowork-notification/internal/infra/sse/handler.go
+++ b/cowork-notification/internal/infra/sse/handler.go
@@ -9,12 +9,14 @@ import (
 	"github.com/cowork/cowork-notification/internal/middleware"
 )
 
+const keepaliveInterval = 30 * time.Second
+
 // Handler는 GET /notifications/stream SSE 엔드포인트를 처리합니다.
 func Handler(hub *Hub) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		flusher, ok := w.(http.Flusher)
 		if !ok {
-			http.Error(w, "SSE를 지원하지 않는 클라이언트입니다", http.StatusInternalServerError)
+			http.Error(w, "SSE not supported", http.StatusInternalServerError)
 			return
 		}
 
@@ -38,7 +40,7 @@ func Handler(hub *Hub) http.HandlerFunc {
 		fmt.Fprintf(w, "event: connected\ndata: {}\n\n")
 		flusher.Flush()
 
-		ticker := time.NewTicker(30 * time.Second)
+		ticker := time.NewTicker(keepaliveInterval)
 		defer ticker.Stop()
 
 		for {

--- a/cowork-notification/internal/infra/sse/hub.go
+++ b/cowork-notification/internal/infra/sse/hub.go
@@ -1,0 +1,55 @@
+package sse
+
+import "sync"
+
+// Hub는 사용자별 SSE 클라이언트 채널을 관리합니다.
+type Hub struct {
+	mu      sync.RWMutex
+	clients map[int64][]chan []byte
+}
+
+func NewHub() *Hub {
+	return &Hub{clients: make(map[int64][]chan []byte)}
+}
+
+// Subscribe는 해당 사용자의 SSE 채널을 등록합니다.
+// 클라이언트 연결 종료 시 반드시 반환된 unsubscribe를 호출해야 합니다.
+func (h *Hub) Subscribe(userID int64) (ch chan []byte, unsubscribe func()) {
+	ch = make(chan []byte, 8)
+
+	h.mu.Lock()
+	h.clients[userID] = append(h.clients[userID], ch)
+	h.mu.Unlock()
+
+	unsubscribe = func() {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		list := h.clients[userID]
+		for i, c := range list {
+			if c == ch {
+				h.clients[userID] = append(list[:i], list[i+1:]...)
+				break
+			}
+		}
+		if len(h.clients[userID]) == 0 {
+			delete(h.clients, userID)
+		}
+		close(ch)
+	}
+	return ch, unsubscribe
+}
+
+// Broadcast는 지정된 사용자들의 모든 SSE 클라이언트에 payload를 전송합니다.
+// 클라이언트 버퍼가 가득 찬 경우 해당 메시지는 드롭됩니다.
+func (h *Hub) Broadcast(userIDs []int64, payload []byte) {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	for _, uid := range userIDs {
+		for _, ch := range h.clients[uid] {
+			select {
+			case ch <- payload:
+			default:
+			}
+		}
+	}
+}

--- a/cowork-notification/internal/infra/sse/hub.go
+++ b/cowork-notification/internal/infra/sse/hub.go
@@ -2,6 +2,8 @@ package sse
 
 import "sync"
 
+const clientChannelBuffer = 8
+
 // Hub는 사용자별 SSE 클라이언트 채널을 관리합니다.
 type Hub struct {
 	mu      sync.RWMutex
@@ -15,7 +17,7 @@ func NewHub() *Hub {
 // Subscribe는 해당 사용자의 SSE 채널을 등록합니다.
 // 클라이언트 연결 종료 시 반드시 반환된 unsubscribe를 호출해야 합니다.
 func (h *Hub) Subscribe(userID int64) (ch chan []byte, unsubscribe func()) {
-	ch = make(chan []byte, 8)
+	ch = make(chan []byte, clientChannelBuffer)
 
 	h.mu.Lock()
 	h.clients[userID] = append(h.clients[userID], ch)


### PR DESCRIPTION
## 개요

기존 FCM 기반 모바일 알림 외에 Kotlin Multiplatform Desktop 앱을 위한 SSE(Server-Sent Events) 알림 채널을 추가하였습니다. Kafka `notification.trigger` 이벤트 수신 시 FCM과 SSE를 동시에 발송하며, 데스크톱 앱은 SSE 스트림을 구독하여 OS 네이티브 알림을 표시할 수 있습니다.

## 본문

### 배경

FCM은 Kotlin Multiplatform Desktop 타깃을 공식 지원하지 않습니다. 데스크톱 앱(KMP Desktop/JVM)은 `java.awt.SystemTray`를 통해 OS 네이티브 알림을 직접 표시할 수 있으므로, 백엔드에서 SSE 스트림으로 이벤트를 전달하는 방식을 채택하였습니다.

### 변경 사항

**cowork-notification (Go)**

- `internal/infra/sse/hub.go`: 사용자 ID별 SSE 클라이언트 채널을 관리하는 Hub를 추가하였습니다. `sync.RWMutex`로 동시 접근을 보호하며, 동일 사용자의 다중 연결(멀티 디바이스)을 지원합니다.
- `internal/infra/sse/handler.go`: `GET /notifications/stream` SSE 핸들러를 추가하였습니다. 30초 주기 keepalive ping과 초기 연결 확인 이벤트(`event: connected`)를 전송합니다.
- `internal/infra/kafka/consumer.go`: Kafka 이벤트 처리 후 SSE Hub로 브로드캐스트를 추가하였습니다. `SSEBroadcaster` 인터페이스로 Hub 의존성을 주입하여 테스트 시 nil safe하게 동작합니다.
- `cmd/server/main.go`: Hub 초기화 및 SSE 라우트를 등록하였습니다.

**cowork-config**

- `cowork-gateway-local.yml` / `cowork-gateway-dev.yml`: `/api/notifications/stream` SSE 전용 라우트(`response-timeout: -1`)와 `/api/notifications/**` 일반 API 라우트를 추가하였습니다. 기존 게이트웨이 설정에는 notification 서비스로의 API 라우트가 누락되어 있었습니다.

### KMP Desktop 연동

```kotlin
httpClient.sse("/api/notifications/stream",
    request = { bearerAuth(token) }
) {
    incoming.collect { event ->
        if (event.event == "connected") return@collect
        val payload = Json.decodeFromString<NotificationEvent>(event.data ?: return@collect)
        trayIcon.displayMessage(payload.title, payload.body, TrayIcon.MessageType.INFO)
    }
}
```

### 주의 사항

- Hub는 인메모리 구조이므로 `cowork-notification`이 다중 인스턴스로 확장될 경우 Redis Pub/Sub으로 대체가 필요합니다.
- 클라이언트 채널 버퍼(8개)가 가득 찬 경우 해당 메시지는 드롭됩니다.
