### PR TITLE
[global] 모니터링 요청 로그 제외

### DIFF
--- a/cowork-authorization/cmd/main.go
+++ b/cowork-authorization/cmd/main.go
@@ -71,7 +71,11 @@ func main() {
 
 	authHandler := handler.NewAuthHandler(authSvc, tokenSvc)
 
-	router := gin.Default()
+	router := gin.New()
+	router.Use(gin.LoggerWithConfig(gin.LoggerConfig{
+		SkipPaths: []string{"/health", "/metrics"},
+	}))
+	router.Use(gin.Recovery())
 	router.Use(monitoring.HTTPMetricsMiddleware())
 
 	router.GET("/health", handler.Health)

--- a/cowork-authorization/cmd/main.go
+++ b/cowork-authorization/cmd/main.go
@@ -35,6 +35,13 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	healthPath          = "/health"
+	healthTrailingPath  = "/health/"
+	metricsPath         = "/metrics"
+	metricsTrailingPath = "/metrics/"
+)
+
 func main() {
 	logger.Init("cowork-authorization")
 
@@ -73,13 +80,13 @@ func main() {
 
 	router := gin.New()
 	router.Use(gin.LoggerWithConfig(gin.LoggerConfig{
-		SkipPaths: []string{"/health", "/health/", "/metrics", "/metrics/"},
+		SkipPaths: []string{healthPath, healthTrailingPath, metricsPath, metricsTrailingPath},
 	}))
 	router.Use(gin.Recovery())
 	router.Use(monitoring.HTTPMetricsMiddleware())
 
-	router.GET("/health", handler.Health)
-	router.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	router.GET(healthPath, handler.Health)
+	router.GET(metricsPath, gin.WrapH(promhttp.Handler()))
 	router.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
 
 	auth := router.Group("/auth")

--- a/cowork-authorization/cmd/main.go
+++ b/cowork-authorization/cmd/main.go
@@ -73,7 +73,7 @@ func main() {
 
 	router := gin.New()
 	router.Use(gin.LoggerWithConfig(gin.LoggerConfig{
-		SkipPaths: []string{"/health", "/metrics"},
+		SkipPaths: []string{"/health", "/health/", "/metrics", "/metrics/"},
 	}))
 	router.Use(gin.Recovery())
 	router.Use(monitoring.HTTPMetricsMiddleware())

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -27,7 +27,7 @@ const loggerImports = process.env.CHAT_LOGGER_ENABLED === 'false'
                 stream: createLogStream(),
                 autoLogging: {
                     ignore: (req) => {
-                        const path = req.url?.split('?')[0];
+                        const path = req.url?.split('?')[0]?.replace(/\/$/, '');
                         return path === '/metrics' || path === '/health';
                     },
                 },

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -26,7 +26,10 @@ const loggerImports = process.env.CHAT_LOGGER_ENABLED === 'false'
                 level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
                 stream: createLogStream(),
                 autoLogging: {
-                    ignore: (req) => req.url?.split('?')[0] === '/metrics',
+                    ignore: (req) => {
+                        const path = req.url?.split('?')[0];
+                        return path === '/metrics' || path === '/health';
+                    },
                 },
                 timestamp: () => `,"@timestamp":"${new Date().toISOString()}"`,
                 formatters: {

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -18,6 +18,10 @@ import { HealthController } from '../health.controller';
 import { MinioModule } from '../storage/minio.module';
 
 const LOG_DIR = process.env.COWORK_CHAT_LOG_DIR ?? `${process.cwd()}/build/logs/cowork/chat`;
+const METRICS_PATH = '/metrics';
+const HEALTH_PATH = '/health';
+const EXCLUDED_AUTO_LOGGING_PATHS = new Set([METRICS_PATH, HEALTH_PATH]);
+
 const loggerImports = process.env.CHAT_LOGGER_ENABLED === 'false'
     ? []
     : [
@@ -28,7 +32,7 @@ const loggerImports = process.env.CHAT_LOGGER_ENABLED === 'false'
                 autoLogging: {
                     ignore: (req) => {
                         const path = req.url?.split('?')[0]?.replace(/\/$/, '');
-                        return path === '/metrics' || path === '/health';
+                        return path !== undefined && EXCLUDED_AUTO_LOGGING_PATHS.has(path);
                     },
                 },
                 timestamp: () => `,"@timestamp":"${new Date().toISOString()}"`,

--- a/cowork-config/src/main/kotlin/com/cowork/config/filter/AccessLogFilter.kt
+++ b/cowork-config/src/main/kotlin/com/cowork/config/filter/AccessLogFilter.kt
@@ -7,6 +7,7 @@ import net.logstash.logback.argument.StructuredArguments.entries
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.filter.OncePerRequestFilter
+import java.util.concurrent.TimeUnit
 
 private const val ACTUATOR_PATH = "/actuator"
 private const val METRICS_PATH = "/metrics"
@@ -23,7 +24,7 @@ class AccessLogFilter : OncePerRequestFilter() {
         filterChain: FilterChain,
     ) {
         val path = request.requestURI
-        val start = System.currentTimeMillis()
+        val start = System.nanoTime()
 
         try {
             filterChain.doFilter(request, response)
@@ -36,7 +37,7 @@ class AccessLogFilter : OncePerRequestFilter() {
                             "method" to request.method,
                             "path" to path,
                             "status" to response.status,
-                            "duration" to System.currentTimeMillis() - start,
+                            "duration" to TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start),
                         )
                     )
                 )

--- a/cowork-config/src/main/kotlin/com/cowork/config/filter/AccessLogFilter.kt
+++ b/cowork-config/src/main/kotlin/com/cowork/config/filter/AccessLogFilter.kt
@@ -1,0 +1,54 @@
+package com.cowork.config.filter
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import net.logstash.logback.argument.StructuredArguments.entries
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+private const val ACTUATOR_PATH = "/actuator"
+private const val METRICS_PATH = "/metrics"
+private const val HEALTH_PATH = "/health"
+
+@Component
+class AccessLogFilter : OncePerRequestFilter() {
+
+    private val log = LoggerFactory.getLogger(AccessLogFilter::class.java)
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val path = request.requestURI
+        val start = System.currentTimeMillis()
+
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            if (!isExcludedLogEndpoint(path)) {
+                log.info(
+                    "{}",
+                    entries(
+                        mapOf(
+                            "method" to request.method,
+                            "path" to path,
+                            "status" to response.status,
+                            "duration" to System.currentTimeMillis() - start,
+                        )
+                    )
+                )
+            }
+        }
+    }
+
+    private fun isExcludedLogEndpoint(path: String): Boolean {
+        val normalizedPath = path.removeSuffix("/")
+        return normalizedPath == ACTUATOR_PATH ||
+            normalizedPath.startsWith("$ACTUATOR_PATH/") ||
+            normalizedPath == METRICS_PATH ||
+            normalizedPath == HEALTH_PATH
+    }
+}

--- a/cowork-config/src/main/resources/configs/application.yml
+++ b/cowork-config/src/main/resources/configs/application.yml
@@ -39,3 +39,4 @@ sdk:
       - "/actuator/**"
       - "/metrics"
       - "/health"
+      - "/api/health"

--- a/cowork-config/src/main/resources/configs/application.yml
+++ b/cowork-config/src/main/resources/configs/application.yml
@@ -32,3 +32,10 @@ management:
   metrics:
     tags:
       application: ${spring.application.name}
+
+sdk:
+  logging:
+    not-logging-urls:
+      - "/actuator/**"
+      - "/metrics"
+      - "/health"

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/AccessLogFilter.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/AccessLogFilter.kt
@@ -22,7 +22,7 @@ class AccessLogFilter : GlobalFilter, Ordered {
         val path = request.path.value()
 
         return chain.filter(exchange).doFinally {
-            if (isMetricsEndpoint(path)) {
+            if (isExcludedLogEndpoint(path)) {
                 return@doFinally
             }
 
@@ -42,6 +42,6 @@ class AccessLogFilter : GlobalFilter, Ordered {
         }
     }
 
-    private fun isMetricsEndpoint(path: String): Boolean =
-        path == "/actuator/prometheus" || path == "/metrics"
+    private fun isExcludedLogEndpoint(path: String): Boolean =
+        path.startsWith("/actuator/") || path == "/metrics" || path == "/health" || path == "/api/health"
 }

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/AccessLogFilter.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/AccessLogFilter.kt
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Component
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
 
+private const val ACTUATOR_PATH = "/actuator"
+private const val METRICS_PATH = "/metrics"
+private const val HEALTH_PATH = "/health"
+private const val API_HEALTH_PATH = "/api/health"
+
 @Component
 class AccessLogFilter : GlobalFilter, Ordered {
 
@@ -42,6 +47,12 @@ class AccessLogFilter : GlobalFilter, Ordered {
         }
     }
 
-    private fun isExcludedLogEndpoint(path: String): Boolean =
-        path.startsWith("/actuator/") || path == "/metrics" || path == "/health" || path == "/api/health"
+    private fun isExcludedLogEndpoint(path: String): Boolean {
+        val normalizedPath = path.removeSuffix("/")
+        return normalizedPath == ACTUATOR_PATH ||
+            normalizedPath.startsWith("$ACTUATOR_PATH/") ||
+            normalizedPath == METRICS_PATH ||
+            normalizedPath == HEALTH_PATH ||
+            normalizedPath == API_HEALTH_PATH
+    }
 }

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/AccessLogFilter.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/AccessLogFilter.kt
@@ -14,6 +14,8 @@ private const val METRICS_PATH = "/metrics"
 private const val HEALTH_PATH = "/health"
 private const val API_HEALTH_PATH = "/api/health"
 
+private val excludedExactPaths = setOf(ACTUATOR_PATH, METRICS_PATH, HEALTH_PATH, API_HEALTH_PATH)
+
 @Component
 class AccessLogFilter : GlobalFilter, Ordered {
 
@@ -49,10 +51,6 @@ class AccessLogFilter : GlobalFilter, Ordered {
 
     private fun isExcludedLogEndpoint(path: String): Boolean {
         val normalizedPath = path.removeSuffix("/")
-        return normalizedPath == ACTUATOR_PATH ||
-            normalizedPath.startsWith("$ACTUATOR_PATH/") ||
-            normalizedPath == METRICS_PATH ||
-            normalizedPath == HEALTH_PATH ||
-            normalizedPath == API_HEALTH_PATH
+        return normalizedPath in excludedExactPaths || normalizedPath.startsWith("$ACTUATOR_PATH/")
     }
 }

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/AccessLogFilter.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/AccessLogFilter.kt
@@ -6,25 +6,23 @@ import org.springframework.cloud.gateway.filter.GatewayFilterChain
 import org.springframework.cloud.gateway.filter.GlobalFilter
 import org.springframework.core.Ordered
 import org.springframework.stereotype.Component
+import org.springframework.util.AntPathMatcher
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
-
-private const val ACTUATOR_PATH = "/actuator"
-private const val METRICS_PATH = "/metrics"
-private const val HEALTH_PATH = "/health"
-private const val API_HEALTH_PATH = "/api/health"
-
-private val excludedExactPaths = setOf(ACTUATOR_PATH, METRICS_PATH, HEALTH_PATH, API_HEALTH_PATH)
+import java.util.concurrent.TimeUnit
 
 @Component
-class AccessLogFilter : GlobalFilter, Ordered {
+class AccessLogFilter(
+    private val sdkLoggingProperties: SdkLoggingProperties,
+) : GlobalFilter, Ordered {
 
     private val log = LoggerFactory.getLogger(AccessLogFilter::class.java)
+    private val pathMatcher = AntPathMatcher()
 
     override fun getOrder(): Int = 0
 
     override fun filter(exchange: ServerWebExchange, chain: GatewayFilterChain): Mono<Void> {
-        val start = System.currentTimeMillis()
+        val start = System.nanoTime()
         val request = exchange.request
         val path = request.path.value()
 
@@ -34,7 +32,7 @@ class AccessLogFilter : GlobalFilter, Ordered {
             }
 
             val status = exchange.response.statusCode?.value() ?: 0
-            val duration = System.currentTimeMillis() - start
+            val duration = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start)
             log.info(
                 "{}",
                 entries(
@@ -51,6 +49,6 @@ class AccessLogFilter : GlobalFilter, Ordered {
 
     private fun isExcludedLogEndpoint(path: String): Boolean {
         val normalizedPath = path.removeSuffix("/")
-        return normalizedPath in excludedExactPaths || normalizedPath.startsWith("$ACTUATOR_PATH/")
+        return sdkLoggingProperties.notLoggingUrls.any { pathMatcher.match(it, normalizedPath) }
     }
 }

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/SdkLoggingProperties.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/filter/SdkLoggingProperties.kt
@@ -1,0 +1,10 @@
+package com.cowork.gateway.filter
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "sdk.logging")
+class SdkLoggingProperties {
+    var notLoggingUrls: List<String> = emptyList()
+}


### PR DESCRIPTION
## 개요

모니터링 및 헬스체크 엔드포인트 요청이 서비스 접근 로그에 반복 기록되는 문제를 수정하였습니다.
Gateway, chat, authorization, Spring 공통 설정에서 `/actuator/**`, `/metrics`, `/health` 계열 경로를 요청 로그 대상에서 제외하였습니다.

## 본문

- Gateway `AccessLogFilter`에서 actuator, metrics, health, gateway health 경로를 접근 로그 제외 대상으로 확장하였습니다.
- chat 서비스의 pino HTTP auto logging에서 `/health` 요청을 추가로 무시하도록 변경하였습니다.
- authorization 서비스의 Gin 기본 로거를 skip path 설정이 가능한 로거로 교체하고 `/health`, `/metrics`를 제외하였습니다.
- Config Server 공통 Spring 설정에 SDK 로깅 제외 URL을 추가하여 Spring 기반 서비스에 동일한 제외 규칙이 적용되도록 하였습니다.

검증:
- `./gradlew test`
- `npm run build`
- `git diff --check`
