### PR TITLE
[global] 의존성 선언 방식을 버전 카탈로그로 통일

### DIFF
--- a/cowork-channel/build.gradle.kts
+++ b/cowork-channel/build.gradle.kts
@@ -26,18 +26,18 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.actuator)
     implementation(libs.micrometer.registry.prometheus)
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
-    implementation("org.springframework.cloud:spring-cloud-starter-config")
-    implementation("org.springframework.kafka:spring-kafka")
+    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.spring.cloud.starter.netflix.eureka.client)
+    implementation(libs.spring.cloud.starter.config)
+    implementation(libs.spring.kafka)
 
-    implementation("com.mysql:mysql-connector-j")
-    implementation("org.flywaydb:flyway-core")
-    implementation("org.flywaydb:flyway-mysql")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation(libs.mysql.connector.j)
+    implementation(libs.flyway.core)
+    implementation(libs.flyway.mysql)
+    implementation(libs.kotlin.reflect)
 
     implementation(libs.the.sdk) {
         exclude(group = "org.springframework.boot")
@@ -47,7 +47,7 @@ dependencies {
     implementation(libs.springdoc.openapi.webmvc.ui)
     implementation(libs.logstash.logback.encoder)
 
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.mockk)
 }
 
@@ -60,4 +60,3 @@ kotlin {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
-

--- a/cowork-config/build.gradle.kts
+++ b/cowork-config/build.gradle.kts
@@ -21,16 +21,16 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation("org.springframework.cloud:spring-cloud-config-server")
-    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-server")
-    implementation("org.springframework.cloud:spring-cloud-starter-bus-kafka")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(libs.spring.cloud.config.server)
+    implementation(libs.spring.cloud.starter.netflix.eureka.server)
+    implementation(libs.spring.cloud.starter.bus.kafka)
+    implementation(libs.spring.boot.starter.actuator)
     implementation(libs.micrometer.registry.prometheus)
-    implementation("org.springframework.vault:spring-vault-core")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation(libs.spring.vault.core)
+    implementation(libs.kotlin.reflect)
 
     implementation(libs.logstash.logback.encoder)
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(libs.spring.boot.starter.test)
 }
 
 kotlin {

--- a/cowork-gateway/build.gradle.kts
+++ b/cowork-gateway/build.gradle.kts
@@ -21,24 +21,24 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation("org.springframework.cloud:spring-cloud-starter-gateway")
-    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
-    implementation("org.springframework.cloud:spring-cloud-starter-config")
-    implementation("org.springframework.retry:spring-retry")
-    implementation("org.springframework.cloud:spring-cloud-starter-bus-kafka")
-    implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j")
-    implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(libs.spring.cloud.starter.gateway)
+    implementation(libs.spring.cloud.starter.netflix.eureka.client)
+    implementation(libs.spring.cloud.starter.config)
+    implementation(libs.spring.retry)
+    implementation(libs.spring.cloud.starter.bus.kafka)
+    implementation(libs.spring.cloud.starter.circuitbreaker.reactor.resilience4j)
+    implementation(libs.spring.boot.starter.security)
+    implementation(libs.spring.boot.starter.actuator)
     implementation(libs.micrometer.registry.prometheus)
-    implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
+    implementation(libs.spring.boot.starter.data.redis.reactive)
     implementation(libs.jjwt.api)
     runtimeOnly(libs.jjwt.impl)
     runtimeOnly(libs.jjwt.jackson)
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation(libs.kotlin.reflect)
     implementation(libs.springdoc.openapi.webflux.ui)
 
     implementation(libs.logstash.logback.encoder)
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(libs.spring.boot.starter.test)
 }
 
 kotlin {

--- a/cowork-preference/build.gradle.kts
+++ b/cowork-preference/build.gradle.kts
@@ -10,23 +10,20 @@ java {
     toolchain { languageVersion = JavaLanguageVersion.of(21) }
 }
 
-val vertxVersion = libs.versions.vertx.get()
-val coroutinesVersion = libs.versions.coroutines.get()
-
 dependencies {
-    implementation(platform("io.vertx:vertx-stack-depchain:$vertxVersion"))
-    implementation("io.vertx:vertx-core")
-    implementation("io.vertx:vertx-web")
-    implementation("io.vertx:vertx-lang-kotlin")
-    implementation("io.vertx:vertx-lang-kotlin-coroutines")
-    implementation("io.vertx:vertx-config")
-    implementation("io.vertx:vertx-pg-client")
-    implementation("com.ongres.scram:client:2.1")
-    implementation("io.vertx:vertx-redis-client")
-    implementation("io.vertx:vertx-kafka-client")
-    implementation("io.vertx:vertx-service-discovery")
-    implementation("io.vertx:vertx-micrometer-metrics")
-    implementation("io.micrometer:micrometer-registry-prometheus:1.12.13")
+    implementation(platform(libs.vertx.stack.depchain))
+    implementation(libs.vertx.core)
+    implementation(libs.vertx.web)
+    implementation(libs.vertx.lang.kotlin)
+    implementation(libs.vertx.lang.kotlin.coroutines)
+    implementation(libs.vertx.config)
+    implementation(libs.vertx.pg.client)
+    implementation(libs.scram.client)
+    implementation(libs.vertx.redis.client)
+    implementation(libs.vertx.kafka.client)
+    implementation(libs.vertx.service.discovery)
+    implementation(libs.vertx.micrometer.metrics)
+    implementation(libs.micrometer.registry.prometheus)
     implementation(libs.eureka.client)
 
     // Flyway (JDBC, 시작 시 블로킹 실행)
@@ -35,15 +32,15 @@ dependencies {
     implementation(libs.postgresql)
 
     // JSON 로깅
-    implementation("org.apache.logging.log4j:log4j-core:2.24.3")
-    implementation("org.apache.logging.log4j:log4j-layout-template-json:2.24.3")
-    implementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3")
+    implementation(libs.log4j.core)
+    implementation(libs.log4j.layout.template.json)
+    implementation(libs.log4j.slf4j2.impl)
 
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutinesVersion")
+    implementation(libs.kotlin.reflect)
+    implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(kotlin("test"))
-    testImplementation("io.vertx:vertx-junit5:$vertxVersion")
+    testImplementation(libs.vertx.junit5)
 }
 
 application {

--- a/cowork-preference/build.gradle.kts
+++ b/cowork-preference/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(libs.vertx.kafka.client)
     implementation(libs.vertx.service.discovery)
     implementation(libs.vertx.micrometer.metrics)
-    implementation(libs.micrometer.registry.prometheus)
+    implementation(libs.micrometer.registry.prometheus.simpleclient)
     implementation(libs.eureka.client)
 
     // Flyway (JDBC, 시작 시 블로킹 실행)

--- a/cowork-project/build.gradle.kts
+++ b/cowork-project/build.gradle.kts
@@ -26,18 +26,18 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.actuator)
     implementation(libs.micrometer.registry.prometheus)
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
-    implementation("org.springframework.cloud:spring-cloud-starter-config")
-    implementation("org.springframework.kafka:spring-kafka")
+    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.spring.cloud.starter.netflix.eureka.client)
+    implementation(libs.spring.cloud.starter.config)
+    implementation(libs.spring.kafka)
 
-    implementation("com.mysql:mysql-connector-j")
-    implementation("org.flywaydb:flyway-core")
-    implementation("org.flywaydb:flyway-mysql")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation(libs.mysql.connector.j)
+    implementation(libs.flyway.core)
+    implementation(libs.flyway.mysql)
+    implementation(libs.kotlin.reflect)
 
     implementation(libs.the.sdk) {
         exclude(group = "org.springframework.boot")
@@ -47,8 +47,8 @@ dependencies {
     implementation(libs.springdoc.openapi.webmvc.ui)
     implementation(libs.logstash.logback.encoder)
 
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.springframework.kafka:spring-kafka-test")
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.kafka.test)
     testImplementation(libs.mockk)
 }
 

--- a/cowork-team/build.gradle.kts
+++ b/cowork-team/build.gradle.kts
@@ -27,18 +27,18 @@ dependencyManagement {
 }
 
 dependencies {
-    implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.actuator)
     implementation(libs.micrometer.registry.prometheus)
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.cloud:spring-cloud-starter-netflix-eureka-client")
-    implementation("org.springframework.cloud:spring-cloud-starter-config")
+    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.spring.cloud.starter.netflix.eureka.client)
+    implementation(libs.spring.cloud.starter.config)
     implementation(libs.spring.cloud.starter.openfeign)
