### PR TITLE
[global] 서비스별 README 문서 최신화 및 구조 표준화

### DIFF
--- a/cowork-authorization/README.md
+++ b/cowork-authorization/README.md
@@ -15,3 +15,10 @@
 
 ## 의존성
 - Eureka Client
+
+## 환경변수
+| 변수 | 설명 |
+|---|---|
+| `DB_DSN` | MySQL DSN |
+| `DATAGSM_CLIENT_ID` | DataGSM 클라이언트 ID |
+| `JWT_SECRET` | JWT 시크릿 키 |

--- a/cowork-authorization/README.md
+++ b/cowork-authorization/README.md
@@ -2,16 +2,16 @@
 
 ## 역할
 인증 서비스.
-
 - JWT 액세스 토큰 / 리프레시 토큰 발급 및 갱신
 - DataGSM OAuth2 PKCE 로그인
 - 회원가입 / 로그인 처리
 
 ## 스택
-TBD (Spring Boot + Java/Kotlin, .NET 등 팀 결정)
+- Go + Gin
+- GORM + MySQL
 
 ## 포트
 `8081`
 
-## DB
-MySQL — Flyway로 스키마 관리 (`db/migration/V1__init.sql`)
+## 의존성
+- Eureka Client

--- a/cowork-channel/README.md
+++ b/cowork-channel/README.md
@@ -2,38 +2,27 @@
 
 ## 역할
 팀 내 채널 관리 서비스.
-
-- 채널 생성/수정/삭제 (`type`은 TEXT/VOICE, `view_type`은 텍스트 외에 WEBHOOK/ACCOUNT_SHARE/FILE_SHARE/MEETING_NOTE 등 표현 분기)
-- 채널 멤버 관리 (공개 채널은 팀 멤버 누구나 합류, 비공개 채널은 채널 생성자/팀 OWNER·ADMIN만 추가 가능)
-- TEXT 채널 한정 웹훅/스레드 관리
-- 팀/유저 라이프사이클 이벤트(Kafka) 수신 후 채널·멤버십 정리
+- 채널 생성/수정/삭제 (TEXT/VOICE, view_type 분기)
+- 채널 멤버 관리, 웹훅/스레드 관리
+- 팀/유저 라이프사이클 이벤트 수신 후 채널·멤버십 정리
 
 ## 스택
 - Spring Boot 3 / Kotlin / Java 21
-- Spring Data JPA + MySQL, Flyway
-- Spring Cloud (Eureka, Config, OpenFeign + Resilience4j)
-- Spring Kafka (consumer, DLQ)
+- Spring Data JPA + MySQL + Flyway
+- Spring Cloud (Eureka, Config)
+- Spring Kafka
 
 ## 포트
 `8083`
 
-## DB
-MySQL — Flyway 관리.
-- `V1__init.sql` (immutable, 기존 스키마 유지)
-- `V2__align_with_spec.sql` 에서 `tb_channels`에 `view_type/description/is_private/created_by` 추가, `tb_channel_members/tb_webhooks/tb_threads` 신설, 기존 `tb_channel_roles` 제거
+## 의존성
+- Eureka, Config Server
+- Kafka consume: `team.lifecycle` (TEAM_DELETED, MEMBER_REMOVED), `user.lifecycle` (USER_DELETED)
 
