### PR TITLE
[ci/cd] 운영 CD 워크플로우 버전 관리 및 태깅 로직 개선

### DIFF
--- a/.github/workflows/cowork-prod-cd.yml
+++ b/.github/workflows/cowork-prod-cd.yml
@@ -26,21 +26,38 @@ jobs:
         run: |
           DATE=$(date -u +"%Y%m%d")
           EXISTING=$(git tag -l "v${DATE}.*" | wc -l | tr -d ' ')
-          VERSION="v${DATE}.${EXISTING}"
+          VERSION="${DATE}.${EXISTING}"
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
 
+      - name: Bump Version Files
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          printf '%s' "${VERSION}" > VERSION
+          for FILE in cowork-*/build.gradle.kts; do
+            perl -i -pe "s/^version = \".*\"/version = \"${VERSION}\"/" "$FILE"
+          done
+          perl -i -pe "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" cowork-chat/package.json
+
+      - name: Commit Version Bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add VERSION cowork-*/build.gradle.kts cowork-chat/package.json
+          git diff --staged --quiet || git commit -m "chore: release v${{ steps.version.outputs.version }} [skip ci]"
+          git push origin main
+
       - name: Create Tag
-        run: git tag ${{ steps.version.outputs.version }}
+        run: git tag v${{ steps.version.outputs.version }}
 
       - name: Push Tag
-        run: git push origin ${{ steps.version.outputs.version }}
+        run: git push origin v${{ steps.version.outputs.version }}
 
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ steps.version.outputs.version }}" \
-            --title "${{ steps.version.outputs.version }}" \
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
             --notes $'## 수정내역\n\n- '
 
       - name: Notify Discord
@@ -51,4 +68,4 @@ jobs:
           status: ${{ job.status }}
           title: "cowork Server Prod CD"
           description: |
-            Released `${{ steps.version.outputs.version }}` · by **${{ github.actor }}**
+            Released `v${{ steps.version.outputs.version }}` · by **${{ github.actor }}**


### PR DESCRIPTION
## 개요

운영 CD 워크플로우의 버전 관리 및 태깅 로직을 개선하였습니다.

## 본문

기존의 단순 태깅 방식에서 벗어나, 릴리즈 시점에 VERSION 파일과 각 서비스의 빌드 구성 파일(build.gradle.kts, package.json)의 버전을 자동으로 갱신하고 커밋하도록 워크플로우를 수정하였습니다. 이를 통해 배포된 아티팩트와 소스 코드 간의 버전 일관성을 확보하였습니다. 또한 태그 명칭을 v 접두사를 포함한 표준 형식으로 통일하였습니다.