### PR TITLE
[global] 문서 및 설정 전반 서비스 명칭 소문자 통일

### DIFF
--- a/.github/workflows/cowork-prod-cd.yml
+++ b/.github/workflows/cowork-prod-cd.yml
@@ -49,6 +49,6 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           status: ${{ job.status }}
-          title: "Cowork Server Prod CD"
+          title: "cowork Server Prod CD"
           description: |
             Released `${{ steps.version.outputs.version }}` · by **${{ github.actor }}**

--- a/.github/workflows/cowork-prod-ci.yml
+++ b/.github/workflows/cowork-prod-ci.yml
@@ -291,7 +291,7 @@ jobs:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           status: ${{ steps.status.outputs.status }}
           color: ${{ steps.status.outputs.color }}
-          title: "Cowork Server Prod CI"
+          title: "cowork Server Prod CI"
           description: |
             `${{ github.ref_name }}` · `${{ steps.sha.outputs.short }}` · by **${{ github.actor }}**
             **Changed:** ${{ needs.detect-changes.outputs.services-list }}

--- a/.github/workflows/cowork-stage-ci.yml
+++ b/.github/workflows/cowork-stage-ci.yml
@@ -282,7 +282,7 @@ jobs:
           webhook: ${{ secrets.DISCORD_INFORMATION_ALERT_CHANNEL_WEBHOOK }}
           status: ${{ steps.status.outputs.status }}
           color: ${{ steps.status.outputs.color }}