-## 권한 모델
-- 채널 수정/삭제: 채널 생성자 OR 팀 OWNER/ADMIN
-- 멤버 추가: 공개 채널은 팀 멤버, 비공개는 채널 관리자
-- 멤버 제거: 본인 OR 채널 생성자 OR 팀 OWNER/ADMIN (단, 채널 생성자는 본인 제거 불가)
-- 웹훅: TEXT 채널에서만, 채널 생성자 OR 팀 OWNER/ADMIN
-- 스레드 수정: 작성자 OR 채널 생성자 OR 팀 OWNER/ADMIN
-
-팀 권한은 `cowork-team` Feign 호출(`TeamClient.getMembership`)로 조회하며, Resilience4j 서킷브레이커가 열리면 fail-closed.
-
-## Kafka
-구독 토픽:
-- `team.lifecycle` — `TEAM_DELETED` / `MEMBER_REMOVED` 처리
-- `user.lifecycle` — `USER_DELETED` 처리
-
-처리 실패 시 `DefaultErrorHandler` + `DeadLetterPublishingRecoverer`로 `<topic>.DLT`에 적재.
+## 환경변수
+| 변수 | 설명 |
+|---|---|
+| `SPRING_DATASOURCE_URL` | MySQL JDBC URL |
+| `MYSQL_USER` | MySQL 계정 |
+| `MYSQL_PASSWORD` | MySQL 비밀번호 |
+| `KAFKA_BOOTSTRAP_SERVERS` | Kafka 브로커 주소 |

--- a/cowork-chat/README.md
+++ b/cowork-chat/README.md
@@ -2,36 +2,28 @@
 
 ## 역할
 채팅 서비스.
-
-- 실시간 메시지 송수신 (WebSocket)
-- 채팅 메시지 저장 및 조회
-- MinIO presigned URL 기반 첨부파일 업로드 준비
-- Kafka: 메시지 이벤트 발행/소비 (`chat.message`, `notification.trigger`)
+- Socket.io 기반 실시간 메시지 송수신
+- 채팅 메시지 저장/조회
+- MinIO presigned URL 기반 첨부파일 업로드
 
 ## 스택
-TBD (NestJS, Go 등 팀 결정)
+- NestJS 11 + TypeScript
+- Socket.io
+- MongoDB (Mongoose)
+- KafkaJS
+- MinIO
 
 ## 포트
 `3000`
 
-## DB
-MongoDB (채팅 메시지 이력 저장)
+## 의존성
+- Kafka produce: `chat.message`, `notification.trigger`
+- MinIO (파일 업로드)
 
-## 파일 업로드
-
-`POST /chat/channels/{channelId}/files/presigned-url`
-
-- Gateway가 주입한 `X-User-Id` 기준으로 채널 멤버 여부를 확인한다.
-- 응답의 `uploadUrl`로 클라이언트가 MinIO에 직접 `PUT` 업로드한다.
-- 업로드 후 메시지 전송 시 `attachments.url`에는 응답의 `fileUrl`을 사용한다.
-- 기본 파일 크기 제한은 100MB다.
-- 기본 presigned URL 발급 제한은 사용자당 1분 20회다.
-
-필수 환경 변수:
-
-- `minio.endpoint`
-- `minio.accessKey`
-- `minio.secretKey`
-- `minio.bucket`
-
-대문자 환경 변수(`MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_BUCKET`)도 같이 지원한다.
+## 환경변수
+| 변수 | 설명 |
+|---|---|
+| `MINIO_ENDPOINT` | MinIO 엔드포인트 |
+| `MINIO_ACCESS_KEY` | MinIO 액세스 키 |
+| `MINIO_SECRET_KEY` | MinIO 시크릿 키 |
+| `MINIO_BUCKET` | MinIO 버킷명 |

--- a/cowork-chat/README.md
+++ b/cowork-chat/README.md
@@ -14,7 +14,7 @@
 - MinIO
 
 ## 포트
-`3000`
+`8087`
 
 ## 의존성
 - Kafka produce: `chat.message`, `notification.trigger`
@@ -23,7 +23,9 @@
 ## 환경변수
 | 변수 | 설명 |
 |---|---|
-| `MINIO_ENDPOINT` | MinIO 엔드포인트 |
+| `MONGODB_URI` | MongoDB 연결 URI |
+| `KAFKA_BOOTSTRAP_SERVERS` | Kafka 브로커 주소 |
+| `MINIO_INTERNAL_ENDPOINT` | MinIO 내부 엔드포인트 |
 | `MINIO_ACCESS_KEY` | MinIO 액세스 키 |
 | `MINIO_SECRET_KEY` | MinIO 시크릿 키 |
 | `MINIO_BUCKET` | MinIO 버킷명 |

