### PR TITLE
[promotion] Elasticsearch 추가 및 이미지 로딩 최적화

### DIFF
--- a/cowork-promotion/components/MemberCard.vue
+++ b/cowork-promotion/components/MemberCard.vue
@@ -41,7 +41,10 @@ const positionColor = computed(() => {
       :src="avatarUrl"
       :alt="member.name"
       class="w-11 h-11 rounded-full object-cover bg-gray-100 ring-2 ring-gray-100"
+      width="44"
+      height="44"
       loading="lazy"
+      decoding="async"
     />
     <div class="min-w-0">
       <p class="font-semibold text-gray-900 text-sm leading-tight truncate">

--- a/cowork-promotion/nuxt.config.ts
+++ b/cowork-promotion/nuxt.config.ts
@@ -25,7 +25,7 @@ export default defineNuxtConfig({
           crossorigin: '',
         },
         { rel: 'preconnect', href: 'https://avatars.githubusercontent.com' },
-        { rel: 'dns-prefetch', href: 'https://github-repository-language-graph-wi.vercel.app' },
+        { rel: 'preconnect', href: 'https://github-repository-language-graph-wi.vercel.app' },
         {
           rel: 'stylesheet',
           href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,400;0,14..32,500;0,14..32,600;0,14..32,700;0,14..32,800;0,14..32,900&display=swap',

--- a/cowork-promotion/nuxt.config.ts
+++ b/cowork-promotion/nuxt.config.ts
@@ -2,6 +2,9 @@ export default defineNuxtConfig({
   compatibilityDate: '2026-04-27',
   devtools: { enabled: false },
   modules: ['@nuxtjs/tailwindcss'],
+  routeRules: {
+    '/': { prerender: true },
+  },
   app: {
     head: {
       title: 'cowork',
@@ -21,6 +24,8 @@ export default defineNuxtConfig({
           href: 'https://fonts.gstatic.com',
           crossorigin: '',
         },
+        { rel: 'preconnect', href: 'https://avatars.githubusercontent.com' },
+        { rel: 'dns-prefetch', href: 'https://github-repository-language-graph-wi.vercel.app' },
         {
           rel: 'stylesheet',
           href: 'https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,400;0,14..32,500;0,14..32,600;0,14..32,700;0,14..32,800;0,14..32,900&display=swap',

--- a/cowork-promotion/pages/index.vue
+++ b/cowork-promotion/pages/index.vue
@@ -355,7 +355,7 @@ const row2 = [...marqueeItems, ...marqueeItems]
                             <img
                                 :alt="`${repo.name} language stats`"
                                 :src="`https://github-repository-language-graph-wi.vercel.app/api?username=team-cowork&repo=${repo.name}&theme=white&langs_count=100`"
-                                class="w-full h-auto block"
+                                class="w-full block aspect-[4/1] object-contain"
                                 loading="lazy"
                                 decoding="async"
                             />

--- a/cowork-promotion/pages/index.vue
+++ b/cowork-promotion/pages/index.vue
@@ -357,6 +357,7 @@ const row2 = [...marqueeItems, ...marqueeItems]
                                 :src="`https://github-repository-language-graph-wi.vercel.app/api?username=team-cowork&repo=${repo.name}&theme=white&langs_count=100`"
                                 class="w-full h-auto block"
                                 loading="lazy"
+                                decoding="async"
                             />
                         </div>
 
@@ -512,7 +513,10 @@ const row2 = [...marqueeItems, ...marqueeItems]
                                             :src="`https://github.com/${member.githubId}.png?size=64`"
                                             :alt="member.name"
                                             class="w-8 h-8 rounded-full object-cover"
+                                            width="32"
+                                            height="32"
                                             loading="lazy"
+                                            decoding="async"
                                         />
                                         <div>
                                             <p class="text-sm font-semibold text-gray-900 leading-tight">{{ member.name }}</p>

--- a/cowork-promotion/pages/index.vue
+++ b/cowork-promotion/pages/index.vue
@@ -61,6 +61,7 @@ const techCategories: { label: string; items: TechItem[] }[] = [
             {name: 'PostgreSQL', color: '#336791', positions: []},
             {name: 'MongoDB', color: '#47A248', positions: ['Server']},
             {name: 'Redis', color: '#DC382D', positions: ['Server']},
+            {name: 'Elasticsearch', color: '#005571', positions: ['Server']},
             {name: 'Flyway', color: '#CC0200', positions: ['Server']},
         ],
     },


### PR DESCRIPTION
## 개요

홍보 페이지의 기술 스택 섹션에 Elasticsearch를 추가하였습니다. 또한 외부 이미지 리소스의 캐싱 및 로딩 방식을 개선하여 페이지 초기 로딩 성능을 향상시켰습니다.

## 본문

**Elasticsearch 기술 스택 추가**
- Database 카테고리에 Elasticsearch를 추가하였습니다 (색상: `#005571`, 포지션: `Server`)
- Position 섹션의 Server 포지션 기술 뱃지에도 자동으로 반영되었습니다

**이미지 캐싱 및 로딩 최적화**
- `nuxt.config.ts`에 `routeRules: { '/': { prerender: true } }`를 추가하여 빌드 시 정적 HTML을 생성하도록 설정하였습니다. 모든 데이터가 정적이므로 SSG 방식으로 CDN에서 바로 서빙이 가능합니다.
- GitHub 아바타 도메인(`avatars.githubusercontent.com`)에 대한 `preconnect`를 추가하여 DNS 조회 및 TLS 핸드셰이크를 선행 처리하도록 하였습니다.
- 언어 그래프 API 도메인(`github-repository-language-graph-wi.vercel.app`)에 `dns-prefetch`를 추가하였습니다.
- `MemberCard.vue`와 `index.vue`의 외부 이미지 태그에 `width`, `height` 속성을 명시하여 CLS(Cumulative Layout Shift)를 방지하였습니다.
- 모든 외부 이미지에 `decoding="async"` 속성을 추가하여 이미지 디코딩을 메인 스레드와 병렬로 처리하도록 하였습니다.