-          title: "Cowork Server Stage CI"
+          title: "cowork Server Stage CI"
           description: |
             `${{ github.ref_name }}` · `${{ steps.sha.outputs.short }}` · by **${{ github.actor }}**
             **Changed:** ${{ needs.detect-changes.outputs.services-list }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# Cowork Server
+# cowork Server
 
 ## Overview
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Cowork Server
+# cowork Server
 
 ## Overview
 
-Team collaboration platform backend. MSA monorepo based on Spring Boot.  
+Team collaboration platform backend. MSA monorepo base.  
 Tech stack: Spring Cloud Gateway, Eureka, OpenFeign, Kafka, Flyway, MySQL, MongoDB

--- a/cowork-authorization/docs/swagger.json
+++ b/cowork-authorization/docs/swagger.json
@@ -2,7 +2,7 @@
     "swagger": "2.0",
     "info": {
         "description": "인증/인가 서비스 — DataGSM OAuth2 PKCE 로그인, JWT 액세스/리프레시 토큰 발급 및 갱신",
-        "title": "Cowork Authorization API",
+        "title": "cowork Authorization API",
         "contact": {},
         "version": "1.0"
     },

--- a/cowork-authorization/docs/swagger.yaml
+++ b/cowork-authorization/docs/swagger.yaml
@@ -14,7 +14,7 @@ definitions:
 info:
   contact: {}
   description: 인증/인가 서비스 — DataGSM OAuth2 PKCE 로그인, JWT 액세스/리프레시 토큰 발급 및 갱신
-  title: Cowork Authorization API
+  title: cowork Authorization API
   version: "1.0"
 paths:
   /auth/refresh:

--- a/cowork-chat/public/asyncapi.json
+++ b/cowork-chat/public/asyncapi.json
@@ -1,7 +1,7 @@
 {
   "asyncapi": "2.6.0",
   "info": {
-    "title": "Cowork Chat WebSocket API",
+    "title": "cowork Chat WebSocket API",
     "version": "1.0.0",
     "description": "Socket.io 기반 실시간 채팅 서비스 이벤트 명세"
   },

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/SwaggerUiController.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/controller/SwaggerUiController.kt
@@ -28,7 +28,7 @@ class SwaggerUiController(
             <head>
               <meta charset="utf-8">
               <meta name="viewport" content="width=device-width, initial-scale=1">
-              <title>Cowork API Docs</title>
+              <title>cowork API Docs</title>
               <link rel="stylesheet" href="/webjars/swagger-ui/swagger-ui.css">
               <link rel="icon" href="/webjars/swagger-ui/favicon-32x32.png">
             </head>

--- a/cowork-monitoring/exporters/README.md
+++ b/cowork-monitoring/exporters/README.md
@@ -2,7 +2,7 @@
 
 This directory documents optional infrastructure exporters that can be added to the monitoring stack.
 
-Typical exporters for the Cowork platform:
+Typical exporters for the cowork platform:
 
 - `node-exporter` for host CPU, memory, disk, and filesystem metrics
 - `cAdvisor` for container metrics

--- a/cowork-monitoring/grafana/dashboards/cowork-logs.json
+++ b/cowork-monitoring/grafana/dashboards/cowork-logs.json
@@ -168,7 +168,7 @@
   "time": { "from": "now-1h", "to": "now" },
   "timepicker": {},
   "timezone": "browser",
-  "title": "Cowork Logs",
+  "title": "cowork Logs",
   "uid": "cowork-logs",
   "version": 1
 }

--- a/cowork-monitoring/grafana/dashboards/infrastructure.json
+++ b/cowork-monitoring/grafana/dashboards/infrastructure.json
@@ -1,5 +1,5 @@
 {
-  "title": "Cowork 인프라 (MySQL + Redis + Kafka + PostgreSQL)",
+  "title": "cowork 인프라 (MySQL + Redis + Kafka + PostgreSQL)",
   "uid": "cowork-infrastructure",
   "tags": ["cowork", "infrastructure"],
   "timezone": "browser",

--- a/cowork-monitoring/grafana/dashboards/overview.json
+++ b/cowork-monitoring/grafana/dashboards/overview.json
@@ -1,5 +1,5 @@
 {
-  "title": "Cowork Overview",
+  "title": "cowork Overview",
   "uid": "cowork-overview",
   "tags": ["cowork"],
   "timezone": "browser",

--- a/cowork-monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/cowork-monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -2,7 +2,7 @@ apiVersion: 1
 
 providers:
   - name: cowork-monitoring
-    folder: Cowork
+    folder: cowork
     type: file
     disableDeletion: false
     updateIntervalSeconds: 30

--- a/cowork-monitoring/prometheus/rules/application-alerts.yml
+++ b/cowork-monitoring/prometheus/rules/application-alerts.yml
@@ -1,18 +1,18 @@
 groups:
   - name: cowork-availability
     rules:
-      - alert: CoworkServiceDown
+      - alert: coworkServiceDown
         expr: up{job=~"cowork-.*"} == 0
         for: 2m
         labels:
           severity: critical
         annotations:
-          summary: "Cowork service down"
+          summary: "cowork service down"
           description: "Service {{ $labels.service }} is unreachable for more than 2 minutes."
 
   - name: cowork-jvm
     rules:
-      - alert: CoworkHighJvmHeapUsage
+      - alert: coworkHighJvmHeapUsage
         expr: |
           (
             jvm_memory_used_bytes{area="heap"} /
@@ -27,7 +27,7 @@ groups:
 
   - name: cowork-http
     rules:
-      - alert: CoworkHttp5xxSpike
+      - alert: coworkHttp5xxSpike
         expr: |
           sum by (service) (
             rate(http_server_requests_seconds_count{status=~"5.."}[5m])
@@ -39,7 +39,7 @@ groups:
           summary: "HTTP 5xx spike detected"
           description: "Service {{ $labels.service }} is returning more than 1 5xx response/sec for 5 minutes."
 
-      - alert: CoworkHttp4xxSpike
+      - alert: coworkHttp4xxSpike
         expr: |
           sum by (service) (
             rate(http_server_requests_seconds_count{status=~"4.."}[5m])
@@ -51,7 +51,7 @@ groups:
           summary: "HTTP 4xx spike detected"
           description: "Service {{ $labels.service }} is returning more than 5 4xx response/sec for 5 minutes."
 
-      - alert: CoworkHighResponseTime
+      - alert: coworkHighResponseTime
         expr: |
           histogram_quantile(0.99,
             sum by (service, le) (
@@ -67,7 +67,7 @@ groups:
 
   - name: cowork-go
     rules:
-      - alert: CoworkGoHighMemory
+      - alert: coworkGoHighMemory
         expr: |
           go_memstats_heap_inuse_bytes{job=~"cowork-.*"} /
           go_memstats_heap_sys_bytes{job=~"cowork-.*"} > 0.85
@@ -80,7 +80,7 @@ groups:
 
   - name: cowork-nodejs
     rules:
-      - alert: CoworkNodeJsHighHeap
+      - alert: coworkNodeJsHighHeap
         expr: |
           nodejs_heap_size_used_bytes / nodejs_heap_size_total_bytes > 0.85
         for: 5m
@@ -92,7 +92,7 @@ groups:
 
   - name: cowork-kafka
     rules:
-      - alert: CoworkKafkaConsumerLag
+      - alert: coworkKafkaConsumerLag
         expr: kafka_consumergroup_lag_sum > 1000
         for: 5m
         labels:

--- a/cowork-preference/src/main/resources/openapi.json
+++ b/cowork-preference/src/main/resources/openapi.json
@@ -1,7 +1,7 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "title": "Cowork Preference API",
+    "title": "cowork Preference API",
     "description": "환경 설정 서비스 — 계정/팀/프로젝트/채널 설정 및 프로젝트 역할 관리",
     "version": "1.0"
   },

--- a/cowork-voice/docs/swagger.json
+++ b/cowork-voice/docs/swagger.json
@@ -2,7 +2,7 @@
     "swagger": "2.0",
     "info": {
         "description": "음성 채널 서비스 — LiveKit 기반 음성 통화 세션 관리",
-        "title": "Cowork Voice API",
+        "title": "cowork Voice API",
         "contact": {},
         "version": "1.0"
     },

--- a/cowork-voice/docs/swagger.yaml
+++ b/cowork-voice/docs/swagger.yaml
@@ -74,7 +74,7 @@ definitions:
 info:
   contact: {}
   description: 음성 채널 서비스 — LiveKit 기반 음성 통화 세션 관리
-  title: Cowork Voice API
+  title: cowork Voice API
   version: "1.0"
 paths:
   /voice/channels/{channel_id}/join:

--- a/docs/grafana-logging-spec.md
+++ b/docs/grafana-logging-spec.md
@@ -2,7 +2,7 @@
 
 ## 개요
 
-Cowork Server의 모든 마이크로서비스(Spring Boot, Go, NestJS, Vert.x)에서 발생하는 로그를 
+cowork Server의 모든 마이크로서비스(Spring Boot, Go, NestJS, Vert.x)에서 발생하는 로그를 
 Loki + Promtail 스택으로 수집하고 Grafana에서 시각화한다.  
 기존 Prometheus + Grafana 모니터링 인프라에 로그 레이어를 추가하는 작업이다.
 


### PR DESCRIPTION
## 개요

서비스 명칭 표기를 `Cowork`에서 `cowork`로 통일하였습니다. 문서, API 명세, 모니터링 설정, CI/CD 워크플로 등 사람이 읽는 텍스트 전반에 걸쳐 수정하였으며, Kotlin 클래스 이름(PascalCase 언어 규칙)은 변경 대상에서 제외하였습니다.

## 본문

**수정 범위**

- `AGENTS.md`, `docs/` 문서: 제목 및 본문 표기 수정
- API 명세 (`swagger.yaml`, `swagger.json`, `openapi.json`, `asyncapi.json`): `info.title` 값 수정
- Grafana 대시보드 JSON: `title` 필드 수정
- Grafana 프로비저닝 설정: `folder` 값 수정
- Prometheus 알림 규칙: 알림 이름(`CoworkServiceDown` 등 8개) 및 `summary` 문자열 수정
- GitHub Actions 워크플로: Discord 알림 `title` 수정
- `SwaggerUiController.kt`: HTML `<title>` 태그 내 문자열 수정

**변경 제외 항목**

Kotlin 클래스 이름(`CoworkTeamApplication`, `CoworkGatewayApplication` 등)은 PascalCase 언어 규칙에 따른 식별자이므로 수정하지 않았습니다.