--- a/cowork-config/README.md
+++ b/cowork-config/README.md
@@ -2,17 +2,17 @@
 
 ## 역할
 중앙화된 설정 서버 + 서비스 디스커버리.
-
-- **Spring Cloud Config Server**: 각 서비스의 설정 파일 외부화 제공
-- **Eureka Server**: 서비스 등록/조회 (Service Discovery)
-- 민감한 값(DB 패스워드, JWT 시크릿 등)은 환경변수 / GitHub Secrets로 주입
+- Spring Cloud Config Server: 각 서비스 설정 파일 외부화
+- Eureka Server: 서비스 등록/조회
 
 ## 스택
-Spring Boot + Spring Cloud Config Server + Spring Cloud Netflix Eureka Server
+- Spring Boot 3 / Kotlin / Java 21
+- Spring Cloud Config Server + Eureka Server
+- Spring Cloud Bus (Kafka)
+- Spring Vault
 
 ## 포트
 `8761`
 
-## 설정 파일 위치
-- 일반 설정: 레포지토리 내 `/config` 디렉터리 또는 별도 private repo
-- 민감 값: 환경변수 (`${ENV_VAR}` 참조)
+## 의존성
+없음 — 가장 먼저 기동해야 함

--- a/cowork-gateway/README.md
+++ b/cowork-gateway/README.md
@@ -2,19 +2,19 @@
 
 ## 역할
 API Gateway. 모든 외부 요청의 단일 진입점.
-
-- JWT 토큰 검증 및 `X-User-Id`, `X-User-Role` 헤더 하위 서비스 전달
+- JWT 검증 및 `X-User-Id`, `X-User-Role` 헤더 하위 서비스 전달
 - Eureka 기반 로드밸런싱 (`lb://cowork-{service}`)
+- Redis 기반 레이트리밋
 - CORS 전역 설정
-- 라우팅 규칙 관리
 
 ## 스택
-Spring Boot + Spring Cloud Gateway (Reactive)
+- Spring Boot 3 / Kotlin / Java 21
+- Spring Cloud Gateway (Reactive)
+- Spring Security + JWT (jjwt)
+- Redis (레이트리밋)
 
 ## 포트
 `8080`
 
 ## 의존성
-- Spring Cloud Gateway
-- Spring Cloud Netflix Eureka Client
-- Spring Cloud Config Client
+- Eureka Client, Config Client

--- a/cowork-monitoring/README.md
+++ b/cowork-monitoring/README.md
@@ -2,7 +2,6 @@
 
 ## 역할
 모니터링 스택 설정 모듈.
-
 - Prometheus 스크레이프 설정 관리
 - Grafana 프로비저닝 및 대시보드 관리
 
@@ -14,5 +13,5 @@
 - Prometheus: `9090`
 - Grafana: `3001`
 
-## 실행
-루트 `docker-compose.yml`에서 관리.
+## 의존성
+루트 `docker-compose.yml`에서 관리

--- a/cowork-notification/README.md
+++ b/cowork-notification/README.md
@@ -1,0 +1,34 @@
+# cowork-notification
+
+## 역할
+알림 서비스.
+- Kafka `notification.trigger` 이벤트 소비 후 FCM 푸시 알림 발송
+- SSE(Server-Sent Events) 기반 실시간 알림 스트림 제공
+
+## 스택
+- Go
+- Firebase FCM
+- MySQL + GORM
+- Eureka Client
+
+## 포트
+`8086`
+
+## 의존성
+- Eureka, Config Server
+- Kafka consume: `notification.trigger`
+- HTTP: `cowork-preference` (알림 설정 조회), `cowork-team`, `cowork-user`
+
+## 환경변수
+| 변수 | 설명 |
+|---|---|
+| `DB_DSN` | MySQL DSN |
+| `KAFKA_BROKERS` | Kafka 브로커 주소 |
+| `KAFKA_TOPIC_NOTIFICATION` | 구독 토픽명 |
+| `KAFKA_GROUP_ID` | 컨슈머 그룹 ID |
+| `FCM_CREDENTIALS_FILE` | Firebase 서비스 계정 키 파일 경로 |
+| `PREFERENCE_SERVICE_URL` | cowork-preference URL |
+| `TEAM_SERVICE_URL` | cowork-team URL |
+| `USER_SERVICE_URL` | cowork-user URL |
+| `APP_CONFIG_URL` | Config Server URL (선택) |
+| `APP_PROFILE` | 활성 프로파일 (선택) |

