### PR TITLE
[chat] 슬래시 커맨드 발행 API 추가

### DIFF
--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Types } from 'mongoose';
 import { ChatController } from './chat.controller';
 import { ChatService } from './chat.service';
@@ -8,6 +8,7 @@ import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { ProjectClient } from './service/project.client';
 import { MinioService } from '../storage/minio.service';
+import { SlashCommand } from './dto/slash-command.dto';
 
 const mockMessageId = new Types.ObjectId().toString();
 const userId = 42;
@@ -197,6 +198,127 @@ describe('ChatController', () => {
             await expect(
                 controller.createGithubIssue(1, dto as any, userId),
             ).rejects.toThrow('Kafka 연결 오류');
+        });
+    });
+
+    describe('createSlashCommand', () => {
+        const payload = {
+            projectId: 100,
+            title: '로그인 버그',
+            body: '특정 브라우저에서 재현됨',
+        };
+
+        it('github.issue.create 슬래시 커맨드가 기존과 동일한 Kafka 이벤트를 발행한다', async () => {
+            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
+            mockGithubIssueProducer.send.mockResolvedValue(undefined);
+
+            const result = await controller.createSlashCommand(
+                1,
+                { command: SlashCommand.GITHUB_ISSUE_CREATE, payload } as any,
+                userId,
+            );
+
+            expect(mockChatService.checkMembershipAndGetTeamId).toHaveBeenCalledWith(1, 42);
+            expect(mockProjectClient.getGithubRepoInfo).toHaveBeenCalledWith(100);
+            expect(mockGithubIssueProducer.send).toHaveBeenCalledWith({
+                channelId: 1,
+                teamId: 10,
+                projectId: 100,
+                owner: 'my-org',
+                repo: 'backend',
+                title: '로그인 버그',
+                body: '특정 브라우저에서 재현됨',
+                requesterId: 42,
+            });
+            expect(result).toEqual({ queued: true });
+        });
+
+        it('body 없이도 github.issue.create 이벤트를 발행한다', async () => {
+            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
+            mockGithubIssueProducer.send.mockResolvedValue(undefined);
+
+            await controller.createSlashCommand(
+                1,
+                { command: SlashCommand.GITHUB_ISSUE_CREATE, payload: { ...payload, body: undefined } } as any,
+                userId,
+            );
+
+            expect(mockGithubIssueProducer.send).toHaveBeenCalledWith(
+                expect.objectContaining({ body: undefined }),
+            );
+        });
+
+        it('채널 멤버가 아니면 ForbiddenException이 전파되고 이벤트를 발행하지 않는다', async () => {
+            mockChatService.checkMembershipAndGetTeamId.mockRejectedValue(new ForbiddenException());
+
+            await expect(
+                controller.createSlashCommand(
+                    1,
+                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload } as any,
+                    userId,
+                ),
+            ).rejects.toThrow(ForbiddenException);
+
+            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
+        });
+
+        it('프로젝트에 GitHub 레포 정보가 없으면 BadRequestException을 던진다', async () => {
+            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue(null);
+
+            await expect(
+                controller.createSlashCommand(
+                    1,
+                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload } as any,
+                    userId,
+                ),
+            ).rejects.toThrow('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
+
+            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
+        });
+
+        it('프로젝트의 teamId가 채널 teamId와 다르면 ForbiddenException을 던진다', async () => {
+            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 99, owner: 'other-org', repo: 'backend' });
+
+            await expect(
+                controller.createSlashCommand(
+                    1,
+                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload } as any,
+                    userId,
+                ),
+            ).rejects.toThrow('해당 프로젝트는 이 채널의 팀에 속하지 않습니다');
+
+            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
+        });
+
+        it('producer 오류가 전파된다', async () => {
+            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
+            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
+            mockGithubIssueProducer.send.mockRejectedValue(new Error('Kafka 연결 오류'));
+
+            await expect(
+                controller.createSlashCommand(
+                    1,
+                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload } as any,
+                    userId,
+                ),
+            ).rejects.toThrow('Kafka 연결 오류');
+        });
+
+        it('지원하지 않는 command는 BadRequestException을 던지고 이벤트를 발행하지 않는다', async () => {
+            await expect(
+                controller.createSlashCommand(
+                    1,
+                    { command: 'unknown.command', payload } as any,
+                    userId,
+                ),
+            ).rejects.toThrow(BadRequestException);
+
+            expect(mockChatService.checkMembershipAndGetTeamId).not.toHaveBeenCalled();
+            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
         });
     });
 

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -32,7 +32,6 @@ import {
 } from './dto/message-response.dto';
 import { CreateGithubIssueDto, CreateGithubIssueResponseDto } from './dto/create-github-issue.dto';
 import {
-    GithubIssueSlashCommandPayloadDto,
     SlashCommand,
     SlashCommandDto,
     SlashCommandResponseDto,
@@ -133,7 +132,8 @@ export class ChatController {
         @Body() dto: CreateGithubIssueDto,
         @UserId() userId: number,
     ): Promise<CreateGithubIssueResponseDto> {
-        return this.publishGithubIssueCreateCommand(channelId, dto, userId);
+        await this.publishGithubIssueCreateCommand(channelId, dto, userId);
+        return { queued: true };
     }
 
     @Post('slash-commands')
@@ -154,14 +154,15 @@ export class ChatController {
             throw new BadRequestException('지원하지 않는 슬래시 커맨드입니다');
         }
 
-        return this.publishGithubIssueCreateCommand(channelId, dto.payload, userId);
+        await this.publishGithubIssueCreateCommand(channelId, dto.payload, userId);
+        return { queued: true };
     }
 
     private async publishGithubIssueCreateCommand(
         channelId: number,
-        dto: CreateGithubIssueDto | GithubIssueSlashCommandPayloadDto,
+        dto: CreateGithubIssueDto,
         userId: number,
-    ): Promise<CreateGithubIssueResponseDto> {
+    ): Promise<void> {
         const channelTeamId = await this.chatService.checkMembershipAndGetTeamId(channelId, userId);
         const repoInfo = await this.projectClient.getGithubRepoInfo(dto.projectId);
         if (!repoInfo) {
@@ -181,7 +182,6 @@ export class ChatController {
             body: dto.body,
             requesterId: userId,
         });
-        return { queued: true };
     }
 
     @Get('messages')

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -35,6 +35,7 @@ import {
     GithubIssueSlashCommandPayloadDto,
     SlashCommand,
     SlashCommandDto,
+    SlashCommandResponseDto,
 } from './dto/slash-command.dto';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
