### PR TITLE
[global] 서비스 간 멤버십 동기화 이벤트 강화 및 라우팅 경로 조정

### DIFF
--- a/.github/workflows/cowork-prod-cd.yml
+++ b/.github/workflows/cowork-prod-cd.yml
@@ -21,38 +21,27 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Calculate Version
+      - name: Read Version
         id: version
         run: |
-          DATE=$(date -u +"%Y%m%d")
-          EXISTING=$(git tag -l "v${DATE}.*" | wc -l | tr -d ' ')
-          VERSION="${DATE}.${EXISTING}"
+          VERSION=$(cat VERSION)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
-
-      - name: Bump Version Files
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          printf '%s' "${VERSION}" > VERSION
-          for FILE in cowork-*/build.gradle.kts; do
-            perl -i -pe "s/^version = \".*\"/version = \"${VERSION}\"/" "$FILE"
-          done
-          perl -i -pe "s/\"version\": \".*\"/\"version\": \"${VERSION}\"/" cowork-chat/package.json
-
-      - name: Commit Version Bump
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add VERSION cowork-*/build.gradle.kts cowork-chat/package.json
-          git diff --staged --quiet || git commit -m "chore: release v${{ steps.version.outputs.version }} [skip ci]"
-          git push origin main
+          if git tag -l "v${VERSION}" | grep -q .; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Create Tag
+        if: steps.version.outputs.skip == 'false'
         run: git tag v${{ steps.version.outputs.version }}
 
       - name: Push Tag
+        if: steps.version.outputs.skip == 'false'
         run: git push origin v${{ steps.version.outputs.version }}
 
       - name: Create GitHub Release
+        if: steps.version.outputs.skip == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/cowork-prod-ci.yml
+++ b/.github/workflows/cowork-prod-ci.yml
@@ -35,6 +35,17 @@ jobs:
 
             const versionPattern = /^v\d{8}\.\d+$/;
             if (versionPattern.test(title)) {
+              const { data: file } = await github.rest.repos.getContent({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                path: 'VERSION',
+                ref: context.payload.pull_request.head.sha
+              });
+              const versionInFile = Buffer.from(file.content, 'base64').toString().trim();
+              const versionInTitle = title.slice(1);
+              if (versionInFile !== versionInTitle) {
+                core.setFailed(`VERSION 파일(${versionInFile})이 PR 제목의 버전(${versionInTitle})과 다릅니다`);
+              }
               return;
             }
 

--- a/cowork-channel/build.gradle.kts
+++ b/cowork-channel/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
     }
     implementation(libs.springdoc.openapi.webmvc.ui)
     implementation(libs.logstash.logback.encoder)
+    implementation(libs.shedlock.spring)
+    implementation(libs.shedlock.provider.jdbc.template)
 
     testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.mockk)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/CoworkChannelApplication.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/CoworkChannelApplication.kt
@@ -3,12 +3,13 @@ package com.cowork.channel
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableScheduling
 class CoworkChannelApplication
 
 fun main(args: Array<String>) {
     runApplication<CoworkChannelApplication>(*args)
 }