--- a/cowork-preference/README.md
+++ b/cowork-preference/README.md
@@ -1,0 +1,31 @@
+# cowork-preference
+
+## 역할
+사용자 알림 및 상태 설정 관리 서비스.
+- 알림 설정 (채널별, 팀별)
+- 계정 상태(온라인/자리비움 등) 관리 및 만료 처리
+- 팀/프로젝트 역할 설정 조회
+
+## 스택
+- Kotlin + Vert.x (Coroutines)
+- PostgreSQL + Flyway
+- Redis (설정 캐시)
+- Spring Kafka
+- Eureka Client
+
+## 포트
+`9001`
+
+## 의존성
+- Eureka, Config Server
+- Kafka produce: `preference.status.changed`, `preference.team.setting.changed`
+- Redis (캐시)
+
+## 환경변수
+| 변수 | 설명 |
+|---|---|
+| `preference.db.host` | PostgreSQL 호스트 |
+| `preference.db.username` | DB 계정 |
+| `preference.db.password` | DB 비밀번호 |
+| `preference.redis.host` | Redis 호스트 |
+| `preference.kafka.bootstrap-servers` | Kafka 브로커 주소 |

--- a/cowork-preference/README.md
+++ b/cowork-preference/README.md
@@ -24,8 +24,8 @@
 ## 환경변수
 | 변수 | 설명 |
 |---|---|
-| `preference.db.host` | PostgreSQL 호스트 |
-| `preference.db.username` | DB 계정 |
-| `preference.db.password` | DB 비밀번호 |
-| `preference.redis.host` | Redis 호스트 |
-| `preference.kafka.bootstrap-servers` | Kafka 브로커 주소 |
+| `POSTGRES_HOST` | PostgreSQL 호스트 |
+| `POSTGRES_USER` | DB 계정 |
+| `POSTGRES_PASSWORD` | DB 비밀번호 |
+| `REDIS_HOST` | Redis 호스트 |
+| `KAFKA_BOOTSTRAP_SERVERS` | Kafka 브로커 주소 |

--- a/cowork-project/README.md
+++ b/cowork-project/README.md
@@ -1,130 +1,27 @@
 # cowork-project
 
-프로젝트 관리 서비스. 팀 내에서 업무 단위인 "프로젝트"를 생성/관리하고 멤버에게 역할(OWNER/EDITOR/VIEWER)을 부여한다.
+## 역할
+프로젝트 관리 서비스.
+- 팀 내 프로젝트 생성/수정/삭제
+- 멤버 역할 관리 (OWNER / EDITOR / VIEWER)
 
 ## 스택
+- Spring Boot 3 / Kotlin / Java 21
+- Spring Data JPA + MySQL + Flyway
+- Spring Cloud (Eureka, Config)
+- Spring Kafka
 
-- Spring Boot 3.4.4 / Kotlin 2.1.20 / Java 21
-- Spring Data JPA + Flyway (MySQL 8.0)
-- Spring Cloud Eureka Client, Config Client
-- team.themoment.sdk (exception/swagger/logging)
+## 포트
+`8084`
 
