### PR TITLE
[global] 전 모듈 운영 환경 Dockerfile 추가

### DIFF
--- a/cowork-authorization/prod.dockerfile
+++ b/cowork-authorization/prod.dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o cowork-authorization ./cmd
+
+FROM alpine:3.20
+RUN apk --no-cache add ca-certificates tzdata && \
+    addgroup -S app && adduser -S app -G app
+USER app
+WORKDIR /app
+COPY --from=builder /app/cowork-authorization /usr/local/bin/cowork-authorization
+EXPOSE 8081
+CMD ["cowork-authorization"]

--- a/cowork-channel/local.dockerfile
+++ b/cowork-channel/local.dockerfile
@@ -5,9 +5,9 @@ COPY gradle gradle
 COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
 COPY cowork-channel/src cowork-channel/src
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
 COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
 RUN chmod +x gradlew && ./gradlew :cowork-channel:bootJar -x test --no-daemon

--- a/cowork-channel/prod.dockerfile
+++ b/cowork-channel/prod.dockerfile
@@ -1,0 +1,32 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /workspace
+COPY gradlew gradlew
+COPY gradle gradle
+COPY settings.gradle.kts build.gradle.kts ./
+COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
+COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
+COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
+COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-channel/src cowork-channel/src
+COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
+COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
+RUN chmod +x gradlew && ./gradlew :cowork-channel:bootJar -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine AS extractor
+WORKDIR /app
+COPY --from=builder /workspace/cowork-channel/build/libs/*.jar app.jar
+RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
+
+FROM eclipse-temurin:21-jre-alpine
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+COPY --from=extractor /app/extracted/dependencies ./
+COPY --from=extractor /app/extracted/spring-boot-loader ./
+COPY --from=extractor /app/extracted/snapshot-dependencies ./
+COPY --from=extractor /app/extracted/application ./
+USER app
+EXPOSE 8083
+ENTRYPOINT ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "org.springframework.boot.loader.launch.JarLauncher"]

--- a/cowork-channel/prod.dockerfile
+++ b/cowork-channel/prod.dockerfile
@@ -5,9 +5,9 @@ COPY gradle gradle
 COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
 COPY cowork-channel/src cowork-channel/src
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
 COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
 RUN chmod +x gradlew && ./gradlew :cowork-channel:bootJar -x test --no-daemon

--- a/cowork-chat/prod.dockerfile
+++ b/cowork-chat/prod.dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+USER app
+EXPOSE 8087
+ENV PORT=8087
+ENV NODE_ENV=production
+CMD ["node", "dist/main.js"]

--- a/cowork-config/local.dockerfile
+++ b/cowork-config/local.dockerfile
@@ -6,8 +6,8 @@ COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-config/src cowork-config/src
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
 COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
 RUN chmod +x gradlew && ./gradlew :cowork-config:bootJar -x test --no-daemon

--- a/cowork-config/prod.dockerfile
+++ b/cowork-config/prod.dockerfile
@@ -1,0 +1,32 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /workspace
+COPY gradlew gradlew
+COPY gradle gradle
+COPY settings.gradle.kts build.gradle.kts ./
+COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
+COPY cowork-config/src cowork-config/src
+COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
+COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
+COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
+COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
+RUN chmod +x gradlew && ./gradlew :cowork-config:bootJar -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine AS extractor
+WORKDIR /app
+COPY --from=builder /workspace/cowork-config/build/libs/*.jar app.jar
+RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
+
+FROM eclipse-temurin:21-jre-alpine
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+COPY --from=extractor /app/extracted/dependencies ./
+COPY --from=extractor /app/extracted/spring-boot-loader ./
+COPY --from=extractor /app/extracted/snapshot-dependencies ./
+COPY --from=extractor /app/extracted/application ./
+USER app
+EXPOSE 8761
+ENTRYPOINT ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "org.springframework.boot.loader.launch.JarLauncher"]

--- a/cowork-config/prod.dockerfile
+++ b/cowork-config/prod.dockerfile
@@ -6,8 +6,8 @@ COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-config/src cowork-config/src
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
 COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
 RUN chmod +x gradlew && ./gradlew :cowork-config:bootJar -x test --no-daemon

--- a/cowork-gateway/local.dockerfile
+++ b/cowork-gateway/local.dockerfile
@@ -6,8 +6,8 @@ COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
 COPY cowork-gateway/src cowork-gateway/src
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
 COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
 RUN chmod +x gradlew && ./gradlew :cowork-gateway:bootJar -x test --no-daemon

--- a/cowork-gateway/prod.dockerfile
+++ b/cowork-gateway/prod.dockerfile
@@ -6,8 +6,8 @@ COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
 COPY cowork-gateway/src cowork-gateway/src
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
 COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
 RUN chmod +x gradlew && ./gradlew :cowork-gateway:bootJar -x test --no-daemon

--- a/cowork-gateway/prod.dockerfile
+++ b/cowork-gateway/prod.dockerfile
@@ -1,0 +1,32 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /workspace
+COPY gradlew gradlew
+COPY gradle gradle
+COPY settings.gradle.kts build.gradle.kts ./
+COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
+COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
+COPY cowork-gateway/src cowork-gateway/src
+COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
+COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
+COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
+RUN chmod +x gradlew && ./gradlew :cowork-gateway:bootJar -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine AS extractor
+WORKDIR /app
+COPY --from=builder /workspace/cowork-gateway/build/libs/*.jar app.jar
+RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
+
+FROM eclipse-temurin:21-jre-alpine
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+COPY --from=extractor /app/extracted/dependencies ./
+COPY --from=extractor /app/extracted/spring-boot-loader ./
+COPY --from=extractor /app/extracted/snapshot-dependencies ./
+COPY --from=extractor /app/extracted/application ./
+USER app
+EXPOSE 8080
+ENTRYPOINT ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "org.springframework.boot.loader.launch.JarLauncher"]

--- a/cowork-notification/prod.dockerfile
+++ b/cowork-notification/prod.dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o cowork-notification ./cmd/server
+
+FROM alpine:3.20
+RUN apk --no-cache add ca-certificates tzdata && \
+    addgroup -S app && adduser -S app -G app
+USER app
+WORKDIR /app
+COPY --from=builder /app/cowork-notification /usr/local/bin/cowork-notification
+EXPOSE 8086
+ENV PORT=8086
+CMD ["cowork-notification"]

--- a/cowork-preference/local.dockerfile
+++ b/cowork-preference/local.dockerfile
@@ -5,8 +5,8 @@ COPY gradle gradle
 COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
 COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
 COPY cowork-preference/src cowork-preference/src

--- a/cowork-preference/prod.dockerfile
+++ b/cowork-preference/prod.dockerfile
@@ -5,8 +5,8 @@ COPY gradle gradle
 COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
 COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
 COPY cowork-preference/src cowork-preference/src

--- a/cowork-preference/prod.dockerfile
+++ b/cowork-preference/prod.dockerfile
@@ -1,0 +1,22 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /workspace
+COPY gradlew gradlew
+COPY gradle gradle
+COPY settings.gradle.kts build.gradle.kts ./
+COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
+COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
+COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
+COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
+COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
+COPY cowork-preference/src cowork-preference/src
+RUN chmod +x gradlew && ./gradlew :cowork-preference:installDist -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+COPY --from=builder /workspace/cowork-preference/build/install/cowork-preference .
+ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
+USER app
+EXPOSE 9001
+ENTRYPOINT ["./bin/cowork-preference"]

--- a/cowork-project/local.dockerfile
+++ b/cowork-project/local.dockerfile
@@ -5,7 +5,6 @@ COPY gradle gradle
 COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
 COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-project/src cowork-project/src

--- a/cowork-project/prod.dockerfile
+++ b/cowork-project/prod.dockerfile
@@ -1,0 +1,33 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /workspace
+COPY gradlew gradlew
+COPY gradle gradle
+COPY settings.gradle.kts build.gradle.kts ./
+COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
+COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
+COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
+COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
+COPY cowork-project/src cowork-project/src
+COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
+COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
+RUN chmod +x gradlew && ./gradlew :cowork-project:bootJar -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine AS extractor
+WORKDIR /app
+COPY --from=builder /workspace/cowork-project/build/libs/*.jar app.jar
+RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
+
+FROM eclipse-temurin:21-jre-alpine
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+COPY --from=extractor /app/extracted/dependencies ./
+COPY --from=extractor /app/extracted/spring-boot-loader ./
+COPY --from=extractor /app/extracted/snapshot-dependencies ./
+COPY --from=extractor /app/extracted/application ./
+USER app
+EXPOSE 8084
+ENTRYPOINT ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "org.springframework.boot.loader.launch.JarLauncher"]

--- a/cowork-project/prod.dockerfile
+++ b/cowork-project/prod.dockerfile
@@ -5,7 +5,6 @@ COPY gradle gradle
 COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
 COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-project/src cowork-project/src

--- a/cowork-team/local.dockerfile
+++ b/cowork-team/local.dockerfile
@@ -5,8 +5,8 @@ COPY gradle gradle
 COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
 COPY cowork-team/src cowork-team/src
 COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts

--- a/cowork-team/prod.dockerfile
+++ b/cowork-team/prod.dockerfile
@@ -5,8 +5,8 @@ COPY gradle gradle
 COPY settings.gradle.kts build.gradle.kts ./
 COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
 COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
 COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
 COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
 COPY cowork-team/src cowork-team/src
 COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts

--- a/cowork-team/prod.dockerfile
+++ b/cowork-team/prod.dockerfile
@@ -1,0 +1,32 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /workspace
+COPY gradlew gradlew
+COPY gradle gradle
+COPY settings.gradle.kts build.gradle.kts ./
+COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
+COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
+COPY cowork-user/build.gradle.kts cowork-user/build.gradle.kts
+COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
+COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
+COPY cowork-team/src cowork-team/src
+COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
+RUN chmod +x gradlew && ./gradlew :cowork-team:bootJar -x test --no-daemon
+
+FROM eclipse-temurin:21-jre-alpine AS extractor
+WORKDIR /app
+COPY --from=builder /workspace/cowork-team/build/libs/*.jar app.jar
+RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
+
+FROM eclipse-temurin:21-jre-alpine
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+COPY --from=extractor /app/extracted/dependencies ./
+COPY --from=extractor /app/extracted/spring-boot-loader ./
+COPY --from=extractor /app/extracted/snapshot-dependencies ./
+COPY --from=extractor /app/extracted/application ./
+USER app
+EXPOSE 8085
+ENTRYPOINT ["java", \
+  "-XX:+UseContainerSupport", \
+  "-XX:MaxRAMPercentage=75.0", \
+  "org.springframework.boot.loader.launch.JarLauncher"]

--- a/cowork-user/build.gradle.kts
+++ b/cowork-user/build.gradle.kts
@@ -1,4 +1,0 @@
-group = "com.cowork"
-version = "20260502.0"
-
-description = "cowork-user is now implemented as an Elixir service. This Gradle file is kept only so root Gradle and Docker build contexts that still copy it do not fail."

--- a/cowork-user/prod.dockerfile
+++ b/cowork-user/prod.dockerfile
@@ -1,0 +1,44 @@
+ARG ELIXIR_IMAGE=hexpm/elixir:1.17.3-erlang-27.1.1-debian-bookworm-20240926-slim
+
+FROM flyway/flyway:11.8.1 AS flyway
+
+FROM ${ELIXIR_IMAGE} AS builder
+WORKDIR /app
+ENV MIX_ENV=prod
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential cmake git curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mix local.hex --force && mix local.rebar --force
+
+COPY cowork-user/mix.exs ./
+COPY cowork-user/config config
+RUN mix deps.get
+RUN mix deps.compile
+
+COPY cowork-user/lib lib
+COPY cowork-user/priv priv
+RUN mix compile
+RUN mix release
+
+FROM debian:bookworm-20240926-slim
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssl curl wget ca-certificates default-mysql-client default-jre-headless libstdc++6 libncurses5 locales \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -r app && useradd -r -g app app \
+    && mkdir -p /var/log/cowork/user && chown -R app:app /var/log/cowork
+
+COPY --from=flyway /flyway /flyway
+COPY cowork-user/src/main/resources/db/migration /flyway/sql
+COPY --from=builder /app/_build/prod/rel/cowork_user ./
+COPY cowork-user/docker-entrypoint.sh /app/docker-entrypoint.sh
+
+ENV PATH="/flyway:${PATH}"
+ENV ELIXIR_ERL_OPTIONS="+fnu"
+RUN chmod +x /app/docker-entrypoint.sh && chown -R app:app /app
+USER app
+EXPOSE 8082
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/cowork-voice/prod.dockerfile
+++ b/cowork-voice/prod.dockerfile
@@ -1,0 +1,16 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o cowork-voice ./cmd/server
+
+FROM alpine:3.20
+RUN apk --no-cache add ca-certificates tzdata && \
+    addgroup -S app && adduser -S app -G app
+USER app
+WORKDIR /app
+COPY --from=builder /app/cowork-voice /usr/local/bin/cowork-voice
+EXPOSE 8084
+ENV PORT=8084
+CMD ["cowork-voice"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -479,6 +479,7 @@ services:
       cowork-config:
         condition: service_healthy
     environment:
+      PORT: "8082"
       APP_CONFIG_URL: http://cowork-config:8761
       APP_PROFILE: ${APP_PROFILE:-local}
       DATABASE_URL: "ecto://${MYSQL_USER}:${MYSQL_PASSWORD}@mysql:3306/cowork_user?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,7 +2,6 @@ rootProject.name = "cowork-server"
 
 include("cowork-gateway")
 include("cowork-config")
-include("cowork-user")
 include("cowork-channel")
 include("cowork-project")
 include("cowork-team")


### PR DESCRIPTION
## 개요

전체 11개 서비스 모듈에 대해 운영 환경 배포용 `prod.dockerfile`을 작성하였습니다. 기존 `local.dockerfile`은 로컬 개발 환경에서의 제로 빌드를 전제로 작성되어 있어, 컨테이너 레지스트리를 통한 배포에 적합한 최적화가 적용되지 않은 상태였습니다. 이번 작업을 통해 각 런타임 유형별로 보안 및 빌드 효율을 개선한 운영 전용 이미지 빌드 파일을 추가하였습니다.

## 본문

### Spring Boot (Kotlin) — config, gateway, channel, team, project

- Spring Boot Layertools(`-Djarmode=layertools`)를 활용하여 JAR를 `dependencies` / `spring-boot-loader` / `snapshot-dependencies` / `application` 4개 레이어로 분리하는 3-stage 빌드로 변경하였습니다.
- 애플리케이션 코드만 변경된 경우 `application` 레이어만 레지스트리에 전송되어 push/pull 비용이 감소합니다.
- `JarLauncher` 직접 호출 방식으로 변경하고 `-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0` JVM 플래그를 추가하였습니다.

### Vert.x (Kotlin) — preference

- `installDist` 빌드 구조는 그대로 유지하였습니다.
- `ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"`을 추가하였습니다. Gradle application 플러그인이 생성하는 시작 스크립트가 `$JAVA_OPTS`를 자동으로 참조합니다.

### Go 1.25 — authorization, notification, voice

- 빌드 플래그에 `-ldflags="-s -w" -trimpath`을 추가하였습니다. 디버그 심볼 제거로 바이너리 크기가 약 30% 감소하고 빌드 재현성이 확보됩니다.
- 런타임 이미지에 non-root 사용자(`addgroup -S app && adduser -S app -G app`)를 추가하였습니다. `local.dockerfile`에는 없던 처리입니다.

### Node.js 22 (NestJS) — chat

- non-root 사용자를 추가하였습니다.
- `ENV NODE_ENV=production`을 명시적으로 설정하였습니다.

### Elixir + Flyway — user

- Debian `groupadd/useradd`를 사용하여 non-root 사용자를 추가하였습니다.
- `docker-entrypoint.sh`의 `mkdir -p` 호출이 non-root 환경에서도 동작하도록, Dockerfile 빌드 단계에서 `/var/log/cowork/user` 디렉토리를 미리 생성하고 `chown -R app:app`으로 소유권을 설정하였습니다.