-

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/config/ShedLockConfig.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/config/ShedLockConfig.kt
@@ -1,0 +1,17 @@
+package com.cowork.channel.config
+
+import net.javacrumbs.shedlock.core.LockProvider
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.sql.DataSource
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
+class ShedLockConfig {
+
+    @Bean
+    fun lockProvider(dataSource: DataSource): LockProvider =
+        JdbcTemplateLockProvider(dataSource)
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMemberEvent.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMemberEvent.kt
@@ -1,0 +1,12 @@
+package com.cowork.channel.event
+
+import java.time.LocalDateTime
+
+data class ChannelMemberEvent(
+    val eventType: String,
+    val channelId: Long,
+    val teamId: Long,
+    val userId: Long,
+    val role: String,
+    val occurredAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMemberEventPublisher.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMemberEventPublisher.kt
@@ -1,0 +1,35 @@
+package com.cowork.channel.event
+
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class ChannelMemberEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, Any>,
+) {
+    private val log = LoggerFactory.getLogger(ChannelMemberEventPublisher::class.java)
+
+    fun publishJoin(channelId: Long, teamId: Long, userId: Long, role: String = "MEMBER") =
+        publish(ChannelMemberEvent("JOIN", channelId, teamId, userId, role))
+
+    fun publishLeave(channelId: Long, teamId: Long, userId: Long, role: String = "MEMBER") =
+        publish(ChannelMemberEvent("LEAVE", channelId, teamId, userId, role))
+
+    private fun publish(event: ChannelMemberEvent) {
+        kafkaTemplate.send("channel.member.event", event.channelId.toString(), event)
+            .whenComplete { result, ex ->
+                if (ex != null) {
+                    log.error(
+                        "채널 멤버 이벤트 발행 실패 [eventType={}, channelId={}, userId={}]",
+                        event.eventType, event.channelId, event.userId, ex,
+                    )
+                } else {
+                    log.info(
+                        "채널 멤버 이벤트 발행 성공 [eventType={}, channelId={}, userId={}, offset={}]",
+                        event.eventType, event.channelId, event.userId, result.recordMetadata.offset(),
+                    )
+                }
+            }
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMemberEventPublisher.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMemberEventPublisher.kt
@@ -4,6 +4,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
 
+private const val TOPIC = "channel.member.event"
+
 @Component
 class ChannelMemberEventPublisher(
     private val kafkaTemplate: KafkaTemplate<String, Any>,
@@ -17,7 +19,7 @@ class ChannelMemberEventPublisher(
         publish(ChannelMemberEvent("LEAVE", channelId, teamId, userId, role))
 
     private fun publish(event: ChannelMemberEvent) {
-        kafkaTemplate.send("channel.member.event", event.channelId.toString(), event)
+        kafkaTemplate.send(TOPIC, event.channelId.toString(), event)
             .whenComplete { result, ex ->
                 if (ex != null) {
                     log.error(

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMembershipSyncPublisher.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMembershipSyncPublisher.kt
@@ -31,17 +31,21 @@ class ChannelMembershipSyncPublisher(
     @EventListener(ApplicationReadyEvent::class)
     @Transactional(readOnly = true)
     fun publishAllSnapshots() {
-        val membersByChannel = channelMemberRepository.findAll().groupBy { it.channelId }
-        channelRepository.findAll().forEach { channel ->
-            val members = membersByChannel[channel.id] ?: emptyList()
-            publishChannelSnapshot(channel, members)
-        }
+        doPublishAll()
     }
 
     @Scheduled(initialDelay = 30_000, fixedDelay = 300_000)
     @SchedulerLock(name = "republishAllChannelSnapshots", lockAtMostFor = "PT10M")
     @Transactional(readOnly = true)
     fun republishAllSnapshots() {
-        publishAllSnapshots()
+        doPublishAll()
+    }
+
+    private fun doPublishAll() {
+        val membersByChannel = channelMemberRepository.findAll().groupBy { it.channelId }
+        channelRepository.findAll().forEach { channel ->
+            val members = membersByChannel[channel.id] ?: emptyList()
+            publishChannelSnapshot(channel, members)
+        }
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMembershipSyncPublisher.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMembershipSyncPublisher.kt
@@ -4,6 +4,7 @@ import com.cowork.channel.domain.Channel
 import com.cowork.channel.domain.ChannelMember
 import com.cowork.channel.repository.ChannelMemberRepository
 import com.cowork.channel.repository.ChannelRepository
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Scheduled
@@ -38,6 +39,7 @@ class ChannelMembershipSyncPublisher(
     }
 
     @Scheduled(initialDelay = 30_000, fixedDelay = 300_000)
+    @SchedulerLock(name = "republishAllChannelSnapshots", lockAtMostFor = "PT10M")
     @Transactional(readOnly = true)
     fun republishAllSnapshots() {
         publishAllSnapshots()

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMembershipSyncPublisher.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMembershipSyncPublisher.kt
@@ -30,8 +30,9 @@ class ChannelMembershipSyncPublisher(
     @EventListener(ApplicationReadyEvent::class)
     @Transactional(readOnly = true)
     fun publishAllSnapshots() {
+        val membersByChannel = channelMemberRepository.findAll().groupBy { it.channelId }
         channelRepository.findAll().forEach { channel ->
-            val members = channelMemberRepository.findByChannelId(channel.id)
+            val members = membersByChannel[channel.id] ?: emptyList()
             publishChannelSnapshot(channel, members)
         }
     }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMembershipSyncPublisher.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelMembershipSyncPublisher.kt
@@ -1,0 +1,44 @@
+package com.cowork.channel.event
+
+import com.cowork.channel.domain.Channel
+import com.cowork.channel.domain.ChannelMember
+import com.cowork.channel.repository.ChannelMemberRepository
+import com.cowork.channel.repository.ChannelRepository
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class ChannelMembershipSyncPublisher(
+    private val channelRepository: ChannelRepository,
+    private val channelMemberRepository: ChannelMemberRepository,
+    private val channelMemberEventPublisher: ChannelMemberEventPublisher,
+) {
+
+    fun publishChannelSnapshot(channel: Channel, members: List<ChannelMember>) {
+        members.forEach { member ->
+            channelMemberEventPublisher.publishJoin(
+                channelId = channel.id,
+                teamId = channel.teamId,
+                userId = member.userId,
+            )
+        }
+    }
+
+    @EventListener(ApplicationReadyEvent::class)
+    @Transactional(readOnly = true)
+    fun publishAllSnapshots() {
+        channelRepository.findAll().forEach { channel ->
+            val members = channelMemberRepository.findByChannelId(channel.id)
+            publishChannelSnapshot(channel, members)
+        }
+    }
+
+    @Scheduled(initialDelay = 30_000, fixedDelay = 300_000)
+    @Transactional(readOnly = true)
+    fun republishAllSnapshots() {
+        publishAllSnapshots()
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
@@ -5,11 +5,15 @@ import com.cowork.channel.domain.ChannelMember
 import com.cowork.channel.domain.ChannelType
 import com.cowork.channel.domain.ChannelViewType
 import com.cowork.channel.dto.*
+import com.cowork.channel.event.ChannelMemberEventPublisher
+import com.cowork.channel.event.ChannelMembershipSyncPublisher
 import com.cowork.channel.repository.ChannelMemberRepository
 import com.cowork.channel.repository.ChannelRepository
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.sdk.exception.ExpectedException
 
 @Service
@@ -18,6 +22,8 @@ class ChannelService(
     private val channelRepository: ChannelRepository,
     private val channelMemberRepository: ChannelMemberRepository,
     private val teamPermissionService: TeamPermissionService,
+    private val channelMemberEventPublisher: ChannelMemberEventPublisher,
+    private val channelMembershipSyncPublisher: ChannelMembershipSyncPublisher,
 ) {
 
     fun findChannelOrThrow(channelId: Long): Channel =
@@ -58,7 +64,12 @@ class ChannelService(
                 createdBy = userId,
             )
         )
-        channelMemberRepository.save(ChannelMember(channelId = channel.id, userId = userId))
+        val member = channelMemberRepository.save(ChannelMember(channelId = channel.id, userId = userId))
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() {
+                channelMembershipSyncPublisher.publishChannelSnapshot(channel, listOf(member))
+            }
+        })
         return ChannelResponse.of(channel)
     }
 
@@ -80,7 +91,15 @@ class ChannelService(
     fun deleteChannel(userId: Long, channelId: Long) {
         val channel = findChannelOrThrow(channelId)
         requireChannelManager(channel, userId)
+        val members = channelMemberRepository.findByChannelId(channelId)
         channelRepository.delete(channel)
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() {
+                members.forEach { member ->
+                    channelMemberEventPublisher.publishLeave(channel.id, channel.teamId, member.userId)
+                }
+            }
+        })
     }
 
     @Transactional
@@ -104,6 +123,11 @@ class ChannelService(
         val member = channelMemberRepository.save(
             ChannelMember(channelId = channelId, userId = request.userId)
         )
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() {
+                channelMemberEventPublisher.publishJoin(channel.id, channel.teamId, request.userId)
+            }
+        })
         return ChannelMemberResponse.of(member)
     }
 
@@ -137,5 +161,10 @@ class ChannelService(
         }
 
         channelMemberRepository.delete(member)
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() {
+                channelMemberEventPublisher.publishLeave(channel.id, channel.teamId, member.userId)
+            }
+        })
     }
 }

--- a/cowork-channel/src/main/resources/db/migration/V5__add_shedlock_table.sql
+++ b/cowork-channel/src/main/resources/db/migration/V5__add_shedlock_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS shedlock (
+    name       VARCHAR(64)  NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at  TIMESTAMP(3) NOT NULL,
+    locked_by  VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
@@ -7,6 +7,8 @@ import com.cowork.channel.domain.ChannelViewType
 import com.cowork.channel.dto.AddMemberRequest
 import com.cowork.channel.dto.CreateChannelRequest
 import com.cowork.channel.dto.UpdateChannelRequest
+import com.cowork.channel.event.ChannelMemberEventPublisher
+import com.cowork.channel.event.ChannelMembershipSyncPublisher
 import com.cowork.channel.repository.ChannelMemberRepository
 import com.cowork.channel.repository.ChannelRepository
 import io.mockk.every
@@ -25,8 +27,10 @@ class ChannelServiceTest {
     private val channelRepository = mockk<ChannelRepository>(relaxed = true)
     private val channelMemberRepository = mockk<ChannelMemberRepository>(relaxed = true)
     private val teamPermission = mockk<TeamPermissionService>()
+    private val channelMemberEventPublisher = mockk<ChannelMemberEventPublisher>(relaxed = true)
+    private val channelMembershipSyncPublisher = mockk<ChannelMembershipSyncPublisher>(relaxed = true)
 
-    private val service = ChannelService(channelRepository, channelMemberRepository, teamPermission)
+    private val service = ChannelService(channelRepository, channelMemberRepository, teamPermission, channelMemberEventPublisher, channelMembershipSyncPublisher)
 
     private fun channel(
         id: Long = 1L,

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
@@ -15,10 +15,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.sdk.exception.ExpectedException
 import java.util.Optional
 
@@ -31,6 +34,16 @@ class ChannelServiceTest {
     private val channelMembershipSyncPublisher = mockk<ChannelMembershipSyncPublisher>(relaxed = true)
 
     private val service = ChannelService(channelRepository, channelMemberRepository, teamPermission, channelMemberEventPublisher, channelMembershipSyncPublisher)
+
+    @BeforeEach
+    fun setUp() {
+        TransactionSynchronizationManager.initSynchronization()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        TransactionSynchronizationManager.clear()
+    }
 
     private fun channel(
         id: Long = 1L,

--- a/cowork-chat/src/membership/event/membership.event.ts
+++ b/cowork-chat/src/membership/event/membership.event.ts
@@ -1,6 +1,7 @@
 export interface ChannelMemberEvent {
     eventType: 'JOIN' | 'LEAVE' | 'ROLE_CHANGE';
     channelId: number;
+    teamId: number;
     userId: number;
     role: string;
     occurredAt: string;

--- a/cowork-chat/src/membership/membership.consumer.ts
+++ b/cowork-chat/src/membership/membership.consumer.ts
@@ -48,19 +48,19 @@ export class MembershipConsumer implements OnModuleInit, OnModuleDestroy {
     }
 
     private async handleEvent(event: ChannelMemberEvent): Promise<void> {
-        const { eventType, channelId, userId, role } = event;
+        const { eventType, channelId, teamId, userId, role } = event;
 
         try {
             if (eventType === 'JOIN') {
                 await this.memberModel.updateOne(
                     { channelId, userId },
-                    { $set: { role } },
+                    { $set: { teamId, role } },
                     { upsert: true },
                 );
             } else if (eventType === 'LEAVE') {
                 await this.memberModel.deleteOne({ channelId, userId });
             } else if (eventType === 'ROLE_CHANGE') {
-                await this.memberModel.updateOne({ channelId, userId }, { $set: { role } });
+                await this.memberModel.updateOne({ channelId, userId }, { $set: { teamId, role } });
             }
         } catch (err) {
             this.logger.error(`멤버십 이벤트 처리 실패 [${eventType}]`, err);

--- a/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
@@ -82,12 +82,12 @@ spring:
                 name: defaultCB
                 fallbackUri: forward:/fallback
 
-        - id: channel-service
-          uri: lb://cowork-channel
+        - id: chat-service-legacy
+          uri: lb://cowork-chat
           predicates:
-            - Path=/api/channels/**
+            - Path=/api/chats/**
           filters:
-            - StripPrefix=1
+            - RewritePath=/api/chats/?(?<segment>.*), /chat/$\{segment}
             - name: CircuitBreaker
               args:
                 name: defaultCB
@@ -96,7 +96,19 @@ spring:
         - id: chat-service
           uri: lb://cowork-chat
           predicates:
-            - Path=/api/chats/**
+            - Path=/api/channels/*/messages/**, /api/channels/*/messages, /api/channels/*/files/**, /api/channels/*/files, /api/channels/*/github/issues, /api/channels/*/slash-commands
+          filters:
+            - StripPrefix=1
+            - PrefixPath=/chat
+            - name: CircuitBreaker
+              args:
+                name: defaultCB
+                fallbackUri: forward:/fallback
+
+        - id: channel-service
+          uri: lb://cowork-channel
+          predicates:
+            - Path=/api/channels/**
           filters:
             - StripPrefix=1
             - name: CircuitBreaker

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -41,6 +41,21 @@ spring:
             maxAge: 3600
 
       routes:
+        - id: chat-service-legacy
+          uri: lb://cowork-chat
+          predicates:
+            - Path=/api/chats/**
+          filters:
+            - RewritePath=/api/chats/?(?<segment>.*), /chat/$\{segment}
+
+        - id: chat-service
+          uri: lb://cowork-chat
+          predicates:
+            - Path=/api/channels/*/messages/**, /api/channels/*/messages, /api/channels/*/files/**, /api/channels/*/files, /api/channels/*/github/issues, /api/channels/*/slash-commands
+          filters:
+            - StripPrefix=1
+            - PrefixPath=/chat
+
         - id: channel-service
           uri: lb://cowork-channel
           predicates:
@@ -106,13 +121,6 @@ spring:
           uri: lb://cowork-project
           predicates:
             - Path=/api/projects/**
-          filters:
-            - StripPrefix=1
-
-        - id: chat-service
-          uri: lb://cowork-chat
-          predicates:
-            - Path=/api/chats/**
           filters:
             - StripPrefix=1
 

--- a/cowork-team/src/main/kotlin/com/cowork/team/event/TeamEventPublisher.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/event/TeamEventPublisher.kt
@@ -15,6 +15,39 @@ class TeamEventPublisher(
 
     fun publishLifecycle(payload: TeamEventPayload) = send(Topics.TEAM_LIFECYCLE, payload)
 
+    fun publishMemberInvited(teamId: Long, teamName: String, actorUserId: Long, targetUserIds: List<Long>) {
+        if (targetUserIds.isEmpty()) return
+        publishLifecycle(
+            TeamEventPayload(
+                eventType = "MEMBER_INVITED",
+                teamId = teamId,
+                teamName = teamName,
+                actorUserId = actorUserId,
+                targetUserIds = targetUserIds.distinct(),
+            )
+        )
+    }
+
+    fun publishRoleChanged(
+        teamId: Long,
+        teamName: String,
+        actorUserId: Long,
+        targetUserIds: List<Long>,
+        newRole: String,
+    ) {
+        if (targetUserIds.isEmpty()) return
+        publishLifecycle(
+            TeamEventPayload(
+                eventType = "ROLE_CHANGED",
+                teamId = teamId,
+                teamName = teamName,
+                actorUserId = actorUserId,
+                targetUserIds = targetUserIds.distinct(),
+                newRole = newRole,
+            )
+        )
+    }
+
     private fun send(topic: String, payload: TeamEventPayload) {
         kafkaTemplate.send(topic, payload.teamId.toString(), payload)
             .whenComplete { result, ex ->

--- a/cowork-team/src/main/kotlin/com/cowork/team/event/TeamLifecycleSyncPublisher.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/event/TeamLifecycleSyncPublisher.kt
@@ -1,0 +1,52 @@
+package com.cowork.team.event
+
+import com.cowork.team.domain.TeamMember
+import com.cowork.team.domain.TeamRole
+import com.cowork.team.repository.TeamMemberRepository
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class TeamLifecycleSyncPublisher(
+    private val teamMemberRepository: TeamMemberRepository,
+    private val teamEventPublisher: TeamEventPublisher,
+) {
+
+    fun publishTeamSnapshot(actorUserId: Long, members: List<TeamMember>) {
+        if (members.isEmpty()) return
+
+        val team = members.first().team
+        teamEventPublisher.publishMemberInvited(
+            teamId = team.id,
+            teamName = team.name,
+            actorUserId = actorUserId,
+            targetUserIds = members.map(TeamMember::userId),
+        )
+
+        members.groupBy(TeamMember::role)
+            .filterKeys { it != TeamRole.MEMBER }
+            .forEach { (role, groupedMembers) ->
+                teamEventPublisher.publishRoleChanged(
+                    teamId = team.id,
+                    teamName = team.name,
+                    actorUserId = actorUserId,
+                    targetUserIds = groupedMembers.map(TeamMember::userId),
+                    newRole = role.name,
+                )
+            }
+    }
+
+    @EventListener(ApplicationReadyEvent::class)
+    @Transactional(readOnly = true)
+    fun publishAllSnapshots() {
+        teamMemberRepository.findAllWithTeam()
+            .groupBy { it.team.id }
+            .values
+            .forEach { members ->
+                val actorUserId = members.firstOrNull { it.role == TeamRole.OWNER }?.userId ?: members.first().userId
+                publishTeamSnapshot(actorUserId = actorUserId, members = members)
+            }
+    }
+}

--- a/cowork-team/src/main/kotlin/com/cowork/team/event/TeamLifecycleSyncPublisher.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/event/TeamLifecycleSyncPublisher.kt
@@ -5,6 +5,7 @@ import com.cowork.team.domain.TeamRole
 import com.cowork.team.repository.TeamMemberRepository
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
 
@@ -41,12 +42,16 @@ class TeamLifecycleSyncPublisher(
     @EventListener(ApplicationReadyEvent::class)
     @Transactional(readOnly = true)
     fun publishAllSnapshots() {
-        teamMemberRepository.findAllWithTeam()
-            .groupBy { it.team.id }
-            .values
-            .forEach { members ->
-                val actorUserId = members.firstOrNull { it.role == TeamRole.OWNER }?.userId ?: members.first().userId
-                publishTeamSnapshot(actorUserId = actorUserId, members = members)
-            }
+        var page = 0
+        do {
+            val idSlice = teamMemberRepository.findAllIds(PageRequest.of(page++, 500))
+            teamMemberRepository.findAllWithTeamByIds(idSlice.content)
+                .groupBy { it.team.id }
+                .values
+                .forEach { members ->
+                    val actorUserId = members.firstOrNull { it.role == TeamRole.OWNER }?.userId ?: members.first().userId
+                    publishTeamSnapshot(actorUserId = actorUserId, members = members)
+                }
+        } while (idSlice.hasNext())
     }
 }

--- a/cowork-team/src/main/kotlin/com/cowork/team/repository/TeamMemberRepository.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/repository/TeamMemberRepository.kt
@@ -2,6 +2,8 @@ package com.cowork.team.repository
 
 import com.cowork.team.domain.TeamMember
 import com.cowork.team.domain.TeamRole
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 
@@ -11,6 +13,12 @@ interface TeamMemberRepository : JpaRepository<TeamMember, Long> {
 
     @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team")
     fun findAllWithTeam(): List<TeamMember>
+
+    @Query("SELECT tm.id FROM TeamMember tm")
+    fun findAllIds(pageable: Pageable): Slice<Long>
+
+    @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.id IN :ids")
+    fun findAllWithTeamByIds(ids: List<Long>): List<TeamMember>
 
     @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.userId = :userId")
     fun findAllByUserIdWithTeam(userId: Long): List<TeamMember>

--- a/cowork-team/src/main/kotlin/com/cowork/team/repository/TeamMemberRepository.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/repository/TeamMemberRepository.kt
@@ -9,6 +9,9 @@ interface TeamMemberRepository : JpaRepository<TeamMember, Long> {
 
     fun findAllByTeamId(teamId: Long): List<TeamMember>
 
+    @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team")
+    fun findAllWithTeam(): List<TeamMember>
+
     @Query("SELECT tm FROM TeamMember tm JOIN FETCH tm.team WHERE tm.userId = :userId")
     fun findAllByUserIdWithTeam(userId: Long): List<TeamMember>
 

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamService.kt
@@ -11,6 +11,7 @@ import com.cowork.team.dto.TeamResponse
 import com.cowork.team.dto.TeamSummaryResponse
 import com.cowork.team.dto.UpdateTeamRequest
 import com.cowork.team.event.TeamEventPublisher
+import com.cowork.team.event.TeamLifecycleSyncPublisher
 import com.cowork.team.repository.TeamMemberRepository
 import com.cowork.team.repository.TeamRepository
 import org.springframework.http.HttpStatus
@@ -26,6 +27,7 @@ class TeamService(
     private val teamRepository: TeamRepository,
     private val teamMemberRepository: TeamMemberRepository,
     private val teamEventPublisher: TeamEventPublisher,
+    private val teamLifecycleSyncPublisher: TeamLifecycleSyncPublisher,
     private val s3Service: S3Service,
 ) {
 
@@ -72,7 +74,13 @@ class TeamService(
             targetUserIds = listOf(ownerId),
         )
         TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() = teamEventPublisher.publishNotification(payload)
+            override fun afterCommit() {
+                teamEventPublisher.publishNotification(payload)
+                teamLifecycleSyncPublisher.publishTeamSnapshot(
+                    actorUserId = ownerId,
+                    members = listOf(TeamMember(team = team, userId = ownerId, role = TeamRole.OWNER)),
+                )
+            }
         })
 
         return TeamResponse.of(team)

--- a/cowork-team/src/test/kotlin/com/cowork/team/service/TeamServiceTest.kt
+++ b/cowork-team/src/test/kotlin/com/cowork/team/service/TeamServiceTest.kt
@@ -5,6 +5,7 @@ import com.cowork.team.domain.TeamMember
 import com.cowork.team.domain.TeamRole
 import com.cowork.team.dto.TeamEventPayload
 import com.cowork.team.event.TeamEventPublisher
+import com.cowork.team.event.TeamLifecycleSyncPublisher
 import com.cowork.team.repository.TeamMemberRepository
 import com.cowork.team.repository.TeamRepository
 import io.mockk.Runs
@@ -25,12 +26,14 @@ class TeamServiceTest {
     private val teamRepository = mockk<TeamRepository>()
     private val teamMemberRepository = mockk<TeamMemberRepository>()
     private val teamEventPublisher = mockk<TeamEventPublisher>(relaxed = true)
+    private val teamLifecycleSyncPublisher = mockk<TeamLifecycleSyncPublisher>(relaxed = true)
     private val s3Service = mockk<S3Service>()
 
     private val service = TeamService(
         teamRepository = teamRepository,
         teamMemberRepository = teamMemberRepository,
         teamEventPublisher = teamEventPublisher,
+        teamLifecycleSyncPublisher = teamLifecycleSyncPublisher,
         s3Service = s3Service,
     )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ postgresql = "42.7.3"
 micrometer = "1.14.5"
 logstash-logback = "8.0"
 mockk = "1.13.13"
+shedlock = "5.16.0"
 
 [libraries]
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
@@ -74,6 +75,8 @@ flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-encoder", version.ref = "logstash-logback" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+shedlock-spring = { module = "net.javacrumbs.shedlock:shedlock-spring", version.ref = "shedlock" }
+shedlock-provider-jdbc-template = { module = "net.javacrumbs.shedlock:shedlock-provider-jdbc-template", version.ref = "shedlock" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }


### PR DESCRIPTION
## 개요

팀 및 채널의 라이프사이클 이벤트를 통한 서비스 간 데이터 동기화 체계를 강화하고, 게이트웨이의 라우팅 설정을 최적화하였습니다.

## 본문

### 서비스 간 멤버십 동기화 이벤트 강화
- **팀 서비스 (`cowork-team`)**: 팀 생성 시 초기 멤버십 스냅샷 동기화 로직을 구현하고, 멤버 초대 및 역할 변경 시의 이벤트를 세분화하여 발행하도록 개선하였습니다.
- **채널 서비스 (`cowork-channel`)**: 채널 생성, 삭제 및 멤버의 참여/탈퇴 시 실시간으로 이벤트를 발행하는 기능을 추가하여 타 서비스와의 정합성을 높였습니다.
- **채팅 서비스 (`cowork-chat`)**: 수신되는 채널 멤버십 이벤트 스키마에 `teamId`를 추가하여 데이터 필터링 및 관리 효율을 개선하였습니다.

### 게이트웨이 라우팅 경로 최적화
- 채팅 서비스와 채널 서비스의 책임 범위에 맞춰 API 라우팅 경로(`Messages`, `Files`, `Slash Commands` 등)를 재조정하였습니다.
- 로컬 및 개발 환경의 게이트웨이 설정을 일관성 있게 업데이트하였습니다.