-## 런타임
+## 의존성
+- Eureka, Config Server
+- Kafka consume: `team.lifecycle` (TEAM_DELETED, MEMBER_REMOVED), `user.lifecycle` (USER_DELETED)
 
-| 항목 | 값 |
-| --- | --- |
-| 포트 | `8084` |
-| 스키마 | `cowork_project` |
-| Swagger paths | `/projects/**` |
-| Eureka | `http://localhost:8761/eureka/` |
-
-## 도메인 모델
-
-### Project (`tb_projects`)
-| 컬럼 | 타입 | 설명 |
-| --- | --- | --- |
-| id | BIGINT PK | 자동증가 |
-| team_id | BIGINT | `cowork-team`의 팀 ID (FK 아님, MSA) |
-| name | VARCHAR(100) | 프로젝트명 |
-| description | VARCHAR(500) nullable | 설명 |
-| status | VARCHAR(20) | `ACTIVE` / `ARCHIVED` |
-| created_by | BIGINT | 생성자 user_id |
-| created_at, updated_at | DATETIME(6) | 자동 관리 |
-
-### ProjectMember (`tb_project_members`)
-| 컬럼 | 타입 | 설명 |
-| --- | --- | --- |
-| id | BIGINT PK | |
-| project_id | BIGINT FK→tb_projects ON DELETE CASCADE | |
-| user_id | BIGINT | `cowork-user` user_id |
-| role | VARCHAR(20) | `OWNER` / `EDITOR` / `VIEWER` |
-| joined_at | DATETIME(6) | |
-
-UNIQUE `(project_id, user_id)` — 한 유저는 한 프로젝트 내 한 멤버십만.
-
-## 권한 모델
-
-| 작업 | 권한 |
-| --- | --- |
-| 프로젝트 생성 | 모든 사용자 (생성자는 자동으로 OWNER) |
-| 프로젝트 수정 | OWNER, EDITOR |
-| 프로젝트 삭제 | OWNER |
-| 멤버 추가/역할 변경/제거 | OWNER |
-| 프로젝트 조회 | 인증된 사용자 (공개 조회) |
-
-**불변 규칙**
-- `OWNER` 역할은 멤버 추가(`addMember`)나 역할 변경(`updateMemberRole`)으로 부여할 수 없음 → 항상 `BAD_REQUEST`.
-- OWNER는 제거할 수 없음 (유일한 OWNER 상실 방지).
-- OWNER의 역할은 변경할 수 없음.
-
-## API
-
-모든 인증 엔드포인트는 Gateway가 주입하는 `X-User-Id: <Long>` 헤더를 요구한다.
-
-### Project
-
-| Method | Path | 권한 | 설명 |
-| --- | --- | --- | --- |
-| POST | `/projects` | 인증 | 프로젝트 생성 → 201 |
-| GET | `/projects/{id}` | - | 프로젝트 상세 (memberCount 포함) |
-| PATCH | `/projects/{id}` | OWNER/EDITOR | 이름/설명/상태 수정 |
-| DELETE | `/projects/{id}` | OWNER | 프로젝트 삭제 → 204 |
-| GET | `/projects?teamId={id}` | - | 팀의 프로젝트 목록 (페이징) |
-| GET | `/projects/me` | 인증 | 내가 참여 중인 프로젝트 (페이징, JOIN 단일쿼리) |
-
-### ProjectMember
-
-| Method | Path | 권한 | 설명 |
-| --- | --- | --- | --- |
-| POST | `/projects/{id}/members` | OWNER | 멤버 추가 → 201 |
-| GET | `/projects/{id}/members` | - | 멤버 목록 |
-| PATCH | `/projects/{id}/members/{memberId}` | OWNER | 역할 변경 |
-| DELETE | `/projects/{id}/members/{memberId}` | OWNER | 멤버 제거 → 204 |
-
-### 요청/응답 예시
-
-**POST `/projects`**
-```json
-// Request
-{ "teamId": 1, "name": "Q2 OKR", "description": "분기 목표 추적" }
-
-// Response 201
-{
-  "id": 10, "teamId": 1, "name": "Q2 OKR",
-  "description": "분기 목표 추적", "status": "ACTIVE",
-  "createdBy": 42,
-  "createdAt": "2026-04-14T10:00:00",
-  "updatedAt": "2026-04-14T10:00:00"
-}
-```
-
-**POST `/projects/10/members`**
-```json
-// Request
-{ "userId": 77, "role": "EDITOR" }
-```
-
-### 에러 응답
-
-`GlobalExceptionHandler`가 아래와 같이 평탄화된 포맷으로 응답한다.
-```json
-{ "message": "프로젝트를 찾을 수 없습니다. id=99" }
-```
-
-| 케이스 | HTTP |
-| --- | --- |
-| `ExpectedException` | 해당 status |
-| 잘못된 JSON 본문 | 400 |
-| 파라미터 타입 불일치 | 400 |
-| 필수 헤더 누락 | 400 |
-| 기타 | 500 |
-
-## 빌드 & 실행
-
-```bash
-# 컴파일
-./gradlew :cowork-project:compileKotlin
-
-# 실행 (MYSQL_USER/PASSWORD 환경변수 필요)
-./gradlew :cowork-project:bootRun
-```
+## 환경변수
+| 변수 | 설명 |
+|---|---|
+| `SPRING_DATASOURCE_URL` | MySQL JDBC URL |
+| `MYSQL_USER` | MySQL 계정 |
+| `MYSQL_PASSWORD` | MySQL 비밀번호 |
+| `KAFKA_BOOTSTRAP_SERVERS` | Kafka 브로커 주소 |

