### PR TITLE
[global] `vault-init` 추가 및 서비스 설정 오류 수정

### DIFF
--- a/cowork-authorization/internal/config/config.go
+++ b/cowork-authorization/internal/config/config.go
@@ -66,7 +66,7 @@ func Load() (*AppConfig, error) {
 		EurekaInstanceHost: getEnvOrDefault("EUREKA_INSTANCE_HOST", "localhost"),
 		EurekaInstancePort: eurekaPort,
 
-		UserServiceURL: getEnvOrDefault("USER_SERVICE_URL", "http://cowork-user:8080"),
+		UserServiceURL: getEnvOrDefault("USER_SERVICE_URL", "http://cowork-user:8082"),
 	}
 
 	return cfg, nil

--- a/cowork-config/src/main/resources/application.yml
+++ b/cowork-config/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
   profiles:
     active: ${SPRING_PROFILES_ACTIVE:dev}
     group:
-      local: native
+      local: composite
 
   cloud:
     bus:
@@ -51,6 +51,16 @@ spring:
     config:
       server:
         composite:
+          - type: vault
+            host: ${VAULT_HOST:localhost}
+            port: ${VAULT_PORT:8200}
+            scheme: ${VAULT_SCHEME:http}
+            authentication: TOKEN
+            token: ${VAULT_TOKEN:dev-root-token}
+            kv-version: 2
+            backend: secret
+            profile-separator: "/"
+            default-context: application
           - type: native
             search-locations: classpath:/configs/
 

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
@@ -62,8 +62,8 @@ class HealthCheckController(
     fun checkAll(): Mono<ResponseEntity<CommonApiResponse<Map<String, ServiceStatus>>>> {
         return routeLocator.routes
             .map { route -> route.uri }
-            .filter { it.scheme == "lb" && it.host != null }
-            .map { it.host!!.lowercase() }
+            .filter { it.scheme == "lb" }
+            .flatMap { uri -> Mono.justOrEmpty(uri.host?.lowercase()) }
             .distinct()
             .collectList()
             .flatMap { serviceIds ->

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/HealthCheckController.kt
@@ -62,8 +62,8 @@ class HealthCheckController(
     fun checkAll(): Mono<ResponseEntity<CommonApiResponse<Map<String, ServiceStatus>>>> {
         return routeLocator.routes
             .map { route -> route.uri }
-            .filter { it.scheme == "lb" }
-            .map { it.host.lowercase() }
+            .filter { it.scheme == "lb" && it.host != null }
+            .map { it.host!!.lowercase() }
             .distinct()
             .collectList()
             .flatMap { serviceIds ->

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,6 +111,34 @@ services:
       timeout: 5s
       retries: 5
 
+  vault-init:
+    image: hashicorp/vault:2.0.0
+    container_name: cowork-vault-init
+    restart: "no"
+    depends_on:
+      vault:
+        condition: service_healthy
+    environment:
+      VAULT_ADDR: http://cowork-vault:8200
+      VAULT_TOKEN: dev-root-token
+      JWT_SECRET: ${JWT_SECRET}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
+      MINIO_PUBLIC_ENDPOINT: ${MINIO_PUBLIC_ENDPOINT:-http://localhost:9000}
+      MINIO_INTERNAL_ENDPOINT: ${MINIO_INTERNAL_ENDPOINT:-http://minio:9000}
+      MINIO_PUBLIC_BASE_URL: ${MINIO_PUBLIC_BASE_URL:-http://localhost:9000/cowork-bucket}
+    entrypoint: >
+      /bin/sh -c "
+      vault secrets enable -version=2 -path=secret kv 2>/dev/null || true;
+      vault kv put secret/application JWT_SECRET=$${JWT_SECRET} MYSQL_USER=$${MYSQL_USER} MYSQL_PASSWORD=$${MYSQL_PASSWORD} POSTGRES_USER=$${POSTGRES_USER} POSTGRES_PASSWORD=$${POSTGRES_PASSWORD} MINIO_ACCESS_KEY=$${MINIO_ACCESS_KEY} MINIO_SECRET_KEY=$${MINIO_SECRET_KEY} MINIO_PUBLIC_ENDPOINT=$${MINIO_PUBLIC_ENDPOINT} MINIO_INTERNAL_ENDPOINT=$${MINIO_INTERNAL_ENDPOINT} MINIO_PUBLIC_BASE_URL=$${MINIO_PUBLIC_BASE_URL};
+      echo 'Vault secrets initialized.';
+      exit 0;
+      "
+
   minio:
     image: minio/minio:latest
     container_name: cowork-minio
@@ -332,9 +360,12 @@ services:
     depends_on:
       kafka:
         condition: service_healthy
+      vault-init:
+        condition: service_completed_successfully
     environment:
       SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-local}
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      VAULT_HOST: cowork-vault
     ports:
       - "8761:8761"
     volumes:
@@ -393,6 +424,7 @@ services:
       EUREKA_SERVER_URL: http://cowork-config:8761/eureka
       EUREKA_INSTANCE_HOST: cowork-authorization
       EUREKA_INSTANCE_PORT: "8081"
+      USER_SERVICE_URL: http://cowork-user:8082
     ports:
       - "8081:8081"
     healthcheck:

--- a/docs/LOCAL_RUN_GUIDE.md
+++ b/docs/LOCAL_RUN_GUIDE.md
@@ -5,6 +5,7 @@
 기준일:
 - 2026-04-27 (초안)
 - 2026-04-27 (Docker 통합 실행으로 전면 개정)
+- 2026-04-28 (vault-init 추가, gateway JWT_SECRET 주입 수정, authorization USER_SERVICE_URL 수정)
 
 검증 기준:
 - `docker-compose.yml`
@@ -122,7 +123,9 @@ docker compose down -v && docker compose up -d
 Docker Compose가 아래 의존 관계를 따라 자동으로 기동한다.
 
 ```
-infra (MySQL, Kafka, Redis, Mongo, Postgres, ...) 
+infra (MySQL, Kafka, Redis, Mongo, Postgres, ...)
+  ├─ vault → vault-init (시크릿 시드)
+  ├─ minio → minio-init (버킷 생성)
   └─ cowork-config (Config Server + Eureka)
        ├─ cowork-gateway
        ├─ cowork-authorization
@@ -181,25 +184,50 @@ Kafka는 외부 접근용(`9094`)과 컨테이너 내부용(`9092`) 리스너가
 | Spring profile | `local` | `dev` 또는 `prod` (Vault 연동) |
 | MinIO | 로컬 컨테이너 | S3 호환 엔드포인트로 변경 |
 
-`dev`/`prod` 프로파일은 Vault Config Server를 사용한다. `.env`에서 `SPRING_PROFILES_ACTIVE` 및 `VAULT_*` 값을 채워야 한다.
+### Vault 시크릿 배포 구조
+
+`dev`/`prod` 프로파일에서 config server(Spring Boot 서비스용)와 환경변수(Go 서비스용)로 시크릿이 각각 주입된다.
+
+| 서비스 유형 | 시크릿 경로 |
+|---|---|
+| Spring Boot (gateway 등) | Vault → config server → 서비스 |
+| Go (authorization, notification, voice) | 컨테이너 환경변수 직접 주입 |
+
+`vault-init` 컨테이너가 Vault 기동 직후 `secret/application` 경로에 아래 시크릿을 자동으로 기록한다.
+
+| Vault 키 | 참조하는 서비스 |
+|---|---|
+| `JWT_SECRET` | gateway (jwt.secret) |
+| `MYSQL_USER`, `MYSQL_PASSWORD` | notification (DB DSN) |
+| `POSTGRES_USER`, `POSTGRES_PASSWORD` | preference (DB) |
+| `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` | user, preference (MinIO) |
+| `MINIO_PUBLIC_ENDPOINT`, `MINIO_INTERNAL_ENDPOINT` | user, preference (MinIO) |
+
+`.env`에서 `SPRING_PROFILES_ACTIVE=dev`로 변경하면 config server가 Vault composite 모드로 전환된다. `VAULT_HOST`는 `cowork-vault`로 자동 설정된다.
 
 ## 10. 자주 쓰는 확인 포인트
 
-| 서비스 | URL |
-|---|---|
-| Eureka Dashboard | `http://localhost:8761` |
-| Gateway Swagger | `http://localhost:8080/swagger-ui.html` |
-| Kafka UI | `http://localhost:8090` |
-| Prometheus | `http://localhost:9090` |
-| Grafana | `http://localhost:3001` |
-| MinIO Console | `http://localhost:9002` |
-| Vault | `http://localhost:8200` |
+| 서비스              | URL                                     |
+|------------------|-----------------------------------------|
+| Eureka Dashboard | `http://localhost:8761`                 |
+| Gateway Swagger  | `http://localhost:8080/swagger-ui.html` |
+| Kafka UI         | `http://localhost:8090`                 |
+| Prometheus       | `http://localhost:9090`                 |
+| Grafana          | `http://localhost:3001`                 |
+| MinIO Console    | `http://localhost:9002`                 |
+| Vault            | `http://localhost:8200`                 |
 
 ## 11. 알려진 주의사항
 
 `cowork-config`:
-- `SPRING_PROFILES_ACTIVE=local`이 적용돼야 native config를 읽는다.
-- `dev` 프로파일로 뜨면 Vault URI가 없어서 실패한다.
+- `local`/`dev`/`prod` 모든 프로파일에서 Vault + native composite 모드로 동작한다.
+- `vault-init` 완료 후 기동하도록 `depends_on`이 설정돼 있다. `VAULT_HOST=cowork-vault`는 docker-compose에 이미 설정돼 있다.
+
+`cowork-gateway`:
+- `jwt.secret`은 모든 프로파일에서 Vault → config server 경로로 주입된다.
+
+`cowork-authorization`:
+- `USER_SERVICE_URL` 기본값이 `http://cowork-user:8082`임. docker-compose에 명시돼 있으므로 별도 설정 불필요.
 
 `cowork-voice`:
 - `.env`의 `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`가 채워져야 기동된다.


### PR DESCRIPTION
## 개요

`docker compose up` 한 번으로 Vault 시크릿이 자동으로 초기화되도록 `vault-init` 컨테이너를 추가하였습니다. 아울러 `cowork-config`의 `local` 프로파일을 Vault + native composite 모드로 전환하고, `cowork-authorization`의 유저 서비스 포트 오기재 및 `cowork-gateway`의 헬스 체크 NPE 가능성을 수정하였습니다.

## 본문

### vault-init 컨테이너 추가 (`docker-compose.yml`)

Vault 컨테이너가 healthy 상태가 된 직후 `vault-init`이 실행되어 `secret/application` 경로에 아래 시크릿을 자동으로 기록합니다.

- `JWT_SECRET` — gateway JWT 검증 키
- `MYSQL_USER`, `MYSQL_PASSWORD` — notification DB DSN
- `POSTGRES_USER`, `POSTGRES_PASSWORD` — preference DB
- `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_PUBLIC_ENDPOINT`, `MINIO_INTERNAL_ENDPOINT`, `MINIO_PUBLIC_BASE_URL` — user / preference MinIO 접근 정보

`cowork-config`가 `vault-init` 완료 후 기동하도록 `depends_on`을 설정하였고, `VAULT_HOST=cowork-vault` 환경변수를 주입하였습니다.

### cowork-config local 프로파일 Vault 연동 (`application.yml`)

기존에 `local` 프로파일은 `native` 단일 백엔드를 사용하였습니다. Vault에 기록된 시크릿을 `local` 환경에서도 읽을 수 있도록 `composite` 모드(Vault → native)로 전환하였습니다. `dev`/`prod`와 동일한 방식으로 동작합니다.

### cowork-authorization 유저 서비스 포트 수정 (`config.go`)

`USER_SERVICE_URL` 기본값이 `:8080`으로 잘못 설정되어 있어 실제 포트인 `:8082`로 수정하였습니다. docker-compose에도 동일한 값을 명시하였습니다.

### cowork-gateway 헬스 체크 NPE 방지 (`HealthCheckController.kt`)

`route.uri.host`가 `null`인 경로가 포함될 경우 NPE가 발생할 수 있었습니다. `filter` 조건에 `it.host != null` 검사를 추가하고 `.map` 내부에서 non-null assertion(`!!`)을 적용하였습니다.

### 문서 업데이트 (`docs/LOCAL_RUN_GUIDE.md`)

- 기동 순서 다이어그램에 `vault-init`, `minio-init` 추가
- Vault 시크릿 배포 구조 테이블 신규 작성
- 각 서비스별 주의사항(cowork-gateway, cowork-authorization) 추가