-    implementation("org.springframework.kafka:spring-kafka")
-    implementation("com.mysql:mysql-connector-j")
-    implementation("org.flywaydb:flyway-core")
-    implementation("org.flywaydb:flyway-mysql")
-    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation(libs.spring.kafka)
+    implementation(libs.mysql.connector.j)
+    implementation(libs.flyway.core)
+    implementation(libs.flyway.mysql)
+    implementation(libs.kotlin.reflect)
     implementation(libs.the.sdk) {
         exclude(group = "org.springframework.boot")
         exclude(group = "org.springframework.cloud")
@@ -48,7 +48,7 @@ dependencies {
 
     implementation(libs.awspring.cloud.s3)
     implementation(libs.logstash.logback.encoder)
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.mockk)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ awspring-cloud = "3.4.0"
 vertx = "4.5.10"
 coroutines = "1.8.1"
 jjwt = "0.12.6"
+scram = "2.1"
+log4j = "2.24.3"
 springdoc-webflux = "2.8.8"
 springdoc-webmvc = "2.8.17"
 the-sdk = "1.5"
@@ -21,16 +23,43 @@ micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-p
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
+spring-boot-starter-data-redis-reactive = { module = "org.springframework.boot:spring-boot-starter-data-redis-reactive" }
+spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 spring-cloud-dependencies = { module = "org.springframework.cloud:spring-cloud-dependencies", version.ref = "spring-cloud" }
+spring-cloud-config-server = { module = "org.springframework.cloud:spring-cloud-config-server" }
 spring-cloud-starter-netflix-eureka-client = { module = "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client" }
+spring-cloud-starter-netflix-eureka-server = { module = "org.springframework.cloud:spring-cloud-starter-netflix-eureka-server" }
 spring-cloud-starter-config = { module = "org.springframework.cloud:spring-cloud-starter-config" }
+spring-cloud-starter-gateway = { module = "org.springframework.cloud:spring-cloud-starter-gateway" }
+spring-cloud-starter-bus-kafka = { module = "org.springframework.cloud:spring-cloud-starter-bus-kafka" }
+spring-cloud-starter-circuitbreaker-reactor-resilience4j = { module = "org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j" }
 spring-cloud-starter-openfeign = { module = "org.springframework.cloud:spring-cloud-starter-openfeign" }
+spring-retry = { module = "org.springframework.retry:spring-retry" }
 spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
+spring-kafka-test = { module = "org.springframework.kafka:spring-kafka-test" }
+spring-vault-core = { module = "org.springframework.vault:spring-vault-core" }
 mysql-connector-j = { module = "com.mysql:mysql-connector-j" }
 awspring-cloud-bom = { module = "io.awspring.cloud:spring-cloud-aws-dependencies", version.ref = "awspring-cloud" }
 awspring-cloud-s3 = { module = "io.awspring.cloud:spring-cloud-aws-starter-s3" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+vertx-stack-depchain = { module = "io.vertx:vertx-stack-depchain", version.ref = "vertx" }
+vertx-core = { module = "io.vertx:vertx-core" }
+vertx-web = { module = "io.vertx:vertx-web" }
+vertx-lang-kotlin = { module = "io.vertx:vertx-lang-kotlin" }
+vertx-lang-kotlin-coroutines = { module = "io.vertx:vertx-lang-kotlin-coroutines" }
+vertx-config = { module = "io.vertx:vertx-config" }
+vertx-pg-client = { module = "io.vertx:vertx-pg-client" }
+vertx-redis-client = { module = "io.vertx:vertx-redis-client" }
+vertx-kafka-client = { module = "io.vertx:vertx-kafka-client" }
+vertx-service-discovery = { module = "io.vertx:vertx-service-discovery" }
+vertx-micrometer-metrics = { module = "io.vertx:vertx-micrometer-metrics" }
+vertx-junit5 = { module = "io.vertx:vertx-junit5", version.ref = "vertx" }
+scram-client = { module = "com.ongres.scram:client", version.ref = "scram" }
+log4j-core = { module = "org.apache.logging.log4j:log4j-core", version.ref = "log4j" }
+log4j-layout-template-json = { module = "org.apache.logging.log4j:log4j-layout-template-json", version.ref = "log4j" }
+log4j-slf4j2-impl = { module = "org.apache.logging.log4j:log4j-slf4j2-impl", version.ref = "log4j" }
 jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
 jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
 jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,10 +18,19 @@ mockk = "1.13.13"
 
 [libraries]
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
+spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
+spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
+spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
 spring-cloud-dependencies = { module = "org.springframework.cloud:spring-cloud-dependencies", version.ref = "spring-cloud" }
+spring-cloud-starter-netflix-eureka-client = { module = "org.springframework.cloud:spring-cloud-starter-netflix-eureka-client" }
+spring-cloud-starter-config = { module = "org.springframework.cloud:spring-cloud-starter-config" }
 spring-cloud-starter-openfeign = { module = "org.springframework.cloud:spring-cloud-starter-openfeign" }
+spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
+mysql-connector-j = { module = "com.mysql:mysql-connector-j" }
 awspring-cloud-bom = { module = "io.awspring.cloud:spring-cloud-aws-dependencies", version.ref = "awspring-cloud" }
 awspring-cloud-s3 = { module = "io.awspring.cloud:spring-cloud-aws-starter-s3" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
 jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
 jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }
@@ -30,6 +39,7 @@ springdoc-openapi-webmvc-ui = { module = "org.springdoc:springdoc-openapi-starte
 the-sdk = { module = "com.github.themoment-team:the-sdk", version.ref = "the-sdk" }
 eureka-client = { module = "com.netflix.eureka:eureka-client", version.ref = "eureka-client" }
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
+flyway-mysql = { module = "org.flywaydb:flyway-mysql", version.ref = "flyway" }
 flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstash-logback" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ mockk = "1.13.13"
 
 [libraries]
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
+micrometer-registry-prometheus-simpleclient = { module = "io.micrometer:micrometer-registry-prometheus-simpleclient", version.ref = "micrometer" }
 spring-boot-starter-web = { module = "org.springframework.boot:spring-boot-starter-web" }
 spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }


### PR DESCRIPTION
## 개요

`cowork-team` 모듈의 `build.gradle.kts`에 하드코딩되어 있던 의존성 문자열을 Gradle 버전 카탈로그(`libs.versions.toml`) 참조 방식으로 전환하였습니다. 이와 함께 버전 카탈로그에 누락된 라이브러리 항목을 추가하였습니다.

## 본문

### 변경 내용

**`cowork-team/build.gradle.kts`**
- 하드코딩 문자열(`"org.springframework.boot:spring-boot-starter-web"` 등) → `libs.xxx` 참조 형식으로 전환

전환된 의존성 목록은 다음과 같습니다.
- `spring-boot-starter-web`
- `spring-boot-starter-actuator`
- `spring-boot-starter-data-jpa`
- `spring-boot-starter-test`
- `spring-cloud-starter-netflix-eureka-client`
- `spring-cloud-starter-config`
- `spring-kafka`
- `mysql-connector-j`
- `flyway-core`
- `flyway-mysql`
- `kotlin-reflect`

**`gradle/libs.versions.toml`**
- 위 의존성에 해당하는 라이브러리 항목 10개를 `[libraries]` 섹션에 추가하였습니다.

### 목적

프로젝트 전체에서 의존성 선언 방식을 버전 카탈로그로 통일하여 일관성을 확보하고, 향후 버전 관리를 단일 파일(`libs.versions.toml`)에서 일괄적으로 처리할 수 있도록 개선하였습니다.