--- a/cowork-promotion/README.md
+++ b/cowork-promotion/README.md
@@ -1,14 +1,14 @@
 # cowork-promotion
 
 ## 역할
-cowork 프로모션 웹 사이트
-
+cowork 프로모션 웹사이트.
 
 ## 스택
-Nuxt.js + Vue.js, Tailwind CSS
+- Nuxt 3
+- Tailwind CSS
 
 ## 포트
 `3000`
 
-## DB
-`None`
+## 의존성
+없음

--- a/cowork-team/README.md
+++ b/cowork-team/README.md
@@ -2,16 +2,32 @@
 
 ## 역할
 팀 관리 서비스.
-
 - 팀 생성/수정/삭제
 - 팀 멤버 초대/탈퇴
-- Kafka: 팀 이벤트 발행 (`notification.trigger`)
+- 팀 프로필 이미지 (MinIO presigned URL)
 
 ## 스택
-TBD (Spring Boot + Java/Kotlin, .NET 등 팀 결정)
+- Spring Boot 3 / Kotlin / Java 21
+- Spring Data JPA + MySQL + Flyway
+- Spring Cloud (Eureka, Config, OpenFeign)
+- Spring Kafka
 
 ## 포트
 `8085`
 
-## DB
-MySQL — Flyway로 스키마 관리 (`db/migration/V1__init.sql`)
+## 의존성
+- Eureka, Config Server
+- Kafka produce: `notification.trigger`
+- MinIO (팀 프로필 이미지)
+
+## 환경변수
+| 변수 | 설명 |
+|---|---|
+| `SPRING_DATASOURCE_URL` | MySQL JDBC URL |
+| `MYSQL_USER` | MySQL 계정 |
+| `MYSQL_PASSWORD` | MySQL 비밀번호 |
+| `KAFKA_BOOTSTRAP_SERVERS` | Kafka 브로커 주소 |
+| `MINIO_ACCESS_KEY` | MinIO 액세스 키 |
+| `MINIO_SECRET_KEY` | MinIO 시크릿 키 |
+| `MINIO_INTERNAL_ENDPOINT` | MinIO 내부 엔드포인트 |
+| `MINIO_BUCKET` | MinIO 버킷명 |

