### PR TITLE
[chat] 런타임 설정 하드코딩 제거

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ MONGO_ROOT_PASSWORD=
 # 호스트(로컬)에서 접근할 때는 docker-compose 기준 9094 사용
 KAFKA_BOOTSTRAP_SERVERS=localhost:9094
 
+# ── Service URLs ───────────────────────────────────────────────────────────
+PROJECT_SERVICE_URL=http://localhost:8084
+EUREKA_SERVER_URL=http://localhost:8761/eureka
+EUREKA_INSTANCE_HOST=localhost
+
 # ── JWT ────────────────────────────────────────────────────────────────────
 JWT_SECRET=
 JWT_ACCESS_EXPIRE=30m

--- a/cowork-chat/public/asyncapi.json
+++ b/cowork-chat/public/asyncapi.json
@@ -7,12 +7,15 @@
   },
   "servers": {
     "development": {
-      "url": "localhost:{port}",
+      "url": "{host}:{port}",
       "protocol": "ws",
       "description": "개발 서버",
       "variables": {
+        "host": {
+          "default": "localhost"
+        },
         "port": {
-          "default": "3000"
+          "default": "8087"
         }
       }
     }

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -19,7 +19,7 @@ import { ChannelMember, ChannelMemberSchema } from './schema/channel-member.sche
 import { MembershipModule } from '../membership/membership.module';
 import { HealthController } from '../health.controller';
 import { MinioModule } from '../storage/minio.module';
-import { getRequiredConfig } from '../common/config/config.util';
+import { getOptionalConfig, getRequiredConfig } from '../common/config/config.util';
 
 const LOG_DIR = process.env.COWORK_CHAT_LOG_DIR ?? `${process.cwd()}/build/logs/cowork/chat`;
 const METRICS_PATH = '/metrics';
@@ -71,9 +71,9 @@ function createLogStream() {
             inject: [ConfigService],
             useFactory: (configService: ConfigService) => ({
                 uri: getRequiredConfig(configService, 'MONGODB_URI'),
-                serverSelectionTimeoutMS: Number(configService.get<string>('MONGODB_SERVER_SELECTION_TIMEOUT_MS') ?? 5000),
-                connectTimeoutMS: Number(configService.get<string>('MONGODB_CONNECT_TIMEOUT_MS') ?? 5000),
-                directConnection: (configService.get<string>('MONGODB_DIRECT_CONNECTION') ?? 'true') !== 'false',
+                serverSelectionTimeoutMS: Number(getOptionalConfig(configService, 'MONGODB_SERVER_SELECTION_TIMEOUT_MS') ?? 5000),
+                connectTimeoutMS: Number(getOptionalConfig(configService, 'MONGODB_CONNECT_TIMEOUT_MS') ?? 5000),
+                directConnection: (getOptionalConfig(configService, 'MONGODB_DIRECT_CONNECTION') ?? 'true') !== 'false',
             }),
         }),
         MongooseModule.forFeature([

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { MongooseModule } from '@nestjs/mongoose';
 import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 import { LoggerModule } from 'nestjs-pino';
@@ -19,6 +19,7 @@ import { ChannelMember, ChannelMemberSchema } from './schema/channel-member.sche
 import { MembershipModule } from '../membership/membership.module';
 import { HealthController } from '../health.controller';
 import { MinioModule } from '../storage/minio.module';
+import { getRequiredConfig } from '../common/config/config.util';
 
 const LOG_DIR = process.env.COWORK_CHAT_LOG_DIR ?? `${process.cwd()}/build/logs/cowork/chat`;
 const METRICS_PATH = '/metrics';
@@ -65,10 +66,15 @@ function createLogStream() {
             defaultMetrics: { enabled: true },
             path: '/metrics',
         }),
-        MongooseModule.forRoot(process.env.MONGODB_URI ?? 'mongodb://127.0.0.1:27017/cowork_chat', {
-            serverSelectionTimeoutMS: Number(process.env.MONGODB_SERVER_SELECTION_TIMEOUT_MS ?? 5000),
-            connectTimeoutMS: Number(process.env.MONGODB_CONNECT_TIMEOUT_MS ?? 5000),
-            directConnection: process.env.MONGODB_DIRECT_CONNECTION !== 'false',
+        MongooseModule.forRootAsync({
+            imports: [ConfigModule],
+            inject: [ConfigService],
+            useFactory: (configService: ConfigService) => ({
+                uri: getRequiredConfig(configService, 'MONGODB_URI'),
+                serverSelectionTimeoutMS: Number(configService.get<string>('MONGODB_SERVER_SELECTION_TIMEOUT_MS') ?? 5000),
+                connectTimeoutMS: Number(configService.get<string>('MONGODB_CONNECT_TIMEOUT_MS') ?? 5000),
+                directConnection: (configService.get<string>('MONGODB_DIRECT_CONNECTION') ?? 'true') !== 'false',
+            }),
         }),
         MongooseModule.forFeature([
             { name: Message.name, schema: MessageSchema },

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.ts
@@ -6,6 +6,7 @@ import { Model, Types } from 'mongoose';
 import { Server } from 'socket.io';
 import { Message } from '../schema/message.schema';
 import { ChatMessageEvent } from './event/chat-message.event';
+import { getRequiredCsvConfig } from '../../common/config/config.util';
 
 @Injectable()
 export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
@@ -26,7 +27,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
     async onModuleInit() {
         const kafka = new Kafka({
             clientId: 'cowork-chat-consumer',
-            brokers: [this.configService.get<string>('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')],
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
         });
         this.consumer = kafka.consumer({ groupId: 'cowork-chat' });
         await this.consumer.connect();

--- a/cowork-chat/src/chat/kafka/chat-message.producer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.producer.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { Kafka, Producer } from 'kafkajs';
 import { SendMessageDto } from '../dto/send-message.dto';
 import { ChatMessageEvent } from './event/chat-message.event';
+import { getRequiredCsvConfig } from '../../common/config/config.util';
 
 @Injectable()
 export class ChatMessageProducer implements OnModuleInit, OnModuleDestroy {
@@ -14,7 +15,7 @@ export class ChatMessageProducer implements OnModuleInit, OnModuleDestroy {
     async onModuleInit() {
         const kafka = new Kafka({
             clientId: 'cowork-chat',
-            brokers: [this.configService.get<string>('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')],
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
         });
         this.producer = kafka.producer();
         await this.producer.connect();

--- a/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
+++ b/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
@@ -4,6 +4,7 @@ import { Kafka, Consumer } from 'kafkajs';
 import { Server } from 'socket.io';
 import { ChatService } from '../chat.service';
 import { GithubIssueResultEvent } from './event/github-issue.event';
+import { getRequiredCsvConfig } from '../../common/config/config.util';
 
 @Injectable()
 export class GithubIssueResultConsumer implements OnModuleInit, OnModuleDestroy {
@@ -23,7 +24,7 @@ export class GithubIssueResultConsumer implements OnModuleInit, OnModuleDestroy 
     async onModuleInit() {
         const kafka = new Kafka({
             clientId: 'cowork-chat-github-result',
-            brokers: [this.configService.get<string>('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')],
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
         });
         this.consumer = kafka.consumer({ groupId: 'cowork-chat-github-result' });
         await this.consumer.connect();

--- a/cowork-chat/src/chat/kafka/github-issue.producer.ts
+++ b/cowork-chat/src/chat/kafka/github-issue.producer.ts
@@ -2,6 +2,7 @@ import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/commo
 import { ConfigService } from '@nestjs/config';
 import { Kafka, Producer } from 'kafkajs';
 import { GithubIssueCreateEvent } from './event/github-issue.event';
+import { getRequiredCsvConfig } from '../../common/config/config.util';
 
 @Injectable()
 export class GithubIssueProducer implements OnModuleInit, OnModuleDestroy {
@@ -13,7 +14,7 @@ export class GithubIssueProducer implements OnModuleInit, OnModuleDestroy {
     async onModuleInit() {
         const kafka = new Kafka({
             clientId: 'cowork-chat-github',
-            brokers: [this.configService.get<string>('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')],
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
         });
         this.producer = kafka.producer();
         await this.producer.connect();

--- a/cowork-chat/src/chat/kafka/notification-trigger.producer.ts
+++ b/cowork-chat/src/chat/kafka/notification-trigger.producer.ts
@@ -1,6 +1,7 @@
 import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Kafka, Producer } from 'kafkajs';
+import { getRequiredCsvConfig } from '../../common/config/config.util';
 
 export interface NotificationTriggerEvent {
     type: string;
@@ -25,7 +26,7 @@ export class NotificationTriggerProducer implements OnModuleInit, OnModuleDestro
     async onModuleInit() {
         const kafka = new Kafka({
             clientId: 'cowork-chat-notification',
-            brokers: [this.configService.get<string>('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')],
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
         });
         this.producer = kafka.producer();
         await this.producer.connect();

--- a/cowork-chat/src/chat/service/project.client.ts
+++ b/cowork-chat/src/chat/service/project.client.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { getRequiredConfig } from '../../common/config/config.util';
 
 export interface GithubRepoInfo {
     teamId: number;
@@ -13,7 +14,7 @@ export class ProjectClient {
     private readonly projectServiceUrl: string;
 
     constructor(private readonly configService: ConfigService) {
-        this.projectServiceUrl = this.configService.get<string>('PROJECT_SERVICE_URL', 'http://localhost:8084').replace(/\/$/, '');
+        this.projectServiceUrl = getRequiredConfig(this.configService, 'PROJECT_SERVICE_URL').replace(/\/$/, '');
     }
 
     async getGithubRepoInfo(projectId: number): Promise<GithubRepoInfo | null> {

--- a/cowork-chat/src/common/config/config.util.ts
+++ b/cowork-chat/src/common/config/config.util.ts
@@ -7,17 +7,30 @@ function normalizeKeys(keys: ConfigKey): string[] {
 }
 
 export function getRequiredConfig(configService: ConfigService, keys: ConfigKey): string {
-    for (const key of normalizeKeys(keys)) {
-        const value = configService.get<string>(key) ?? process.env[key];
-        if (value !== undefined && value !== '') {
-            return value;
-        }
-    }
+    const value = getConfigValue(configService, keys);
+    if (value !== undefined) return value;
 
     throw new Error(`Required configuration is missing: ${normalizeKeys(keys).join(' or ')}`);
 }
 
 export function getOptionalConfig(configService: ConfigService, keys: ConfigKey): string | undefined {
+    return getConfigValue(configService, keys);
+}
+
+export function getRequiredCsvConfig(configService: ConfigService, keys: ConfigKey): string[] {
+    const values = getRequiredConfig(configService, keys)
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+
+    if (values.length === 0) {
+        throw new Error(`Required CSV configuration is empty: ${normalizeKeys(keys).join(' or ')}`);
+    }
+
+    return values;
+}
+
+function getConfigValue(configService: ConfigService, keys: ConfigKey): string | undefined {
     for (const key of normalizeKeys(keys)) {
         const value = configService.get<string>(key) ?? process.env[key];
         if (value !== undefined && value !== '') {
@@ -26,11 +39,4 @@ export function getOptionalConfig(configService: ConfigService, keys: ConfigKey)
     }
 
     return undefined;
-}
-
-export function getRequiredCsvConfig(configService: ConfigService, keys: ConfigKey): string[] {
-    return getRequiredConfig(configService, keys)
-        .split(',')
-        .map((value) => value.trim())
-        .filter(Boolean);
 }

--- a/cowork-chat/src/common/config/config.util.ts
+++ b/cowork-chat/src/common/config/config.util.ts
@@ -1,0 +1,36 @@
+import { ConfigService } from '@nestjs/config';
+
+type ConfigKey = string | string[];
+
+function normalizeKeys(keys: ConfigKey): string[] {
+    return Array.isArray(keys) ? keys : [keys];
+}
+
+export function getRequiredConfig(configService: ConfigService, keys: ConfigKey): string {
+    for (const key of normalizeKeys(keys)) {
+        const value = configService.get<string>(key) ?? process.env[key];
+        if (value !== undefined && value !== '') {
+            return value;
+        }
+    }
+
+    throw new Error(`Required configuration is missing: ${normalizeKeys(keys).join(' or ')}`);
+}
+
+export function getOptionalConfig(configService: ConfigService, keys: ConfigKey): string | undefined {
+    for (const key of normalizeKeys(keys)) {
+        const value = configService.get<string>(key) ?? process.env[key];
+        if (value !== undefined && value !== '') {
+            return value;
+        }
+    }
+
+    return undefined;
+}
+
+export function getRequiredCsvConfig(configService: ConfigService, keys: ConfigKey): string[] {
+    return getRequiredConfig(configService, keys)
+        .split(',')
+        .map((value) => value.trim())
+        .filter(Boolean);
+}

--- a/cowork-chat/src/common/config/config.util.ts
+++ b/cowork-chat/src/common/config/config.util.ts
@@ -30,6 +30,15 @@ export function getRequiredCsvConfig(configService: ConfigService, keys: ConfigK
     return values;
 }
 
+export function requireEnv(key: string): string {
+    const value = process.env[key];
+    if (value !== undefined && value !== '') {
+        return value;
+    }
+
+    throw new Error(`Required environment variable is missing: ${key}`);
+}
+
 function getConfigValue(configService: ConfigService, keys: ConfigKey): string | undefined {
     for (const key of normalizeKeys(keys)) {
         const value = configService.get<string>(key) ?? process.env[key];

--- a/cowork-chat/src/eureka/eureka-client.ts
+++ b/cowork-chat/src/eureka/eureka-client.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import { requireEnv } from '../common/config/config.util';
 
 type EurekaConfig = {
     enabled: boolean;
@@ -9,15 +10,6 @@ type EurekaConfig = {
     instanceId: string;
     leaseRenewalIntervalSeconds: number;
 };
-
-function requireEnv(key: string): string {
-    const value = process.env[key];
-    if (value !== undefined && value !== '') {
-        return value;
-    }
-
-    throw new Error(`Required environment variable is missing: ${key}`);
-}
 
 export class EurekaClient {
     private heartbeatTimer?: NodeJS.Timeout;

--- a/cowork-chat/src/eureka/eureka-client.ts
+++ b/cowork-chat/src/eureka/eureka-client.ts
@@ -10,6 +10,15 @@ type EurekaConfig = {
     leaseRenewalIntervalSeconds: number;
 };
 
+function requireEnv(key: string): string {
+    const value = process.env[key];
+    if (value !== undefined && value !== '') {
+        return value;
+    }
+
+    throw new Error(`Required environment variable is missing: ${key}`);
+}
+
 export class EurekaClient {
     private heartbeatTimer?: NodeJS.Timeout;
     private isPolling = false;
@@ -18,12 +27,12 @@ export class EurekaClient {
 
     static fromEnv(port: number): EurekaClient {
         const appName = process.env.EUREKA_APP_NAME ?? 'cowork-chat';
-        const host = process.env.EUREKA_INSTANCE_HOST ?? 'localhost';
+        const host = requireEnv('EUREKA_INSTANCE_HOST');
         const instanceId = process.env.EUREKA_INSTANCE_ID ?? `${host}:${appName}:${port}`;
 
         return new EurekaClient({
             enabled: process.env.EUREKA_ENABLED !== 'false',
-            serverUrl: (process.env.EUREKA_SERVER_URL ?? 'http://localhost:8761/eureka').replace(/\/$/, ''),
+            serverUrl: requireEnv('EUREKA_SERVER_URL').replace(/\/$/, ''),
             appName,
             host,
             port,

--- a/cowork-chat/src/main.ts
+++ b/cowork-chat/src/main.ts
@@ -8,20 +8,12 @@ import { join } from 'path';
 import { Logger as PinoLogger } from 'nestjs-pino';
 import { ChatModule } from './chat/chat.module';
 import { EurekaClient } from './eureka/eureka-client';
+import { requireEnv } from './common/config/config.util';
 
 function debugStartup(message: string) {
     if (process.env.DEBUG_STARTUP === 'true') {
         console.log(`[startup] ${message}`);
     }
-}
-
-function requireEnv(key: string): string {
-    const value = process.env[key];
-    if (value !== undefined && value !== '') {
-        return value;
-    }
-
-    throw new Error(`Required environment variable is missing: ${key}`);
 }
 
 async function bootstrap() {
@@ -79,7 +71,7 @@ async function bootstrap() {
     process.once('SIGTERM', shutdown);
 
     new Logger('Bootstrap').log(`Chat server running on port ${port}`);
-    new Logger('Bootstrap').log(`Swagger UI path: /api`);
+    new Logger('Bootstrap').log(`Swagger UI: ${await app.getUrl()}/api`);
 }
 
 bootstrap().catch((err) => {

--- a/cowork-chat/src/main.ts
+++ b/cowork-chat/src/main.ts
@@ -15,6 +15,15 @@ function debugStartup(message: string) {
     }
 }
 
+function requireEnv(key: string): string {
+    const value = process.env[key];
+    if (value !== undefined && value !== '') {
+        return value;
+    }
+
+    throw new Error(`Required environment variable is missing: ${key}`);
+}
+
 async function bootstrap() {
     debugStartup('creating Nest application');
     const app = await NestFactory.create<NestExpressApplication>(ChatModule, { bufferLogs: true });
@@ -47,7 +56,7 @@ async function bootstrap() {
     const document = SwaggerModule.createDocument(app, config);
     SwaggerModule.setup('api', app, document, { jsonDocumentUrl: 'api-json' });
 
-    const port = Number(process.env.PORT ?? 3000);
+    const port = Number(requireEnv('PORT'));
     debugStartup(`listening on ${port}`);
     await app.listen(port);
     debugStartup('HTTP server listening');
@@ -70,7 +79,7 @@ async function bootstrap() {
     process.once('SIGTERM', shutdown);
 
     new Logger('Bootstrap').log(`Chat server running on port ${port}`);
-    new Logger('Bootstrap').log(`Swagger UI: http://localhost:${port}/api`);
+    new Logger('Bootstrap').log(`Swagger UI path: /api`);
 }
 
 bootstrap().catch((err) => {

--- a/cowork-chat/src/membership/membership.consumer.ts
+++ b/cowork-chat/src/membership/membership.consumer.ts
@@ -5,6 +5,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { ChannelMember } from '../chat/schema/channel-member.schema';
 import { ChannelMemberEvent } from './event/membership.event';
+import { getRequiredCsvConfig } from '../common/config/config.util';
 
 @Injectable()
 export class MembershipConsumer implements OnModuleInit, OnModuleDestroy {
@@ -19,7 +20,7 @@ export class MembershipConsumer implements OnModuleInit, OnModuleDestroy {
     async onModuleInit() {
         const kafka = new Kafka({
             clientId: 'cowork-chat-membership',
-            brokers: [this.configService.get<string>('KAFKA_BOOTSTRAP_SERVERS', 'localhost:9092')],
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
         });
         this.consumer = kafka.consumer({ groupId: 'cowork-chat-membership' });
         await this.consumer.connect();

--- a/cowork-chat/src/storage/minio.config.ts
+++ b/cowork-chat/src/storage/minio.config.ts
@@ -28,8 +28,8 @@ export function buildMinioConfig(configService: ConfigService): MinioConfig {
         'MINIO_INTERNAL_ENDPOINT',
     ]);
     const endpointUrl = new URL(internalEndpoint);
-    const accessKey = getOptionalConfig(configService, ['minio.accessKey', 'MINIO_ACCESS_KEY']) ?? '';
-    const secretKey = getOptionalConfig(configService, ['minio.secretKey', 'MINIO_SECRET_KEY']) ?? '';
+    const accessKey = getRequiredConfig(configService, ['minio.accessKey', 'MINIO_ACCESS_KEY']);
+    const secretKey = getRequiredConfig(configService, ['minio.secretKey', 'MINIO_SECRET_KEY']);
     const bucket = getRequiredConfig(configService, ['minio.bucket', 'MINIO_BUCKET']);
 
     return {

--- a/cowork-chat/src/storage/minio.config.ts
+++ b/cowork-chat/src/storage/minio.config.ts
@@ -1,4 +1,5 @@
 import { ConfigService } from '@nestjs/config';
+import { getOptionalConfig, getRequiredConfig } from '../common/config/config.util';
 
 const DEFAULT_PRESIGNED_PUT_EXPIRY_SECONDS = 600;
 const DEFAULT_MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;
@@ -20,51 +21,38 @@ export interface MinioConfig {
     uploadRateLimitMaxRequests: number;
 }
 
-function getConfigValue(configService: ConfigService, ...keys: string[]): string | undefined {
-    for (const key of keys) {
-        const value = configService.get<string>(key) ?? process.env[key];
-        if (value !== undefined && value !== '') {
-            return value;
-        }
-    }
-    return undefined;
-}
-
 export function buildMinioConfig(configService: ConfigService): MinioConfig {
-    const internalEndpoint = getConfigValue(
-        configService,
+    const internalEndpoint = getRequiredConfig(configService, [
         'minio.endpoint',
         'MINIO_ENDPOINT',
         'MINIO_INTERNAL_ENDPOINT',
-    ) ?? 'http://localhost:9000';
+    ]);
     const endpointUrl = new URL(internalEndpoint);
-    const accessKey = getConfigValue(configService, 'minio.accessKey', 'MINIO_ACCESS_KEY') ?? '';
-    const secretKey = getConfigValue(configService, 'minio.secretKey', 'MINIO_SECRET_KEY') ?? '';
-    const bucket = getConfigValue(configService, 'minio.bucket', 'MINIO_BUCKET') ?? 'cowork-bucket';
+    const accessKey = getOptionalConfig(configService, ['minio.accessKey', 'MINIO_ACCESS_KEY']) ?? '';
+    const secretKey = getOptionalConfig(configService, ['minio.secretKey', 'MINIO_SECRET_KEY']) ?? '';
+    const bucket = getRequiredConfig(configService, ['minio.bucket', 'MINIO_BUCKET']);
 
     return {
         endPoint: endpointUrl.hostname,
         port: endpointUrl.port ? Number(endpointUrl.port) : undefined,
-        useSSL: (getConfigValue(configService, 'minio.useSSL', 'MINIO_USE_SSL') ?? String(endpointUrl.protocol === 'https:')) === 'true',
+        useSSL: (getOptionalConfig(configService, ['minio.useSSL', 'MINIO_USE_SSL']) ?? String(endpointUrl.protocol === 'https:')) === 'true',
         accessKey,
         secretKey,
         bucket,
         publicBaseUrl: (
-            getConfigValue(configService, 'minio.publicBaseUrl', 'MINIO_PUBLIC_BASE_URL')
-            ?? `${getConfigValue(configService, 'minio.publicEndpoint', 'MINIO_PUBLIC_ENDPOINT') ?? internalEndpoint}/${bucket}`
+            getOptionalConfig(configService, ['minio.publicBaseUrl', 'MINIO_PUBLIC_BASE_URL'])
+            ?? `${getOptionalConfig(configService, ['minio.publicEndpoint', 'MINIO_PUBLIC_ENDPOINT']) ?? internalEndpoint}/${bucket}`
         ).replace(/\/$/, ''),
-        presignedPutExpirySeconds: Number(getConfigValue(
+        presignedPutExpirySeconds: Number(getOptionalConfig(
             configService,
-            'minio.presignedPutExpirySeconds',
-            'MINIO_PRESIGNED_PUT_EXPIRY_SECONDS',
+            ['minio.presignedPutExpirySeconds', 'MINIO_PRESIGNED_PUT_EXPIRY_SECONDS'],
         ) ?? DEFAULT_PRESIGNED_PUT_EXPIRY_SECONDS),
-        maxFileSizeBytes: Number(getConfigValue(
+        maxFileSizeBytes: Number(getOptionalConfig(
             configService,
-            'minio.chatMaxFileSizeBytes',
-            'MINIO_CHAT_MAX_FILE_SIZE_BYTES',
+            ['minio.chatMaxFileSizeBytes', 'MINIO_CHAT_MAX_FILE_SIZE_BYTES'],
         ) ?? DEFAULT_MAX_FILE_SIZE_BYTES),
         allowedContentTypes: (
-            getConfigValue(configService, 'minio.chatAllowedContentTypes', 'MINIO_CHAT_ALLOWED_CONTENT_TYPES')
+            getOptionalConfig(configService, ['minio.chatAllowedContentTypes', 'MINIO_CHAT_ALLOWED_CONTENT_TYPES'])
             ?? [
                 'video/mp4',
                 'video/quicktime',
@@ -84,15 +72,13 @@ export function buildMinioConfig(configService: ConfigService): MinioConfig {
             .split(',')
             .map((contentType) => contentType.trim())
             .filter(Boolean),
-        uploadRateLimitWindowMs: Number(getConfigValue(
+        uploadRateLimitWindowMs: Number(getOptionalConfig(
             configService,
-            'minio.chatUploadRateLimitWindowMs',
-            'MINIO_CHAT_UPLOAD_RATE_LIMIT_WINDOW_MS',
+            ['minio.chatUploadRateLimitWindowMs', 'MINIO_CHAT_UPLOAD_RATE_LIMIT_WINDOW_MS'],
         ) ?? DEFAULT_UPLOAD_RATE_LIMIT_WINDOW_MS),
-        uploadRateLimitMaxRequests: Number(getConfigValue(
+        uploadRateLimitMaxRequests: Number(getOptionalConfig(
             configService,
-            'minio.chatUploadRateLimitMaxRequests',
-            'MINIO_CHAT_UPLOAD_RATE_LIMIT_MAX_REQUESTS',
+            ['minio.chatUploadRateLimitMaxRequests', 'MINIO_CHAT_UPLOAD_RATE_LIMIT_MAX_REQUESTS'],
         ) ?? DEFAULT_UPLOAD_RATE_LIMIT_MAX_REQUESTS),
     };
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -641,6 +641,7 @@ services:
       MONGODB_URI: "mongodb://${MONGO_ROOT_USERNAME}:${MONGO_ROOT_PASSWORD}@mongodb:27017/cowork_chat?authSource=admin"
       MONGODB_DIRECT_CONNECTION: "false"
       KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      PROJECT_SERVICE_URL: http://cowork-project:8084
       EUREKA_SERVER_URL: http://cowork-config:8761/eureka
       EUREKA_INSTANCE_HOST: cowork-chat
       MINIO_INTERNAL_ENDPOINT: http://minio:9000

--- a/scripts/run/local/chat.sh
+++ b/scripts/run/local/chat.sh
@@ -12,6 +12,9 @@ SERVICE_COMMAND=(
    export ALLOWED_ORIGINS="${ALLOWED_ORIGINS:-http://localhost:3000}"
    export MONGODB_URI="${MONGODB_URI:-mongodb://${MONGO_ROOT_USERNAME}:${MONGO_ROOT_PASSWORD}@localhost:27017/cowork_chat?authSource=admin}"
    export KAFKA_BOOTSTRAP_SERVERS="${KAFKA_BOOTSTRAP_SERVERS:-localhost:9094}"
+   export PROJECT_SERVICE_URL="${PROJECT_SERVICE_URL:-http://localhost:8084}"
+   export EUREKA_SERVER_URL="${EUREKA_SERVER_URL:-http://localhost:8761/eureka}"
+   export EUREKA_INSTANCE_HOST="${EUREKA_INSTANCE_HOST:-localhost}"
    npm run start:dev'
 )
 


### PR DESCRIPTION
## 개요

chat 모듈의 런타임 설정에서 로컬 기본값 하드코딩을 제거하였습니다.
필수 인프라 설정은 환경 변수 또는 ConfigService에서 명시적으로 주입되도록 정리하였습니다.

## 본문

MongoDB, Kafka, Project 서비스, Eureka, MinIO 관련 설정을 공통 설정 헬퍼를 통해 조회하도록 변경하였습니다. 필수 설정이 누락된 경우 애플리케이션이 명확한 오류로 실패하도록 하여 운영 환경에서 의도하지 않은 localhost 연결을 방지하였습니다.

Kafka broker 설정은 CSV 값을 파싱하도록 개선하여 복수 broker 구성을 지원하였습니다. 로컬 실행 스크립트와 docker-compose에는 chat 서비스 실행에 필요한 `PROJECT_SERVICE_URL`, `EUREKA_SERVER_URL`, `EUREKA_INSTANCE_HOST` 값을 명시하였습니다.

AsyncAPI 개발 서버 포트 기본값을 chat 서비스 포트인 8087로 맞추고, host 변수를 분리하였습니다.
