### PR TITLE
[team] Gradle 버전 카탈로그 정리

### DIFF
--- a/cowork-team/build.gradle.kts
+++ b/cowork-team/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.spring.dependency.management)
     alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlin.spring)
-    id("org.jetbrains.kotlin.plugin.jpa") version "2.1.20"
+    alias(libs.plugins.kotlin.jpa)
 }
 
 group = "com.cowork"
@@ -33,7 +33,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
     implementation("org.springframework.cloud:spring-cloud-starter-config")
-    implementation("org.springframework.cloud:spring-cloud-starter-openfeign")
+    implementation(libs.spring.cloud.starter.openfeign)
     implementation("org.springframework.kafka:spring-kafka")
     implementation("com.mysql:mysql-connector-j")
     implementation("org.flywaydb:flyway-core")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ mockk = "1.13.13"
 [libraries]
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
 spring-cloud-dependencies = { module = "org.springframework.cloud:spring-cloud-dependencies", version.ref = "spring-cloud" }
+spring-cloud-starter-openfeign = { module = "org.springframework.cloud:spring-cloud-starter-openfeign" }
 awspring-cloud-bom = { module = "io.awspring.cloud:spring-cloud-aws-dependencies", version.ref = "awspring-cloud" }
 awspring-cloud-s3 = { module = "io.awspring.cloud:spring-cloud-aws-starter-s3" }
 jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }


### PR DESCRIPTION
## 개요

`cowork-team`의 Gradle 의존성 선언을 version catalog 기반으로 정리하였습니다.

## 본문

OpenFeign starter 의존성을 `gradle/libs.versions.toml`에 alias로 추가하였습니다.

`cowork-team` 모듈에서 OpenFeign starter를 문자열 좌표 대신 catalog alias로 참조하도록 변경하였습니다.

Kotlin JPA 플러그인도 기존 직접 버전 선언 대신 catalog alias를 사용하도록 맞추었습니다.

검증은 `./gradlew :cowork-team:compileKotlin`으로 완료하였습니다.