--- a/cowork-user/README.md
+++ b/cowork-user/README.md
@@ -1,29 +1,28 @@
 # cowork-user
 
-Elixir 기반 사용자 관리 서비스.
-
 ## 역할
+사용자 계정/프로필 관리 서비스.
 - 사용자 계정/프로필 조회 및 수정
-- 사용자 검색
-- MinIO 기반 프로필 이미지 presigned URL 발급/확정
+- MinIO 기반 프로필 이미지 presigned URL 발급
 - Kafka `user.data.sync` 이벤트 소비
-- Eureka 등록 및 heartbeat
 
-## 런타임 계약
-- 포트: `8082`
-- Eureka 앱명: `cowork-user`
-- Health: `/actuator/health`
-- Metrics: `/actuator/prometheus`
-- OpenAPI: `/v3/api-docs`
-- Swagger UI: `/swagger-ui.html`
-- Config Server: `APP_CONFIG_URL` + `APP_PROFILE`
-- DB env: `DATABASE_URL`, `DB_JDBC_URL`, `DB_USERNAME`, `DB_PASSWORD`
+## 스택
+- Elixir
+- MySQL + Flyway
 
-## DB
-- MySQL
-- 기존 Flyway 이력과 테이블 유지
-- 기동 시 `flyway migrate` 자동 실행
+## 포트
+`8082`
 
-## 로컬 검증 메모
-- `docker compose` 기준으로 `user.data.sync` 토픽 생성 후 Kafka 소비까지 검증됨
-- 검증 payload는 `user_id`, `name`, `email`, `sex`, `major` 등 기존 sync 필드를 수용
+## 의존성
+- Eureka, Config Server
+- Kafka consume: `user.data.sync`
+- MinIO (프로필 이미지)
+
+## 환경변수
+| 변수 | 설명 |
+|---|---|
+| `DATABASE_URL` | MySQL URL |
+| `DB_USERNAME` | MySQL 계정 |
+| `DB_PASSWORD` | MySQL 비밀번호 |
+| `APP_CONFIG_URL` | Config Server URL |
+| `APP_PROFILE` | 활성 프로파일 |

--- a/cowork-voice/README.md
+++ b/cowork-voice/README.md
@@ -11,7 +11,15 @@
 - MongoDB
 
 ## 포트
-`9000`
+`8084`
 
 ## 의존성
 - Kafka produce: `voice.session.event`
+
+## 환경변수
+| 변수 | 설명 |
+|---|---|
+| `MONGODB_URI` | MongoDB 연결 URI |
+| `LIVEKIT_API_KEY` | LiveKit API 키 |
+| `LIVEKIT_API_SECRET` | LiveKit API 시크릿 |
+| `KAFKA_BROKERS` | Kafka 브로커 주소 |

--- a/cowork-voice/README.md
+++ b/cowork-voice/README.md
@@ -2,17 +2,16 @@
 
 ## 역할
 음성 채널 서비스.
-
 - 음성 세션 생성/종료
 - 음성 채널 참여자 관리
-- Kafka: 음성 세션 이벤트 발행 (`voice.session.event`)
 
 ## 스택
 - Go
 - LiveKit
+- MongoDB
 
 ## 포트
 `9000`
 
-## DB
-MongoDB (음성 세션 로그 / 메타데이터)
+## 의존성
+- Kafka produce: `voice.session.event`


### PR DESCRIPTION
## 개요

전체 서비스의 README 문서를 최신화하고 구조를 표준화하였습니다.

## 본문

- 모든 서비스의 README 형식을 역할, 스택, 포트, 의존성, 환경변수 섹션으로 통일하였습니다.
- cowork-notification 및 cowork-preference 서비스의 README를 신규 추가하였습니다.
- 각 서비스별 실제 구현 스택과 환경변수 정보를 최신 상태로 업데이트하였습니다.
- 불필요하거나 중복된 도메인 상세 설명을 제거하여 가독성을 높였습니다.