@@ -141,14 +142,14 @@ export class ChatController {
         summary: '슬래시 커맨드 발행',
         description: '현재 지원 커맨드: github.issue.create',
     })
-    @ApiResponse({ status: 201, type: CreateGithubIssueResponseDto })
+    @ApiResponse({ status: 201, type: SlashCommandResponseDto })
     @ApiResponse({ status: 400, description: '지원하지 않는 커맨드 또는 유효하지 않은 payload' })
     @ApiResponse({ status: 403, description: '채널 멤버 아님' })
     async createSlashCommand(
         @Param('channelId', ParseIntPipe) channelId: number,
         @Body() dto: SlashCommandDto,
         @UserId() userId: number,
-    ): Promise<CreateGithubIssueResponseDto> {
+    ): Promise<SlashCommandResponseDto> {
         if (dto.command !== SlashCommand.GITHUB_ISSUE_CREATE) {
             throw new BadRequestException('지원하지 않는 슬래시 커맨드입니다');
         }

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -31,6 +31,11 @@ import {
     SendMessageResponseDto,
 } from './dto/message-response.dto';
 import { CreateGithubIssueDto, CreateGithubIssueResponseDto } from './dto/create-github-issue.dto';
+import {
+    GithubIssueSlashCommandPayloadDto,
+    SlashCommand,
+    SlashCommandDto,
+} from './dto/slash-command.dto';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { ProjectClient } from './service/project.client';
@@ -115,13 +120,46 @@ export class ChatController {
 
     @Post('github/issues')
     @HttpCode(HttpStatus.CREATED)
-    @ApiOperation({ summary: 'GitHub 이슈 생성 (클라이언트 슬래시 커맨드 → Kafka 비동기)' })
+    @ApiOperation({
+        summary: '[Deprecated] GitHub 이슈 생성 (클라이언트 슬래시 커맨드 → Kafka 비동기)',
+        description: 'Deprecated: 신규 클라이언트는 POST /chat/channels/{channelId}/slash-commands 사용을 권장합니다.',
+        deprecated: true,
+    })
     @ApiResponse({ status: 201, type: CreateGithubIssueResponseDto })
     @ApiResponse({ status: 403, description: '채널 멤버 아님' })
     async createGithubIssue(
         @Param('channelId', ParseIntPipe) channelId: number,
         @Body() dto: CreateGithubIssueDto,
         @UserId() userId: number,
+    ): Promise<CreateGithubIssueResponseDto> {
+        return this.publishGithubIssueCreateCommand(channelId, dto, userId);
+    }
+
+    @Post('slash-commands')
+    @HttpCode(HttpStatus.CREATED)
+    @ApiOperation({
+        summary: '슬래시 커맨드 발행',
+        description: '현재 지원 커맨드: github.issue.create',
+    })
+    @ApiResponse({ status: 201, type: CreateGithubIssueResponseDto })
+    @ApiResponse({ status: 400, description: '지원하지 않는 커맨드 또는 유효하지 않은 payload' })
+    @ApiResponse({ status: 403, description: '채널 멤버 아님' })
+    async createSlashCommand(
+        @Param('channelId', ParseIntPipe) channelId: number,
+        @Body() dto: SlashCommandDto,
+        @UserId() userId: number,
+    ): Promise<CreateGithubIssueResponseDto> {
+        if (dto.command !== SlashCommand.GITHUB_ISSUE_CREATE) {
+            throw new BadRequestException('지원하지 않는 슬래시 커맨드입니다');
+        }
+
+        return this.publishGithubIssueCreateCommand(channelId, dto.payload, userId);
+    }
+
+    private async publishGithubIssueCreateCommand(
+        channelId: number,
+        dto: CreateGithubIssueDto | GithubIssueSlashCommandPayloadDto,
+        userId: number,
     ): Promise<CreateGithubIssueResponseDto> {
         const channelTeamId = await this.chatService.checkMembershipAndGetTeamId(channelId, userId);
         const repoInfo = await this.projectClient.getGithubRepoInfo(dto.projectId);

--- a/cowork-chat/src/chat/dto/slash-command.dto.ts
+++ b/cowork-chat/src/chat/dto/slash-command.dto.ts
@@ -26,3 +26,8 @@ export class SlashCommandDto {
     @Type(() => GithubIssueSlashCommandPayloadDto)
     payload!: GithubIssueSlashCommandPayloadDto;
 }
+
+export class SlashCommandResponseDto {
+    @ApiProperty({ description: '큐 등록 여부' })
+    queued!: boolean;
+}

--- a/cowork-chat/src/chat/dto/slash-command.dto.ts
+++ b/cowork-chat/src/chat/dto/slash-command.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsEnum, ValidateNested } from 'class-validator';
+import { CreateGithubIssueDto } from './create-github-issue.dto';
+
+export enum SlashCommand {
+    GITHUB_ISSUE_CREATE = 'github.issue.create',
+}
+
+export class GithubIssueSlashCommandPayloadDto extends CreateGithubIssueDto {}
+
+export class SlashCommandDto {
+    @ApiProperty({
+        description: '실행할 슬래시 커맨드',
+        enum: SlashCommand,
+        example: SlashCommand.GITHUB_ISSUE_CREATE,
+    })
+    @IsEnum(SlashCommand)
+    command!: SlashCommand;
+
+    @ApiProperty({
+        description: '커맨드별 구조화 payload',
+        type: GithubIssueSlashCommandPayloadDto,
+    })
+    @ValidateNested()
+    @Type(() => GithubIssueSlashCommandPayloadDto)
+    payload!: GithubIssueSlashCommandPayloadDto;
+}


### PR DESCRIPTION
## 개요

`cowork-chat`에 범용 슬래시 커맨드 발행 API를 추가하였습니다.
현재는 GitHub 이슈 생성 커맨드인 `github.issue.create`만 지원하며, 기존 GitHub 이슈 Kafka 발행 흐름을 그대로 재사용하도록 구성하였습니다.

## 본문

- `POST /chat/channels/{channelId}/slash-commands` 엔드포인트를 추가하였습니다.
- 슬래시 커맨드 요청 DTO와 `github.issue.create` payload DTO를 추가하였습니다.
- 기존 `POST /chat/channels/{channelId}/github/issues` API는 동작을 유지하되 Swagger에서 deprecated로 표시하고 새 슬래시 커맨드 API 사용을 안내하였습니다.
- GitHub 이슈 생성 검증 및 Kafka 이벤트 발행 로직을 private helper로 분리하여 기존 API와 새 API가 같은 흐름을 사용하도록 정리하였습니다.
- 슬래시 커맨드 성공, optional body, 멤버십 실패, repo 정보 없음, teamId 불일치, producer 오류, 미지원 command 케이스에 대한 컨트롤러 테스트를 추가하였습니다.

검증:
- `npm test -- chat.controller.spec.ts`
- `npm run build`
- `npm test`
