### PR TITLE
[chat] GitHub 이슈 연동 추가

### DIFF
--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -5,6 +5,7 @@ import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
 import { ChatGateway } from './chat.gateway';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
+import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { MinioService } from '../storage/minio.service';
 
 const mockMessageId = new Types.ObjectId().toString();
@@ -20,6 +21,10 @@ const mockChatService = {
 
 const mockProducer = {
     sendMessage: jest.fn(),
+};
+
+const mockGithubIssueProducer = {
+    send: jest.fn(),
 };
 
 const mockMinioService = {
@@ -43,6 +48,7 @@ describe('ChatController', () => {
                 { provide: ChatGateway, useValue: mockChatGateway },
                 { provide: ChatMessageProducer, useValue: mockProducer },
                 { provide: MinioService, useValue: mockMinioService },
+                { provide: GithubIssueProducer, useValue: mockGithubIssueProducer },
             ],
         }).compile();
 
@@ -79,7 +85,7 @@ describe('ChatController', () => {
     });
 
     describe('sendMessage', () => {
-        const dto = { teamId: 10, channelId: 1, content: '안녕하세요' };
+        const dto = { teamId: 10, content: '안녕하세요' };
 
         it('멤버십 검증 후 Kafka로 메시지를 발행한다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
@@ -88,11 +94,7 @@ describe('ChatController', () => {
             const result = await controller.sendMessage(1, dto as any, userId, userRole);
 
             expect(mockChatService.checkMembership).toHaveBeenCalledWith(1, 42);
-            expect(mockProducer.sendMessage).toHaveBeenCalledWith(
-                expect.objectContaining({ channelId: 1, content: '안녕하세요' }),
-                42,
-                'ROLE_USER',
-            );
+            expect(mockProducer.sendMessage).toHaveBeenCalledWith(1, dto, 42, 'ROLE_USER');
             expect(result).toEqual({ queued: true });
         });
 
@@ -104,6 +106,65 @@ describe('ChatController', () => {
             ).rejects.toThrow(ForbiddenException);
 
             expect(mockProducer.sendMessage).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('createGithubIssue', () => {
+        const dto = {
+            teamId: 10,
+            owner: 'my-org',
+            repo: 'backend',
+            title: '로그인 버그',
+            body: '특정 브라우저에서 재현됨',
+        };
+
+        it('멤버십 검증 후 github.issue.create 토픽으로 이벤트를 발행한다', async () => {
+            mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockGithubIssueProducer.send.mockResolvedValue(undefined);
+
+            const result = await controller.createGithubIssue(1, dto as any, userId);
+
+            expect(mockChatService.checkMembership).toHaveBeenCalledWith(1, 42);
+            expect(mockGithubIssueProducer.send).toHaveBeenCalledWith({
+                channelId: 1,
+                teamId: 10,
+                owner: 'my-org',
+                repo: 'backend',
+                title: '로그인 버그',
+                body: '특정 브라우저에서 재현됨',
+                requesterId: 42,
+            });
+            expect(result).toEqual({ queued: true });
+        });
+
+        it('body 없이도 이슈 생성 이벤트를 발행한다', async () => {
+            mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockGithubIssueProducer.send.mockResolvedValue(undefined);
+
+            await controller.createGithubIssue(1, { ...dto, body: undefined } as any, userId);
+
+            expect(mockGithubIssueProducer.send).toHaveBeenCalledWith(
+                expect.objectContaining({ body: undefined }),
+            );
+        });
+
+        it('채널 멤버가 아니면 ForbiddenException이 전파되고 이벤트를 발행하지 않는다', async () => {
+            mockChatService.checkMembership.mockRejectedValue(new ForbiddenException());
+
+            await expect(
+                controller.createGithubIssue(1, dto as any, userId),
+            ).rejects.toThrow(ForbiddenException);
+
+            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
+        });
+
+        it('producer 오류가 전파된다', async () => {
+            mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockGithubIssueProducer.send.mockRejectedValue(new Error('Kafka 연결 오류'));
+
+            await expect(
+                controller.createGithubIssue(1, dto as any, userId),
+            ).rejects.toThrow('Kafka 연결 오류');
         });
     });
 

--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -15,6 +15,7 @@ const userRole = 'ROLE_USER';
 
 const mockChatService = {
     checkMembership: jest.fn(),
+    getChannelTeamId: jest.fn(),
     getMessages: jest.fn(),
     editMessage: jest.fn(),
     deleteMessage: jest.fn(),
@@ -124,12 +125,14 @@ describe('ChatController', () => {
 
         it('프로젝트 레포 정보를 조회한 뒤 github.issue.create 토픽으로 이벤트를 발행한다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockChatService.getChannelTeamId.mockResolvedValue(10);
             mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockResolvedValue(undefined);
 
             const result = await controller.createGithubIssue(1, dto as any, userId);
 
             expect(mockChatService.checkMembership).toHaveBeenCalledWith(1, 42);
+            expect(mockChatService.getChannelTeamId).toHaveBeenCalledWith(1);
             expect(mockProjectClient.getGithubRepoInfo).toHaveBeenCalledWith(100);
             expect(mockGithubIssueProducer.send).toHaveBeenCalledWith({
                 channelId: 1,
@@ -146,6 +149,7 @@ describe('ChatController', () => {
 
         it('body 없이도 이슈 생성 이벤트를 발행한다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockChatService.getChannelTeamId.mockResolvedValue(10);
             mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockResolvedValue(undefined);
 
@@ -168,6 +172,7 @@ describe('ChatController', () => {
 
         it('프로젝트에 GitHub 레포 정보가 없으면 BadRequestException을 던진다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockChatService.getChannelTeamId.mockResolvedValue(10);
             mockProjectClient.getGithubRepoInfo.mockResolvedValue(null);
 
             await expect(
@@ -177,8 +182,21 @@ describe('ChatController', () => {
             expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
         });
 
+        it('프로젝트의 teamId가 채널 teamId와 다르면 ForbiddenException을 던진다', async () => {
+            mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockChatService.getChannelTeamId.mockResolvedValue(10);
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 99, owner: 'other-org', repo: 'backend' });
+
+            await expect(
+                controller.createGithubIssue(1, dto as any, userId),
+            ).rejects.toThrow('해당 프로젝트는 이 채널의 팀에 속하지 않습니다');
+
+            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
+        });
+
         it('producer 오류가 전파된다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockChatService.getChannelTeamId.mockResolvedValue(10);
             mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockRejectedValue(new Error('Kafka 연결 오류'));
 

--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -117,7 +117,6 @@ describe('ChatController', () => {
 
     describe('createGithubIssue', () => {
         const dto = {
-            teamId: 10,
             projectId: 100,
             title: '로그인 버그',
             body: '특정 브라우저에서 재현됨',
@@ -125,7 +124,7 @@ describe('ChatController', () => {
 
         it('프로젝트 레포 정보를 조회한 뒤 github.issue.create 토픽으로 이벤트를 발행한다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ owner: 'my-org', repo: 'backend' });
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockResolvedValue(undefined);
 
             const result = await controller.createGithubIssue(1, dto as any, userId);
@@ -147,7 +146,7 @@ describe('ChatController', () => {
 
         it('body 없이도 이슈 생성 이벤트를 발행한다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ owner: 'my-org', repo: 'backend' });
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockResolvedValue(undefined);
 
             await controller.createGithubIssue(1, { ...dto, body: undefined } as any, userId);
@@ -180,7 +179,7 @@ describe('ChatController', () => {
 
         it('producer 오류가 전파된다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ owner: 'my-org', repo: 'backend' });
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockRejectedValue(new Error('Kafka 연결 오류'));
 
             await expect(

--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -15,7 +15,7 @@ const userRole = 'ROLE_USER';
 
 const mockChatService = {
     checkMembership: jest.fn(),
-    getChannelTeamId: jest.fn(),
+    checkMembershipAndGetTeamId: jest.fn(),
     getMessages: jest.fn(),
     editMessage: jest.fn(),
     deleteMessage: jest.fn(),
@@ -124,15 +124,13 @@ describe('ChatController', () => {
         };
 
         it('프로젝트 레포 정보를 조회한 뒤 github.issue.create 토픽으로 이벤트를 발행한다', async () => {
-            mockChatService.checkMembership.mockResolvedValue(undefined);
-            mockChatService.getChannelTeamId.mockResolvedValue(10);
+            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
             mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockResolvedValue(undefined);
 
             const result = await controller.createGithubIssue(1, dto as any, userId);
 
-            expect(mockChatService.checkMembership).toHaveBeenCalledWith(1, 42);
-            expect(mockChatService.getChannelTeamId).toHaveBeenCalledWith(1);
+            expect(mockChatService.checkMembershipAndGetTeamId).toHaveBeenCalledWith(1, 42);
             expect(mockProjectClient.getGithubRepoInfo).toHaveBeenCalledWith(100);
             expect(mockGithubIssueProducer.send).toHaveBeenCalledWith({
                 channelId: 1,
@@ -148,8 +146,7 @@ describe('ChatController', () => {
         });
 
         it('body 없이도 이슈 생성 이벤트를 발행한다', async () => {
-            mockChatService.checkMembership.mockResolvedValue(undefined);
-            mockChatService.getChannelTeamId.mockResolvedValue(10);
+            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
             mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockResolvedValue(undefined);
 
@@ -161,7 +158,7 @@ describe('ChatController', () => {
         });
 
         it('채널 멤버가 아니면 ForbiddenException이 전파되고 이벤트를 발행하지 않는다', async () => {
-            mockChatService.checkMembership.mockRejectedValue(new ForbiddenException());
+            mockChatService.checkMembershipAndGetTeamId.mockRejectedValue(new ForbiddenException());
 
             await expect(
                 controller.createGithubIssue(1, dto as any, userId),
@@ -171,8 +168,7 @@ describe('ChatController', () => {
         });
 
         it('프로젝트에 GitHub 레포 정보가 없으면 BadRequestException을 던진다', async () => {
-            mockChatService.checkMembership.mockResolvedValue(undefined);
-            mockChatService.getChannelTeamId.mockResolvedValue(10);
+            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
             mockProjectClient.getGithubRepoInfo.mockResolvedValue(null);
 
             await expect(
@@ -183,8 +179,7 @@ describe('ChatController', () => {
         });
 
         it('프로젝트의 teamId가 채널 teamId와 다르면 ForbiddenException을 던진다', async () => {
-            mockChatService.checkMembership.mockResolvedValue(undefined);
-            mockChatService.getChannelTeamId.mockResolvedValue(10);
+            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
             mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 99, owner: 'other-org', repo: 'backend' });
 
             await expect(
@@ -195,8 +190,7 @@ describe('ChatController', () => {
         });
 
         it('producer 오류가 전파된다', async () => {
-            mockChatService.checkMembership.mockResolvedValue(undefined);
-            mockChatService.getChannelTeamId.mockResolvedValue(10);
+            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
             mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockRejectedValue(new Error('Kafka 연결 오류'));
 

--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -6,6 +6,7 @@ import { ChatService } from './chat.service';
 import { ChatGateway } from './chat.gateway';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
+import { ProjectClient } from './service/project.client';
 import { MinioService } from '../storage/minio.service';
 
 const mockMessageId = new Types.ObjectId().toString();
@@ -25,6 +26,10 @@ const mockProducer = {
 
 const mockGithubIssueProducer = {
     send: jest.fn(),
+};
+
+const mockProjectClient = {
+    getGithubRepoInfo: jest.fn(),
 };
 
 const mockMinioService = {
@@ -49,6 +54,7 @@ describe('ChatController', () => {
                 { provide: ChatMessageProducer, useValue: mockProducer },
                 { provide: MinioService, useValue: mockMinioService },
                 { provide: GithubIssueProducer, useValue: mockGithubIssueProducer },
+                { provide: ProjectClient, useValue: mockProjectClient },
             ],
         }).compile();
 
@@ -112,22 +118,24 @@ describe('ChatController', () => {
     describe('createGithubIssue', () => {
         const dto = {
             teamId: 10,
-            owner: 'my-org',
-            repo: 'backend',
+            projectId: 100,
             title: '로그인 버그',
             body: '특정 브라우저에서 재현됨',
         };
 
-        it('멤버십 검증 후 github.issue.create 토픽으로 이벤트를 발행한다', async () => {
+        it('프로젝트 레포 정보를 조회한 뒤 github.issue.create 토픽으로 이벤트를 발행한다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockResolvedValue(undefined);
 
             const result = await controller.createGithubIssue(1, dto as any, userId);
 
             expect(mockChatService.checkMembership).toHaveBeenCalledWith(1, 42);
+            expect(mockProjectClient.getGithubRepoInfo).toHaveBeenCalledWith(100);
             expect(mockGithubIssueProducer.send).toHaveBeenCalledWith({
                 channelId: 1,
                 teamId: 10,
+                projectId: 100,
                 owner: 'my-org',
                 repo: 'backend',
                 title: '로그인 버그',
@@ -139,6 +147,7 @@ describe('ChatController', () => {
 
         it('body 없이도 이슈 생성 이벤트를 발행한다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockResolvedValue(undefined);
 
             await controller.createGithubIssue(1, { ...dto, body: undefined } as any, userId);
@@ -158,8 +167,20 @@ describe('ChatController', () => {
             expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
         });
 
+        it('프로젝트에 GitHub 레포 정보가 없으면 BadRequestException을 던진다', async () => {
+            mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue(null);
+
+            await expect(
+                controller.createGithubIssue(1, dto as any, userId),
+            ).rejects.toThrow('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
+
+            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
+        });
+
         it('producer 오류가 전파된다', async () => {
             mockChatService.checkMembership.mockResolvedValue(undefined);
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ owner: 'my-org', repo: 'backend' });
             mockGithubIssueProducer.send.mockRejectedValue(new Error('Kafka 연결 오류'));
 
             await expect(

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -11,6 +11,7 @@ import {
     HttpStatus,
     ParseIntPipe,
     BadRequestException,
+    ForbiddenException,
 } from '@nestjs/common';
 import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ChatService } from './chat.service';
@@ -123,9 +124,15 @@ export class ChatController {
         @UserId() userId: number,
     ): Promise<CreateGithubIssueResponseDto> {
         await this.chatService.checkMembership(channelId, userId);
-        const repoInfo = await this.projectClient.getGithubRepoInfo(dto.projectId);
+        const [channelTeamId, repoInfo] = await Promise.all([
+            this.chatService.getChannelTeamId(channelId),
+            this.projectClient.getGithubRepoInfo(dto.projectId),
+        ]);
         if (!repoInfo) {
             throw new BadRequestException('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
+        }
+        if (channelTeamId !== repoInfo.teamId) {
+            throw new ForbiddenException('해당 프로젝트는 이 채널의 팀에 속하지 않습니다');
         }
 
         await this.githubIssueProducer.send({

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -28,7 +28,9 @@ import {
     MessageResponseDto,
     SendMessageResponseDto,
 } from './dto/message-response.dto';
+import { CreateGithubIssueDto, CreateGithubIssueResponseDto } from './dto/create-github-issue.dto';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
+import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { MessageDocument } from './schema/message.schema';
 import { UserId, UserRole } from '../common/decorator/user.decorator';
 import { MinioService } from '../storage/minio.service';
@@ -43,6 +45,7 @@ export class ChatController {
         private readonly chatGateway: ChatGateway,
         private readonly producer: ChatMessageProducer,
         private readonly minioService: MinioService,
+        private readonly githubIssueProducer: GithubIssueProducer,
     ) {}
 
     @Post('files/presigned-url')
@@ -103,7 +106,29 @@ export class ChatController {
     ): Promise<SendMessageResponseDto> {
         await this.chatService.checkMembership(channelId, userId);
         await this.producer.sendMessage(channelId, dto, userId, userRole);
+        return { queued: true };
+    }
 
+    @Post('github/issues')
+    @HttpCode(HttpStatus.CREATED)
+    @ApiOperation({ summary: 'GitHub 이슈 생성 (클라이언트 슬래시 커맨드 → Kafka 비동기)' })
+    @ApiResponse({ status: 201, type: CreateGithubIssueResponseDto })
+    @ApiResponse({ status: 403, description: '채널 멤버 아님' })
+    async createGithubIssue(
+        @Param('channelId', ParseIntPipe) channelId: number,
+        @Body() dto: CreateGithubIssueDto,
+        @UserId() userId: number,
+    ): Promise<CreateGithubIssueResponseDto> {
+        await this.chatService.checkMembership(channelId, userId);
+        await this.githubIssueProducer.send({
+            channelId,
+            teamId: dto.teamId,
+            owner: dto.owner,
+            repo: dto.repo,
+            title: dto.title,
+            body: dto.body,
+            requesterId: userId,
+        });
         return { queued: true };
     }
 

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -123,10 +123,8 @@ export class ChatController {
         @Body() dto: CreateGithubIssueDto,
         @UserId() userId: number,
     ): Promise<CreateGithubIssueResponseDto> {
-        const [channelTeamId, repoInfo] = await Promise.all([
-            this.chatService.checkMembershipAndGetTeamId(channelId, userId),
-            this.projectClient.getGithubRepoInfo(dto.projectId),
-        ]);
+        const channelTeamId = await this.chatService.checkMembershipAndGetTeamId(channelId, userId);
+        const repoInfo = await this.projectClient.getGithubRepoInfo(dto.projectId);
         if (!repoInfo) {
             throw new BadRequestException('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
         }

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -123,9 +123,8 @@ export class ChatController {
         @Body() dto: CreateGithubIssueDto,
         @UserId() userId: number,
     ): Promise<CreateGithubIssueResponseDto> {
-        await this.chatService.checkMembership(channelId, userId);
         const [channelTeamId, repoInfo] = await Promise.all([
-            this.chatService.getChannelTeamId(channelId),
+            this.chatService.checkMembershipAndGetTeamId(channelId, userId),
             this.projectClient.getGithubRepoInfo(dto.projectId),
         ]);
         if (!repoInfo) {

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -10,6 +10,7 @@ import {
     HttpCode,
     HttpStatus,
     ParseIntPipe,
+    BadRequestException,
 } from '@nestjs/common';
 import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ChatService } from './chat.service';
@@ -31,6 +32,7 @@ import {
 import { CreateGithubIssueDto, CreateGithubIssueResponseDto } from './dto/create-github-issue.dto';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
+import { ProjectClient } from './service/project.client';
 import { MessageDocument } from './schema/message.schema';
 import { UserId, UserRole } from '../common/decorator/user.decorator';
 import { MinioService } from '../storage/minio.service';
@@ -46,6 +48,7 @@ export class ChatController {
         private readonly producer: ChatMessageProducer,
         private readonly minioService: MinioService,
         private readonly githubIssueProducer: GithubIssueProducer,
+        private readonly projectClient: ProjectClient,
     ) {}
 
     @Post('files/presigned-url')
@@ -120,11 +123,17 @@ export class ChatController {
         @UserId() userId: number,
     ): Promise<CreateGithubIssueResponseDto> {
         await this.chatService.checkMembership(channelId, userId);
+        const repoInfo = await this.projectClient.getGithubRepoInfo(dto.projectId);
+        if (!repoInfo) {
+            throw new BadRequestException('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
+        }
+
         await this.githubIssueProducer.send({
             channelId,
             teamId: dto.teamId,
-            owner: dto.owner,
-            repo: dto.repo,
+            projectId: dto.projectId,
+            owner: repoInfo.owner,
+            repo: repoInfo.repo,
             title: dto.title,
             body: dto.body,
             requesterId: userId,

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -130,7 +130,7 @@ export class ChatController {
 
         await this.githubIssueProducer.send({
             channelId,
-            teamId: dto.teamId,
+            teamId: repoInfo.teamId,
             projectId: dto.projectId,
             owner: repoInfo.owner,
             repo: repoInfo.repo,

--- a/cowork-chat/src/chat/chat.gateway.spec.ts
+++ b/cowork-chat/src/chat/chat.gateway.spec.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { ChatGateway } from './chat.gateway';
 import { ChatService } from './chat.service';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
+import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
 
 const mockConfigService = {
     get: jest.fn().mockReturnValue(''),
@@ -26,6 +27,10 @@ const mockConsumer = {
     setSocketServer: jest.fn(),
 };
 
+const mockGithubIssueResultConsumer = {
+    setSocketServer: jest.fn(),
+};
+
 describe('ChatGateway', () => {
     let gateway: ChatGateway;
 
@@ -35,6 +40,7 @@ describe('ChatGateway', () => {
                 ChatGateway,
                 { provide: ChatService, useValue: mockChatService },
                 { provide: ChatMessageConsumer, useValue: mockConsumer },
+                { provide: GithubIssueResultConsumer, useValue: mockGithubIssueResultConsumer },
                 { provide: ConfigService, useValue: mockConfigService },
             ],
         }).compile();

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -13,6 +13,7 @@ import { ConfigService } from '@nestjs/config';
 import { Server, Socket } from 'socket.io';
 import { ChatService } from './chat.service';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
+import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
 import { RequestContextUtil } from '../common/util/request-context.util';
 import { JoinChannelDto } from './dto/join-channel.dto';
 
@@ -33,11 +34,13 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     constructor(
         private readonly chatService: ChatService,
         private readonly consumer: ChatMessageConsumer,
+        private readonly githubIssueResultConsumer: GithubIssueResultConsumer,
         private readonly configService: ConfigService,
     ) {}
 
     afterInit(server: Server) {
         this.consumer.setSocketServer(server);
+        this.githubIssueResultConsumer.setSocketServer(server);
     }
 
     async handleConnection(client: Socket) {

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -11,6 +11,8 @@ import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { NotificationTriggerProducer } from './kafka/notification-trigger.producer';
 import { NotificationOutboxPoller } from './kafka/notification-outbox.poller';
+import { GithubIssueProducer } from './kafka/github-issue.producer';
+import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
 import { Message, MessageSchema } from './schema/message.schema';
 import { ChannelMember, ChannelMemberSchema } from './schema/channel-member.schema';
 import { MembershipModule } from '../membership/membership.module';
@@ -82,6 +84,8 @@ function createLogStream() {
         ChatMessageConsumer,
         NotificationTriggerProducer,
         NotificationOutboxPoller,
+        GithubIssueProducer,
+        GithubIssueResultConsumer,
     ],
 })
 export class ChatModule {}

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -13,6 +13,7 @@ import { NotificationTriggerProducer } from './kafka/notification-trigger.produc
 import { NotificationOutboxPoller } from './kafka/notification-outbox.poller';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
+import { ProjectClient } from './service/project.client';
 import { Message, MessageSchema } from './schema/message.schema';
 import { ChannelMember, ChannelMemberSchema } from './schema/channel-member.schema';
 import { MembershipModule } from '../membership/membership.module';
@@ -86,6 +87,7 @@ function createLogStream() {
         NotificationOutboxPoller,
         GithubIssueProducer,
         GithubIssueResultConsumer,
+        ProjectClient,
     ],
 })
 export class ChatModule {}

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -25,6 +25,7 @@ const mockMessageModel = {
     aggregate: mockAggregate,
     findById: jest.fn(),
     deleteOne: jest.fn(),
+    create: jest.fn(),
     collection: { name: 'messages' },
 };
 
@@ -182,6 +183,27 @@ describe('ChatService', () => {
             await expect(
                 service.deleteMessage(mockMessageId, 42, 'ROLE_ADMIN'),
             ).resolves.toBeDefined();
+        });
+    });
+
+    describe('saveSystemMessage', () => {
+        it('시스템 메시지는 clientMessageId 없이 저장한다', async () => {
+            mockMessageModel.create.mockResolvedValue({ toObject: jest.fn() });
+
+            await service.saveSystemMessage(10, 1, '이슈가 생성됐어요', 100);
+
+            expect(mockMessageModel.create).toHaveBeenCalledWith({
+                teamId: 10,
+                projectId: 100,
+                channelId: 1,
+                authorId: 0,
+                content: '이슈가 생성됐어요',
+                type: 'SYSTEM',
+                attachments: [],
+                mentions: [],
+                clientMessageId: undefined,
+                notificationStatus: 'SENT',
+            });
         });
     });
 });

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -6,6 +6,8 @@ import { ChannelMember } from './schema/channel-member.schema';
 import { EditMessageDto } from './dto/edit-message.dto';
 import { UserRole } from '../common/enum/user-role.enum';
 
+const SYSTEM_AUTHOR_ID = 0;
+
 @Injectable()
 export class ChatService {
     constructor(
@@ -21,6 +23,12 @@ export class ChatService {
     async checkMembership(channelId: number, userId: number): Promise<void> {
         const member = await this.memberModel.exists({ channelId, userId });
         if (!member) throw new ForbiddenException('채널 접근 권한이 없습니다');
+    }
+
+    async checkMembershipAndGetTeamId(channelId: number, userId: number): Promise<number> {
+        const member = await this.memberModel.findOne({ channelId, userId }, { teamId: 1 });
+        if (!member) throw new ForbiddenException('채널 접근 권한이 없습니다');
+        return member.teamId;
     }
 
     async getChannelTeamId(channelId: number): Promise<number> {
@@ -102,7 +110,7 @@ export class ChatService {
             teamId,
             projectId,
             channelId,
-            authorId: 0,
+            authorId: SYSTEM_AUTHOR_ID,
             content,
             type: 'SYSTEM',
             attachments: [],

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -31,12 +31,6 @@ export class ChatService {
         return member.teamId;
     }
 
-    async getChannelTeamId(channelId: number): Promise<number> {
-        const member = await this.memberModel.findOne({ channelId });
-        if (!member) throw new ForbiddenException('채널 접근 권한이 없습니다');
-        return member.teamId;
-    }
-
     async getMessages(channelId: number, before?: string) {
         const query: Record<string, unknown> = { channelId };
         if (before) {

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -23,6 +23,12 @@ export class ChatService {
         if (!member) throw new ForbiddenException('채널 접근 권한이 없습니다');
     }
 
+    async getChannelTeamId(channelId: number): Promise<number> {
+        const member = await this.memberModel.findOne({ channelId });
+        if (!member) throw new ForbiddenException('채널 접근 권한이 없습니다');
+        return member.teamId;
+    }
+
     async getMessages(channelId: number, before?: string) {
         const query: Record<string, unknown> = { channelId };
         if (before) {
@@ -101,6 +107,7 @@ export class ChatService {
             type: 'SYSTEM',
             attachments: [],
             mentions: [],
+            clientMessageId: undefined,
             notificationStatus: 'SENT',
         });
     }

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -86,6 +86,25 @@ export class ChatService {
         return { channelId: message.channelId, messageId };
     }
 
+    async saveSystemMessage(
+        teamId: number,
+        channelId: number,
+        content: string,
+        projectId: number | null = null,
+    ) {
+        return this.messageModel.create({
+            teamId,
+            projectId,
+            channelId,
+            authorId: 0,
+            content,
+            type: 'SYSTEM',
+            attachments: [],
+            mentions: [],
+            notificationStatus: 'SENT',
+        });
+    }
+
     private isAdmin(role: string): boolean {
         return role === UserRole.ADMIN;
     }

--- a/cowork-chat/src/chat/dto/create-github-issue.dto.ts
+++ b/cowork-chat/src/chat/dto/create-github-issue.dto.ts
@@ -1,0 +1,34 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength } from 'class-validator';
+
+export class CreateGithubIssueDto {
+    @ApiProperty({ description: '팀 ID', example: 1 })
+    @IsNumber()
+    teamId!: number;
+
+    @ApiProperty({ description: 'GitHub 레포 소유자 (org 또는 user)', example: 'my-org' })
+    @IsString()
+    @IsNotEmpty()
+    owner!: string;
+
+    @ApiProperty({ description: 'GitHub 레포 이름', example: 'backend' })
+    @IsString()
+    @IsNotEmpty()
+    repo!: string;
+
+    @ApiProperty({ description: '이슈 제목', example: '로그인 버그' })
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(256)
+    title!: string;
+
+    @ApiPropertyOptional({ description: '이슈 본문', example: '특정 브라우저에서 로그인이 안 됨' })
+    @IsString()
+    @IsOptional()
+    body?: string;
+}
+
+export class CreateGithubIssueResponseDto {
+    @ApiProperty({ description: '큐 등록 여부' })
+    queued!: boolean;
+}

--- a/cowork-chat/src/chat/dto/create-github-issue.dto.ts
+++ b/cowork-chat/src/chat/dto/create-github-issue.dto.ts
@@ -6,15 +6,9 @@ export class CreateGithubIssueDto {
     @IsNumber()
     teamId!: number;
 
-    @ApiProperty({ description: 'GitHub 레포 소유자 (org 또는 user)', example: 'my-org' })
-    @IsString()
-    @IsNotEmpty()
-    owner!: string;
-
-    @ApiProperty({ description: 'GitHub 레포 이름', example: 'backend' })
-    @IsString()
-    @IsNotEmpty()
-    repo!: string;
+    @ApiProperty({ description: '프로젝트 ID', example: 100 })
+    @IsNumber()
+    projectId!: number;
 
     @ApiProperty({ description: '이슈 제목', example: '로그인 버그' })
     @IsString()

--- a/cowork-chat/src/chat/dto/create-github-issue.dto.ts
+++ b/cowork-chat/src/chat/dto/create-github-issue.dto.ts
@@ -2,10 +2,6 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsNotEmpty, IsNumber, IsOptional, IsString, MaxLength } from 'class-validator';
 
 export class CreateGithubIssueDto {
-    @ApiProperty({ description: '팀 ID', example: 1 })
-    @IsNumber()
-    teamId!: number;
-
     @ApiProperty({ description: '프로젝트 ID', example: 100 })
     @IsNumber()
     projectId!: number;

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.spec.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.spec.ts
@@ -1,0 +1,41 @@
+import { ChatMessageConsumer } from './chat-message.consumer';
+
+const mockMessageModel = {
+    create: jest.fn(),
+};
+
+const mockConfigService = {
+    get: jest.fn().mockReturnValue('localhost:9092'),
+};
+
+describe('ChatMessageConsumer', () => {
+    let consumer: ChatMessageConsumer;
+
+    beforeEach(() => {
+        consumer = new ChatMessageConsumer(mockMessageModel as any, mockConfigService as any);
+        jest.clearAllMocks();
+    });
+
+    it('clientMessageId가 없으면 null 대신 undefined로 저장한다', async () => {
+        mockMessageModel.create.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
+
+        await (consumer as any).handleMessageEvent({
+            teamId: 10,
+            projectId: null,
+            channelId: 1,
+            authorId: 42,
+            authorRole: 'MEMBER',
+            content: 'hello',
+            type: 'TEXT',
+            attachments: [],
+            clientMessageId: undefined,
+            occurredAt: new Date().toISOString(),
+        });
+
+        expect(mockMessageModel.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                clientMessageId: undefined,
+            }),
+        );
+    });
+});

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.ts
@@ -75,7 +75,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
                 parentMessageId: (event.parentMessageId && Types.ObjectId.isValid(event.parentMessageId))
                     ? new Types.ObjectId(event.parentMessageId)
                     : null,
-                clientMessageId: event.clientMessageId ?? null,
+                clientMessageId: event.clientMessageId,
                 mentions,
                 notificationStatus: 'PENDING',
             });

--- a/cowork-chat/src/chat/kafka/event/github-issue.event.ts
+++ b/cowork-chat/src/chat/kafka/event/github-issue.event.ts
@@ -1,0 +1,18 @@
+export interface GithubIssueCreateEvent {
+    channelId: number;
+    teamId: number;
+    owner: string;
+    repo: string;
+    title: string;
+    body?: string;
+    requesterId: number;
+}
+
+export interface GithubIssueResultEvent {
+    channelId: number;
+    teamId: number;
+    success: boolean;
+    issueUrl?: string;
+    issueNumber?: number;
+    error?: string;
+}

--- a/cowork-chat/src/chat/kafka/event/github-issue.event.ts
+++ b/cowork-chat/src/chat/kafka/event/github-issue.event.ts
@@ -1,6 +1,7 @@
 export interface GithubIssueCreateEvent {
     channelId: number;
     teamId: number;
+    projectId: number;
     owner: string;
     repo: string;
     title: string;
@@ -11,6 +12,7 @@ export interface GithubIssueCreateEvent {
 export interface GithubIssueResultEvent {
     channelId: number;
     teamId: number;
+    projectId?: number;
     success: boolean;
     issueUrl?: string;
     issueNumber?: number;

--- a/cowork-chat/src/chat/kafka/github-issue-result.consumer.spec.ts
+++ b/cowork-chat/src/chat/kafka/github-issue-result.consumer.spec.ts
@@ -1,0 +1,132 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getModelToken } from '@nestjs/mongoose';
+import { Server } from 'socket.io';
+import { GithubIssueResultConsumer } from './github-issue-result.consumer';
+import { Message } from '../schema/message.schema';
+import { GithubIssueResultEvent } from './event/github-issue.event';
+
+const mockToObject = jest.fn();
+const mockMessageCreate = jest.fn();
+
+const mockMessageModel = {
+    create: mockMessageCreate,
+};
+
+const mockEmit = jest.fn();
+const mockTo = jest.fn(() => ({ emit: mockEmit }));
+const mockIo = { to: mockTo } as unknown as Server;
+
+describe('GithubIssueResultConsumer', () => {
+    let consumer: GithubIssueResultConsumer;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                GithubIssueResultConsumer,
+                {
+                    provide: getModelToken(Message.name),
+                    useValue: mockMessageModel,
+                },
+                {
+                    provide: ConfigService,
+                    useValue: { get: jest.fn().mockReturnValue('localhost:9092') },
+                },
+            ],
+        }).compile();
+
+        consumer = module.get<GithubIssueResultConsumer>(GithubIssueResultConsumer);
+        consumer.setSocketServer(mockIo);
+        jest.clearAllMocks();
+    });
+
+    const callHandleResultEvent = (event: GithubIssueResultEvent) =>
+        (consumer as any).handleResultEvent(event);
+
+    describe('이슈 생성 성공', () => {
+        it('성공 SYSTEM 메시지를 저장하고 WebSocket으로 브로드캐스트한다', async () => {
+            const savedDoc = { toObject: mockToObject.mockReturnValue({ content: '성공' }) };
+            mockMessageCreate.mockResolvedValue(savedDoc);
+
+            const event: GithubIssueResultEvent = {
+                channelId: 5,
+                teamId: 1,
+                success: true,
+                issueUrl: 'https://github.com/my-org/backend/issues/42',
+            };
+
+            await callHandleResultEvent(event);
+
+            expect(mockMessageCreate).toHaveBeenCalledWith({
+                teamId: 1,
+                projectId: null,
+                channelId: 5,
+                authorId: 0,
+                content: '✅ 이슈가 생성됐어요: https://github.com/my-org/backend/issues/42',
+                type: 'SYSTEM',
+                attachments: [],
+                mentions: [],
+                notificationStatus: 'SENT',
+            });
+            expect(mockTo).toHaveBeenCalledWith('chat:5');
+            expect(mockEmit).toHaveBeenCalledWith('message', expect.anything());
+        });
+    });
+
+    describe('이슈 생성 실패', () => {
+        it('실패 SYSTEM 메시지를 저장하고 WebSocket으로 브로드캐스트한다', async () => {
+            const savedDoc = { toObject: mockToObject.mockReturnValue({ content: '실패' }) };
+            mockMessageCreate.mockResolvedValue(savedDoc);
+
+            const event: GithubIssueResultEvent = {
+                channelId: 5,
+                teamId: 1,
+                success: false,
+                error: '레포지토리를 찾을 수 없어요',
+            };
+
+            await callHandleResultEvent(event);
+
+            expect(mockMessageCreate).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: '❌ 이슈 생성 실패: 레포지토리를 찾을 수 없어요',
+                    type: 'SYSTEM',
+                }),
+            );
+            expect(mockTo).toHaveBeenCalledWith('chat:5');
+        });
+
+        it('error 필드가 없으면 기본 오류 메시지를 사용한다', async () => {
+            mockMessageCreate.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
+
+            await callHandleResultEvent({ channelId: 5, teamId: 1, success: false });
+
+            expect(mockMessageCreate).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    content: '❌ 이슈 생성 실패: 알 수 없는 오류',
+                }),
+            );
+        });
+    });
+
+    describe('WebSocket 서버 미설정', () => {
+        it('io가 없어도 메시지 저장은 정상 처리된다', async () => {
+            const consumerWithoutIo = new (GithubIssueResultConsumer as any)(
+                mockMessageModel,
+                { get: jest.fn().mockReturnValue('localhost:9092') },
+            );
+            mockMessageCreate.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
+
+            await expect(
+                (consumerWithoutIo as any).handleResultEvent({
+                    channelId: 5,
+                    teamId: 1,
+                    success: true,
+                    issueUrl: 'https://github.com/my-org/backend/issues/1',
+                }),
+            ).resolves.not.toThrow();
+
+            expect(mockMessageCreate).toHaveBeenCalled();
+        });
+    });
+});

--- a/cowork-chat/src/chat/kafka/github-issue-result.consumer.spec.ts
+++ b/cowork-chat/src/chat/kafka/github-issue-result.consumer.spec.ts
@@ -1,16 +1,15 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
-import { getModelToken } from '@nestjs/mongoose';
 import { Server } from 'socket.io';
 import { GithubIssueResultConsumer } from './github-issue-result.consumer';
-import { Message } from '../schema/message.schema';
+import { ChatService } from '../chat.service';
 import { GithubIssueResultEvent } from './event/github-issue.event';
 
 const mockToObject = jest.fn();
-const mockMessageCreate = jest.fn();
+const mockSaveSystemMessage = jest.fn();
 
-const mockMessageModel = {
-    create: mockMessageCreate,
+const mockChatService = {
+    saveSystemMessage: mockSaveSystemMessage,
 };
 
 const mockEmit = jest.fn();
@@ -25,8 +24,8 @@ describe('GithubIssueResultConsumer', () => {
             providers: [
                 GithubIssueResultConsumer,
                 {
-                    provide: getModelToken(Message.name),
-                    useValue: mockMessageModel,
+                    provide: ChatService,
+                    useValue: mockChatService,
                 },
                 {
                     provide: ConfigService,
@@ -46,28 +45,24 @@ describe('GithubIssueResultConsumer', () => {
     describe('이슈 생성 성공', () => {
         it('성공 SYSTEM 메시지를 저장하고 WebSocket으로 브로드캐스트한다', async () => {
             const savedDoc = { toObject: mockToObject.mockReturnValue({ content: '성공' }) };
-            mockMessageCreate.mockResolvedValue(savedDoc);
+            mockSaveSystemMessage.mockResolvedValue(savedDoc);
 
             const event: GithubIssueResultEvent = {
                 channelId: 5,
                 teamId: 1,
+                projectId: 100,
                 success: true,
                 issueUrl: 'https://github.com/my-org/backend/issues/42',
             };
 
             await callHandleResultEvent(event);
 
-            expect(mockMessageCreate).toHaveBeenCalledWith({
-                teamId: 1,
-                projectId: null,
-                channelId: 5,
-                authorId: 0,
-                content: '✅ 이슈가 생성됐어요: https://github.com/my-org/backend/issues/42',
-                type: 'SYSTEM',
-                attachments: [],
-                mentions: [],
-                notificationStatus: 'SENT',
-            });
+            expect(mockSaveSystemMessage).toHaveBeenCalledWith(
+                1,
+                5,
+                '✅ 이슈가 생성됐어요: https://github.com/my-org/backend/issues/42',
+                100,
+            );
             expect(mockTo).toHaveBeenCalledWith('chat:5');
             expect(mockEmit).toHaveBeenCalledWith('message', expect.anything());
         });
@@ -76,7 +71,7 @@ describe('GithubIssueResultConsumer', () => {
     describe('이슈 생성 실패', () => {
         it('실패 SYSTEM 메시지를 저장하고 WebSocket으로 브로드캐스트한다', async () => {
             const savedDoc = { toObject: mockToObject.mockReturnValue({ content: '실패' }) };
-            mockMessageCreate.mockResolvedValue(savedDoc);
+            mockSaveSystemMessage.mockResolvedValue(savedDoc);
 
             const event: GithubIssueResultEvent = {
                 channelId: 5,
@@ -87,35 +82,36 @@ describe('GithubIssueResultConsumer', () => {
 
             await callHandleResultEvent(event);
 
-            expect(mockMessageCreate).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    content: '❌ 이슈 생성 실패: 레포지토리를 찾을 수 없어요',
-                    type: 'SYSTEM',
-                }),
+            expect(mockSaveSystemMessage).toHaveBeenCalledWith(
+                1,
+                5,
+                '❌ 이슈 생성 실패: 레포지토리를 찾을 수 없어요',
+                null,
             );
             expect(mockTo).toHaveBeenCalledWith('chat:5');
         });
 
         it('error 필드가 없으면 기본 오류 메시지를 사용한다', async () => {
-            mockMessageCreate.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
+            mockSaveSystemMessage.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
 
             await callHandleResultEvent({ channelId: 5, teamId: 1, success: false });
 
-            expect(mockMessageCreate).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    content: '❌ 이슈 생성 실패: 알 수 없는 오류',
-                }),
+            expect(mockSaveSystemMessage).toHaveBeenCalledWith(
+                1,
+                5,
+                '❌ 이슈 생성 실패: 알 수 없는 오류',
+                null,
             );
         });
     });
 
     describe('WebSocket 서버 미설정', () => {
         it('io가 없어도 메시지 저장은 정상 처리된다', async () => {
-            const consumerWithoutIo = new (GithubIssueResultConsumer as any)(
-                mockMessageModel,
-                { get: jest.fn().mockReturnValue('localhost:9092') },
+            const consumerWithoutIo = new GithubIssueResultConsumer(
+                mockChatService as any,
+                { get: jest.fn().mockReturnValue('localhost:9092') } as any,
             );
-            mockMessageCreate.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
+            mockSaveSystemMessage.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
 
             await expect(
                 (consumerWithoutIo as any).handleResultEvent({
@@ -126,7 +122,7 @@ describe('GithubIssueResultConsumer', () => {
                 }),
             ).resolves.not.toThrow();
 
-            expect(mockMessageCreate).toHaveBeenCalled();
+            expect(mockSaveSystemMessage).toHaveBeenCalled();
         });
     });
 });

--- a/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
+++ b/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
@@ -56,6 +56,7 @@ export class GithubIssueResultConsumer implements OnModuleInit, OnModuleDestroy 
             event.teamId,
             event.channelId,
             content,
+            event.projectId ?? null,
         );
 
         this.notifyClient(event.channelId, saved.toObject());

--- a/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
+++ b/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
@@ -1,0 +1,72 @@
+import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { InjectModel } from '@nestjs/mongoose';
+import { Kafka, Consumer } from 'kafkajs';
+import { Model } from 'mongoose';
+import { Server } from 'socket.io';
+import { Message } from '../schema/message.schema';
+import { GithubIssueResultEvent } from './event/github-issue.event';
+
+@Injectable()
+export class GithubIssueResultConsumer implements OnModuleInit, OnModuleDestroy {
+    private readonly logger = new Logger(GithubIssueResultConsumer.name);
+    private consumer!: Consumer;
+    private io?: Server;
+
+    constructor(
+        @InjectModel(Message.name) private readonly messageModel: Model<Message>,
+        private readonly configService: ConfigService,
+    ) {}
+
+    setSocketServer(io: Server) {
+        this.io = io;
+    }
+
+    async onModuleInit() {
+        const kafka = new Kafka({
+            clientId: 'cowork-chat-github-result',
+            brokers: [this.configService.get<string>('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')],
+        });
+        this.consumer = kafka.consumer({ groupId: 'cowork-chat-github-result' });
+        await this.consumer.connect();
+        await this.consumer.subscribe({ topic: 'github.issue.result', fromBeginning: false });
+
+        await this.consumer.run({
+            eachMessage: async ({ message }) => {
+                if (!message.value) return;
+                try {
+                    const event: GithubIssueResultEvent = JSON.parse(message.value.toString());
+                    await this.handleResultEvent(event);
+                } catch (err) {
+                    this.logger.error('이슈 결과 처리 중 오류 발생', err);
+                }
+            },
+        });
+
+        this.logger.log('Kafka consumer started: github.issue.result');
+    }
+
+    async onModuleDestroy() {
+        await this.consumer.disconnect();
+    }
+
+    private async handleResultEvent(event: GithubIssueResultEvent): Promise<void> {
+        const content = event.success
+            ? `✅ 이슈가 생성됐어요: ${event.issueUrl}`
+            : `❌ 이슈 생성 실패: ${event.error ?? '알 수 없는 오류'}`;
+
+        const saved = await this.messageModel.create({
+            teamId: event.teamId,
+            projectId: null,
+            channelId: event.channelId,
+            authorId: 0,
+            content,
+            type: 'SYSTEM',
+            attachments: [],
+            mentions: [],
+            notificationStatus: 'SENT',
+        });
+
+        this.io?.to(`chat:${event.channelId}`).emit('message', saved.toObject());
+    }
+}

--- a/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
+++ b/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
@@ -1,10 +1,8 @@
 import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { InjectModel } from '@nestjs/mongoose';
 import { Kafka, Consumer } from 'kafkajs';
-import { Model } from 'mongoose';
 import { Server } from 'socket.io';
-import { Message } from '../schema/message.schema';
+import { ChatService } from '../chat.service';
 import { GithubIssueResultEvent } from './event/github-issue.event';
 
 @Injectable()
@@ -14,7 +12,7 @@ export class GithubIssueResultConsumer implements OnModuleInit, OnModuleDestroy 
     private io?: Server;
 
     constructor(
-        @InjectModel(Message.name) private readonly messageModel: Model<Message>,
+        private readonly chatService: ChatService,
         private readonly configService: ConfigService,
     ) {}
 
@@ -39,6 +37,7 @@ export class GithubIssueResultConsumer implements OnModuleInit, OnModuleDestroy 
                     await this.handleResultEvent(event);
                 } catch (err) {
                     this.logger.error('이슈 결과 처리 중 오류 발생', err);
+                    if (!(err instanceof SyntaxError)) throw err;
                 }
             },
         });
@@ -51,22 +50,25 @@ export class GithubIssueResultConsumer implements OnModuleInit, OnModuleDestroy 
     }
 
     private async handleResultEvent(event: GithubIssueResultEvent): Promise<void> {
-        const content = event.success
-            ? `✅ 이슈가 생성됐어요: ${event.issueUrl}`
-            : `❌ 이슈 생성 실패: ${event.error ?? '알 수 없는 오류'}`;
+        const content = this.formatIssueResultMessage(event);
 
-        const saved = await this.messageModel.create({
-            teamId: event.teamId,
-            projectId: null,
-            channelId: event.channelId,
-            authorId: 0,
+        const saved = await this.chatService.saveSystemMessage(
+            event.teamId,
+            event.channelId,
             content,
-            type: 'SYSTEM',
-            attachments: [],
-            mentions: [],
-            notificationStatus: 'SENT',
-        });
+        );
 
-        this.io?.to(`chat:${event.channelId}`).emit('message', saved.toObject());
+        this.notifyClient(event.channelId, saved.toObject());
+    }
+
+    private formatIssueResultMessage(event: GithubIssueResultEvent): string {
+        if (event.success) {
+            return `✅ 이슈가 생성됐어요: ${event.issueUrl}`;
+        }
+        return `❌ 이슈 생성 실패: ${event.error ?? '알 수 없는 오류'}`;
+    }
+
+    private notifyClient(channelId: number, message: any): void {
+        this.io?.to(`chat:${channelId}`).emit('message', message);
     }
 }

--- a/cowork-chat/src/chat/kafka/github-issue.producer.spec.ts
+++ b/cowork-chat/src/chat/kafka/github-issue.producer.spec.ts
@@ -43,6 +43,7 @@ describe('GithubIssueProducer', () => {
         const event: GithubIssueCreateEvent = {
             channelId: 5,
             teamId: 1,
+            projectId: 100,
             owner: 'my-org',
             repo: 'backend',
             title: '로그인 버그',
@@ -69,6 +70,7 @@ describe('GithubIssueProducer', () => {
         await producer.send({
             channelId: 99,
             teamId: 1,
+            projectId: 100,
             owner: 'org',
             repo: 'repo',
             title: '제목',

--- a/cowork-chat/src/chat/kafka/github-issue.producer.spec.ts
+++ b/cowork-chat/src/chat/kafka/github-issue.producer.spec.ts
@@ -1,0 +1,89 @@
+import { ConfigService } from '@nestjs/config';
+import { GithubIssueProducer } from './github-issue.producer';
+import { GithubIssueCreateEvent } from './event/github-issue.event';
+
+const mockSend = jest.fn();
+const mockConnect = jest.fn();
+const mockDisconnect = jest.fn();
+
+jest.mock('kafkajs', () => ({
+    Kafka: jest.fn().mockImplementation(() => ({
+        producer: jest.fn().mockReturnValue({
+            connect: mockConnect,
+            disconnect: mockDisconnect,
+            send: mockSend,
+        }),
+    })),
+}));
+
+describe('GithubIssueProducer', () => {
+    let producer: GithubIssueProducer;
+
+    beforeEach(async () => {
+        jest.clearAllMocks();
+        const configService = {
+            get: jest.fn().mockReturnValue('localhost:9092'),
+        } as unknown as ConfigService;
+
+        producer = new GithubIssueProducer(configService);
+        await producer.onModuleInit();
+    });
+
+    afterEach(async () => {
+        await producer.onModuleDestroy();
+    });
+
+    it('onModuleInit 시 Kafka producer에 연결한다', () => {
+        expect(mockConnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('이벤트를 github.issue.create 토픽으로 발행한다', async () => {
+        mockSend.mockResolvedValue(undefined);
+
+        const event: GithubIssueCreateEvent = {
+            channelId: 5,
+            teamId: 1,
+            owner: 'my-org',
+            repo: 'backend',
+            title: '로그인 버그',
+            body: '상세 내용',
+            requesterId: 42,
+        };
+
+        await producer.send(event);
+
+        expect(mockSend).toHaveBeenCalledWith({
+            topic: 'github.issue.create',
+            messages: [
+                {
+                    key: '5',
+                    value: JSON.stringify(event),
+                },
+            ],
+        });
+    });
+
+    it('channelId를 Kafka 메시지 key로 사용한다', async () => {
+        mockSend.mockResolvedValue(undefined);
+
+        await producer.send({
+            channelId: 99,
+            teamId: 1,
+            owner: 'org',
+            repo: 'repo',
+            title: '제목',
+            requesterId: 1,
+        });
+
+        expect(mockSend).toHaveBeenCalledWith(
+            expect.objectContaining({
+                messages: [expect.objectContaining({ key: '99' })],
+            }),
+        );
+    });
+
+    it('onModuleDestroy 시 연결을 해제한다', async () => {
+        await producer.onModuleDestroy();
+        expect(mockDisconnect).toHaveBeenCalledTimes(1);
+    });
+});

--- a/cowork-chat/src/chat/kafka/github-issue.producer.ts
+++ b/cowork-chat/src/chat/kafka/github-issue.producer.ts
@@ -1,0 +1,38 @@
+import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Kafka, Producer } from 'kafkajs';
+import { GithubIssueCreateEvent } from './event/github-issue.event';
+
+@Injectable()
+export class GithubIssueProducer implements OnModuleInit, OnModuleDestroy {
+    private readonly logger = new Logger(GithubIssueProducer.name);
+    private producer!: Producer;
+
+    constructor(private readonly configService: ConfigService) {}
+
+    async onModuleInit() {
+        const kafka = new Kafka({
+            clientId: 'cowork-chat-github',
+            brokers: [this.configService.get<string>('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')],
+        });
+        this.producer = kafka.producer();
+        await this.producer.connect();
+        this.logger.log('GitHub issue producer connected');
+    }
+
+    async onModuleDestroy() {
+        await this.producer.disconnect();
+    }
+
+    async send(event: GithubIssueCreateEvent): Promise<void> {
+        await this.producer.send({
+            topic: 'github.issue.create',
+            messages: [
+                {
+                    key: event.channelId.toString(),
+                    value: JSON.stringify(event),
+                },
+            ],
+        });
+    }
+}

--- a/cowork-chat/src/chat/schema/channel-member.schema.ts
+++ b/cowork-chat/src/chat/schema/channel-member.schema.ts
@@ -6,6 +6,7 @@ export type ChannelMemberDocument = HydratedDocument<ChannelMember>;
 @Schema({ timestamps: true, versionKey: false })
 export class ChannelMember {
     @Prop({ required: true }) channelId!: number;
+    @Prop({ required: true }) teamId!: number;
     @Prop({ required: true }) userId!: number;
     @Prop({ default: 'MEMBER' }) role!: string;
 }

--- a/cowork-chat/src/chat/schema/message.schema.ts
+++ b/cowork-chat/src/chat/schema/message.schema.ts
@@ -41,7 +41,7 @@ export class Message {
 
     @Prop({ default: false }) isPinned!: boolean;
 
-    @Prop({ type: String, default: null }) clientMessageId!: string | null;
+    @Prop({ type: String }) clientMessageId?: string | null;
 
     @Prop({ type: [Number], default: [] }) mentions!: number[];
 

--- a/cowork-chat/src/chat/service/project.client.spec.ts
+++ b/cowork-chat/src/chat/service/project.client.spec.ts
@@ -85,7 +85,10 @@ describe('ProjectClient', () => {
 
             const result = await client.getGithubRepoInfo(1);
 
-            expect(global.fetch).toHaveBeenCalledWith('http://localhost:8084/projects/1');
+            expect(global.fetch).toHaveBeenCalledWith(
+                'http://localhost:8084/projects/1',
+                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+            );
             expect(result).toEqual({ teamId: 10, owner: 'my-org', repo: 'backend' });
         });
 
@@ -107,16 +110,22 @@ describe('ProjectClient', () => {
             expect(await client.getGithubRepoInfo(1)).toBeNull();
         });
 
-        it('HTTP 오류 응답이면 null을 반환한다', async () => {
+        it('404 응답이면 null을 반환한다', async () => {
             (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 });
 
             expect(await client.getGithubRepoInfo(99)).toBeNull();
         });
 
-        it('네트워크 오류가 발생하면 null을 반환한다', async () => {
+        it('5xx 응답이면 예외를 던진다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+
+            await expect(client.getGithubRepoInfo(1)).rejects.toThrow('프로젝트 서비스 응답 오류: 500');
+        });
+
+        it('네트워크 오류가 발생하면 예외를 던진다', async () => {
             (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNREFUSED'));
 
-            expect(await client.getGithubRepoInfo(1)).toBeNull();
+            await expect(client.getGithubRepoInfo(1)).rejects.toThrow('ECONNREFUSED');
         });
     });
 });

--- a/cowork-chat/src/chat/service/project.client.spec.ts
+++ b/cowork-chat/src/chat/service/project.client.spec.ts
@@ -1,0 +1,112 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { ProjectClient } from './project.client';
+
+describe('ProjectClient', () => {
+    let client: ProjectClient;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ProjectClient,
+                {
+                    provide: ConfigService,
+                    useValue: { get: jest.fn().mockReturnValue('http://localhost:8084') },
+                },
+            ],
+        }).compile();
+
+        client = module.get<ProjectClient>(ProjectClient);
+    });
+
+    describe('parseRepoUrl (private)', () => {
+        const parse = (url: string | null | undefined) =>
+            (client as any).parseRepoUrl(url);
+
+        it('표준 GitHub URL에서 owner와 repo를 파싱한다', () => {
+            expect(parse('https://github.com/my-org/backend')).toEqual({
+                owner: 'my-org',
+                repo: 'backend',
+            });
+        });
+
+        it('.git 접미사를 제거한다', () => {
+            expect(parse('https://github.com/my-org/backend.git')).toEqual({
+                owner: 'my-org',
+                repo: 'backend',
+            });
+        });
+
+        it('하위 경로가 있어도 owner/repo만 추출한다', () => {
+            expect(parse('https://github.com/my-org/backend/tree/main')).toEqual({
+                owner: 'my-org',
+                repo: 'backend',
+            });
+        });
+
+        it('null이면 null을 반환한다', () => {
+            expect(parse(null)).toBeNull();
+        });
+
+        it('undefined이면 null을 반환한다', () => {
+            expect(parse(undefined)).toBeNull();
+        });
+
+        it('빈 문자열이면 null을 반환한다', () => {
+            expect(parse('')).toBeNull();
+        });
+
+        it('GitHub URL이 아니면 null을 반환한다', () => {
+            expect(parse('https://gitlab.com/my-org/backend')).toBeNull();
+        });
+
+        it('형식이 잘못된 URL이면 null을 반환한다', () => {
+            expect(parse('not-a-url')).toBeNull();
+        });
+    });
+
+    describe('getGithubRepoInfo', () => {
+        beforeEach(() => {
+            global.fetch = jest.fn();
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('프로젝트 서비스 응답에서 레포 정보를 파싱해 반환한다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({
+                ok: true,
+                json: jest.fn().mockResolvedValue({
+                    githubRepoUrl: 'https://github.com/my-org/backend',
+                }),
+            });
+
+            const result = await client.getGithubRepoInfo(1);
+
+            expect(global.fetch).toHaveBeenCalledWith('http://localhost:8084/projects/1');
+            expect(result).toEqual({ owner: 'my-org', repo: 'backend' });
+        });
+
+        it('githubRepoUrl이 null이면 null을 반환한다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({
+                ok: true,
+                json: jest.fn().mockResolvedValue({ githubRepoUrl: null }),
+            });
+
+            expect(await client.getGithubRepoInfo(1)).toBeNull();
+        });
+
+        it('HTTP 오류 응답이면 null을 반환한다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 });
+
+            expect(await client.getGithubRepoInfo(99)).toBeNull();
+        });
+
+        it('네트워크 오류가 발생하면 null을 반환한다', async () => {
+            (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNREFUSED'));
+
+            expect(await client.getGithubRepoInfo(1)).toBeNull();
+        });
+    });
+});

--- a/cowork-chat/src/chat/service/project.client.spec.ts
+++ b/cowork-chat/src/chat/service/project.client.spec.ts
@@ -78,6 +78,7 @@ describe('ProjectClient', () => {
             (global.fetch as jest.Mock).mockResolvedValue({
                 ok: true,
                 json: jest.fn().mockResolvedValue({
+                    teamId: 10,
                     githubRepoUrl: 'https://github.com/my-org/backend',
                 }),
             });
@@ -85,13 +86,22 @@ describe('ProjectClient', () => {
             const result = await client.getGithubRepoInfo(1);
 
             expect(global.fetch).toHaveBeenCalledWith('http://localhost:8084/projects/1');
-            expect(result).toEqual({ owner: 'my-org', repo: 'backend' });
+            expect(result).toEqual({ teamId: 10, owner: 'my-org', repo: 'backend' });
         });
 
         it('githubRepoUrl이 null이면 null을 반환한다', async () => {
             (global.fetch as jest.Mock).mockResolvedValue({
                 ok: true,
-                json: jest.fn().mockResolvedValue({ githubRepoUrl: null }),
+                json: jest.fn().mockResolvedValue({ teamId: 10, githubRepoUrl: null }),
+            });
+
+            expect(await client.getGithubRepoInfo(1)).toBeNull();
+        });
+
+        it('teamId가 없으면 null을 반환한다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({
+                ok: true,
+                json: jest.fn().mockResolvedValue({ githubRepoUrl: 'https://github.com/my-org/backend' }),
             });
 
             expect(await client.getGithubRepoInfo(1)).toBeNull();

--- a/cowork-chat/src/chat/service/project.client.ts
+++ b/cowork-chat/src/chat/service/project.client.ts
@@ -2,6 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
 export interface GithubRepoInfo {
+    teamId: number;
     owner: string;
     repo: string;
 }
@@ -22,15 +23,17 @@ export class ProjectClient {
                 this.logger.warn(`프로젝트 조회 실패 projectId=${projectId} status=${res.status}`);
                 return null;
             }
-            const body = await res.json() as { githubRepoUrl?: string | null };
-            return this.parseRepoUrl(body.githubRepoUrl);
+            const body = await res.json() as { teamId?: number | null; githubRepoUrl?: string | null };
+            const repoInfo = this.parseRepoUrl(body.githubRepoUrl);
+            if (!repoInfo || typeof body.teamId !== 'number') return null;
+            return { teamId: body.teamId, ...repoInfo };
         } catch (err) {
             this.logger.error(`프로젝트 서비스 호출 오류 projectId=${projectId}`, err);
             return null;
         }
     }
 
-    private parseRepoUrl(url: string | null | undefined): GithubRepoInfo | null {
+    private parseRepoUrl(url: string | null | undefined): Omit<GithubRepoInfo, 'teamId'> | null {
         if (!url) return null;
         // https://github.com/{owner}/{repo} 또는 https://github.com/{owner}/{repo}.git
         const match = url.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/.*)?$/);

--- a/cowork-chat/src/chat/service/project.client.ts
+++ b/cowork-chat/src/chat/service/project.client.ts
@@ -1,0 +1,40 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface GithubRepoInfo {
+    owner: string;
+    repo: string;
+}
+
+@Injectable()
+export class ProjectClient {
+    private readonly logger = new Logger(ProjectClient.name);
+    private readonly projectServiceUrl: string;
+
+    constructor(private readonly configService: ConfigService) {
+        this.projectServiceUrl = this.configService.get<string>('PROJECT_SERVICE_URL', 'http://localhost:8084');
+    }
+
+    async getGithubRepoInfo(projectId: number): Promise<GithubRepoInfo | null> {
+        try {
+            const res = await fetch(`${this.projectServiceUrl}/projects/${projectId}`);
+            if (!res.ok) {
+                this.logger.warn(`프로젝트 조회 실패 projectId=${projectId} status=${res.status}`);
+                return null;
+            }
+            const body = await res.json() as { githubRepoUrl?: string | null };
+            return this.parseRepoUrl(body.githubRepoUrl);
+        } catch (err) {
+            this.logger.error(`프로젝트 서비스 호출 오류 projectId=${projectId}`, err);
+            return null;
+        }
+    }
+
+    private parseRepoUrl(url: string | null | undefined): GithubRepoInfo | null {
+        if (!url) return null;
+        // https://github.com/{owner}/{repo} 또는 https://github.com/{owner}/{repo}.git
+        const match = url.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/.*)?$/);
+        if (!match) return null;
+        return { owner: match[1], repo: match[2] };
+    }
+}

--- a/cowork-chat/src/chat/service/project.client.ts
+++ b/cowork-chat/src/chat/service/project.client.ts
@@ -18,10 +18,12 @@ export class ProjectClient {
 
     async getGithubRepoInfo(projectId: number): Promise<GithubRepoInfo | null> {
         try {
-            const res = await fetch(`${this.projectServiceUrl}/projects/${projectId}`);
+            const res = await fetch(`${this.projectServiceUrl}/projects/${projectId}`, {
+                signal: AbortSignal.timeout(5000),
+            });
+            if (res.status === 404) return null;
             if (!res.ok) {
-                this.logger.warn(`프로젝트 조회 실패 projectId=${projectId} status=${res.status}`);
-                return null;
+                throw new Error(`프로젝트 서비스 응답 오류: ${res.status}`);
             }
             const body = await res.json() as { teamId?: number | null; githubRepoUrl?: string | null };
             const repoInfo = this.parseRepoUrl(body.githubRepoUrl);
@@ -29,7 +31,7 @@ export class ProjectClient {
             return { teamId: body.teamId, ...repoInfo };
         } catch (err) {
             this.logger.error(`프로젝트 서비스 호출 오류 projectId=${projectId}`, err);
-            return null;
+            throw err;
         }
     }
 

--- a/cowork-chat/src/chat/service/project.client.ts
+++ b/cowork-chat/src/chat/service/project.client.ts
@@ -13,7 +13,7 @@ export class ProjectClient {
     private readonly projectServiceUrl: string;
 
     constructor(private readonly configService: ConfigService) {
-        this.projectServiceUrl = this.configService.get<string>('PROJECT_SERVICE_URL', 'http://localhost:8084');
+        this.projectServiceUrl = this.configService.get<string>('PROJECT_SERVICE_URL', 'http://localhost:8084').replace(/\/$/, '');
     }
 
     async getGithubRepoInfo(projectId: number): Promise<GithubRepoInfo | null> {

--- a/cowork-chat/src/chat/service/project.client.ts
+++ b/cowork-chat/src/chat/service/project.client.ts
@@ -37,9 +37,14 @@ export class ProjectClient {
 
     private parseRepoUrl(url: string | null | undefined): Omit<GithubRepoInfo, 'teamId'> | null {
         if (!url) return null;
-        // https://github.com/{owner}/{repo} 또는 https://github.com/{owner}/{repo}.git
-        const match = url.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/.*)?$/);
-        if (!match) return null;
-        return { owner: match[1], repo: match[2] };
+        try {
+            const parsed = new URL(url);
+            if (parsed.hostname !== 'github.com') return null;
+            const parts = parsed.pathname.split('/').filter(Boolean);
+            if (parts.length < 2) return null;
+            return { owner: parts[0], repo: parts[1].replace(/\.git$/, '') };
+        } catch {
+            return null;
+        }
     }
 }

--- a/cowork-project/src/main/resources/db/migration/V2__add_github_owner_to_projects.sql
+++ b/cowork-project/src/main/resources/db/migration/V2__add_github_owner_to_projects.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tb_projects ADD COLUMN github_repo_url VARCHAR(512) DEFAULT NULL COMMENT 'GitHub 레포지토리 URL (예: https://github.com/my-org/my-repo)';


### PR DESCRIPTION
## 개요

채팅 서비스에서 GitHub 이슈 생성 요청을 Kafka 이벤트로 발행하는 API를 추가하였습니다.
GitHub 이슈 생성 결과를 채팅 시스템 메시지로 저장하고 WebSocket으로 브로드캐스트하도록 연동하였습니다.
프로젝트에 GitHub 레포지토리 URL을 저장할 수 있도록 project 서비스 마이그레이션을 추가하였습니다.

## 본문

- `POST /chat/channels/:channelId/github/issues` 엔드포인트를 추가하여 채널 멤버십 검증 후 `github.issue.create` 토픽으로 이슈 생성 이벤트를 발행하였습니다.
- `github.issue.result` 토픽 컨슈머를 추가하여 성공/실패 결과를 `SYSTEM` 메시지로 저장하고 해당 채널 룸에 실시간 전파하도록 구성하였습니다.
- GitHub 이슈 생성 요청/결과 이벤트 타입과 DTO, Kafka producer/consumer 테스트를 추가하였습니다.
- 프로젝트 서비스에서 GitHub 레포지토리 URL을 저장할 수 있도록 `tb_projects.github_repo_url` 컬럼을 추가하는 Flyway 마이그레이션을 추가하였습니다.
- 프로젝트 서비스 응답의 GitHub URL에서 owner/repo 정보를 파싱하는 `ProjectClient`와 관련 테스트를 추가하였습니다.

테스트는 `cowork-chat`에서 아래 명령으로 확인하였습니다.

```bash
npm test -- --runInBand chat.controller.spec.ts github-issue.producer.spec.ts github-issue-result.consumer.spec.ts project.client.spec.ts
```
