### PR TITLE
[chat] Socket.io 연결 시 JWT Bearer 토큰 인증 구현

### DIFF
--- a/cowork-chat/package-lock.json
+++ b/cowork-chat/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/common": "^11.1.19",
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.1.19",
+        "@nestjs/jwt": "^11.0.2",
         "@nestjs/microservices": "^11.1.19",
         "@nestjs/mongoose": "^11.0.4",
         "@nestjs/platform-express": "^11.1.19",
@@ -1262,6 +1263,19 @@
         }
       }
     },
+    "node_modules/@nestjs/jwt": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/@nestjs/jwt/-/jwt-11.0.2.tgz",
+      "integrity": "sha512-rK8aE/3/Ma45gAWfCksAXUNbOoSOUudU0Kn3rT39htPF7wsYXtKfjALKeKKJbFrIWbLjsbqfXX5bIJNvgBugGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonwebtoken": "9.0.10",
+        "jsonwebtoken": "9.0.3"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
+      }
+    },
     "node_modules/@nestjs/mapped-types": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.1.tgz",
@@ -1790,11 +1804,27 @@
         "pretty-format": "^30.0.0"
       }
     },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/mime-types": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-3.0.1.tgz",
       "integrity": "sha512-xRMsfuQbnRq1Ef+C+RKaENOxXX87Ygl38W1vDfPHRku02TgQr+Qd8iivLtAMcR0KF5/29xlnFihkTlbqFrGOVQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -2591,6 +2621,12 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -3126,6 +3162,15 @@
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -4763,6 +4808,61 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/kafkajs": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
@@ -4842,11 +4942,53 @@
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/cowork-chat/package.json
+++ b/cowork-chat/package.json
@@ -19,6 +19,7 @@
     "@nestjs/common": "^11.1.19",
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.1.19",
+    "@nestjs/jwt": "^11.0.2",
     "@nestjs/microservices": "^11.1.19",
     "@nestjs/mongoose": "^11.0.4",
     "@nestjs/platform-express": "^11.1.19",

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -16,6 +16,7 @@ import { ChatService } from './chat.service';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
 import { JoinChannelDto } from './dto/join-channel.dto';
+import { UserRole } from '../common/enum/user-role.enum';
 
 @WebSocketGateway({
     namespace: '/chat',
@@ -53,12 +54,12 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 
             const payload = this.jwtService.verify<{ sub: string; role?: string }>(token);
             const userId = Number(payload.sub);
-            if (isNaN(userId)) {
+            if (isNaN(userId) || userId <= 0) {
                 throw new Error('토큰의 sub 클레임이 유효하지 않습니다');
             }
 
             client.data.userId = userId;
-            client.data.userRole = payload.role ?? 'ROLE_USER';
+            client.data.userRole = payload.role ?? UserRole.USER;
             this.logger.log(`연결됨: ${client.id} (userId=${userId})`);
         } catch (err) {
             const message = err instanceof Error ? err.message : '인증 실패';

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -10,11 +10,11 @@ import {
 } from '@nestjs/websockets';
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
 import { ChatService } from './chat.service';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
-import { RequestContextUtil } from '../common/util/request-context.util';
 import { JoinChannelDto } from './dto/join-channel.dto';
 
 @WebSocketGateway({
@@ -36,6 +36,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         private readonly consumer: ChatMessageConsumer,
         private readonly githubIssueResultConsumer: GithubIssueResultConsumer,
         private readonly configService: ConfigService,
+        private readonly jwtService: JwtService,
     ) {}
 
     afterInit(server: Server) {
@@ -45,12 +46,24 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 
     async handleConnection(client: Socket) {
         try {
-            const userId = RequestContextUtil.getUserId(client.handshake.headers as any);
+            const token = client.handshake.auth?.token as string | undefined;
+            if (!token) {
+                throw new Error('토큰이 전달되지 않았습니다');
+            }
+
+            const payload = this.jwtService.verify<{ sub: string; role?: string }>(token);
+            const userId = Number(payload.sub);
+            if (isNaN(userId)) {
+                throw new Error('토큰의 sub 클레임이 유효하지 않습니다');
+            }
+
             client.data.userId = userId;
-            client.data.userRole = RequestContextUtil.getUserRole(client.handshake.headers as any);
+            client.data.userRole = payload.role ?? 'ROLE_USER';
             this.logger.log(`연결됨: ${client.id} (userId=${userId})`);
-        } catch {
-            this.logger.warn(`인증 실패로 연결 거부: ${client.id}`);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : '인증 실패';
+            this.logger.warn(`인증 실패로 연결 거부: ${client.id} - ${message}`);
+            client.emit('exception', { message: '인증 실패: ' + message });
             client.disconnect();
         }
     }

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -52,7 +52,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
                 throw new Error('토큰이 전달되지 않았습니다');
             }
 
-            const payload = this.jwtService.verify<{ sub: string; role?: string }>(token);
+            const payload = await this.jwtService.verifyAsync<{ sub: string; role?: string }>(token);
             const userId = Number(payload.sub);
             if (isNaN(userId) || userId <= 0) {
                 throw new Error('토큰의 sub 클레임이 유효하지 않습니다');

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
 import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 import { LoggerModule } from 'nestjs-pino';
@@ -61,6 +62,14 @@ function createLogStream() {
 @Module({
     imports: [
         ConfigModule,
+        JwtModule.registerAsync({
+            imports: [ConfigModule],
+            inject: [ConfigService],
+            useFactory: (configService: ConfigService) => ({
+                secret: getRequiredConfig(configService, 'JWT_SECRET'),
+                signOptions: { algorithm: 'HS256' },
+            }),
+        }),
         ...loggerImports,
         PrometheusModule.register({
             defaultMetrics: { enabled: true },

--- a/cowork-chat/src/main.ts
+++ b/cowork-chat/src/main.ts
@@ -44,8 +44,12 @@ async function bootstrap() {
             '| `message:edited` | S→C | 메시지 수정됨 |\n' +
             '| `message:deleted` | S→C | 메시지 삭제됨 |\n\n' +
             '## 인증\n' +
-            'Gateway에서 주입된 `X-User-Id`, `X-User-Role` 헤더 사용.\n' +
-            'WebSocket은 handshake 헤더로 인증.',
+            'REST API: Gateway에서 주입된 `X-User-Id`, `X-User-Role` 헤더 사용.\n' +
+            'WebSocket: Socket.io handshake의 `auth.token`에 JWT Bearer 토큰 전달.\n' +
+            '```js\n' +
+            'io(url, { auth: { token: "<JWT>" } })\n' +
+            '```\n' +
+            '인증 실패 시 서버는 `exception` 이벤트를 emit한 후 연결을 끊습니다.',
         )
         .setVersion('1.0')
         .build();

--- a/cowork-config/src/main/resources/configs/cowork-chat-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-chat-dev.yml
@@ -1,5 +1,6 @@
-# MONGODB_URI는 Vault secret/cowork-chat 에서 주입됨
+# MONGODB_URI, JWT_SECRET은 Vault secret/cowork-chat 에서 주입됨
 PORT: 8087
+JWT_SECRET: ${JWT_SECRET}
 MONGODB_DIRECT_CONNECTION: false
 MONGODB_SERVER_SELECTION_TIMEOUT_MS: 5000
 MONGODB_CONNECT_TIMEOUT_MS: 5000

--- a/cowork-config/src/main/resources/configs/cowork-chat-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-chat-local.yml
@@ -1,5 +1,6 @@
-# MONGODB_URI는 Vault secret/cowork-chat 에서 주입됨
+# MONGODB_URI, JWT_SECRET은 Vault secret/cowork-chat 에서 주입됨
 PORT: 8087
+JWT_SECRET: ${JWT_SECRET}
 MONGODB_DIRECT_CONNECTION: false
 MONGODB_SERVER_SELECTION_TIMEOUT_MS: 5000
 MONGODB_CONNECT_TIMEOUT_MS: 5000

--- a/cowork-gateway/src/main/kotlin/com/cowork/gateway/security/SecurityConfig.kt
+++ b/cowork-gateway/src/main/kotlin/com/cowork/gateway/security/SecurityConfig.kt
@@ -49,6 +49,9 @@ class SecurityConfig(
                     .pathMatchers("/swagger-ui.html", "/swagger-ui/**", "/webjars/**").permitAll()
                     .pathMatchers("/v3/api-docs/**").permitAll()
                     .pathMatchers(HttpMethod.POST, "/api/voice/webhook").permitAll()
+                    // Socket.io auth는 HTTP 헤더가 아닌 프로토콜 레벨에서 전달되므로
+                    // Gateway JWT 검증을 우회하고 chat 서비스에서 직접 검증한다
+                    .pathMatchers("/chat-ws/**").permitAll()
                     .anyExchange().authenticated()
             }
             .addFilterAt(jwtFilter, SecurityWebFiltersOrder.AUTHENTICATION)


### PR DESCRIPTION
## 개요

Socket.io 연결 시 JWT Bearer 토큰 인증을 구현하였습니다. 기존에는 Gateway 주입 헤더(`X-User-Id`) 방식을 사용하였으나, 브라우저 WebSocket은 HTTP 업그레이드 요청에 커스텀 헤더를 설정할 수 없어 클라이언트가 `auth: { token }` 형태로 전달하는 Socket.io 프로토콜 레벨 토큰을 chat 서비스에서 직접 검증하도록 변경하였습니다. 아울러 Gateway의 `/chat-ws/**` 경로를 `permitAll`로 허용하여 WebSocket 업그레이드 요청이 차단되지 않도록 수정하였습니다.

## 본문

### 배경

클라이언트의 텍스트 채널 메시지 입력이 비활성화 상태였습니다. Socket.io 연결 시 Gateway가 `anyExchange().authenticated()` 정책으로 `/chat-ws/**` 경로를 차단하고 있었으며, 클라이언트가 전달하는 `auth: { token }` 값은 Socket.io 프로토콜 레벨 데이터라 HTTP 업그레이드 요청 헤더에 포함되지 않아 Gateway에서 인식할 수 없었습니다.

### 변경 사항

**cowork-gateway — SecurityConfig**
- `/chat-ws/**` 경로를 `permitAll()` 목록에 추가하여 WebSocket 업그레이드 요청이 Gateway JWT 필터를 통과하도록 수정하였습니다.

**cowork-chat — ChatGateway**
- `handleConnection`에서 `client.handshake.auth.token`을 추출하여 `JwtService.verify()`로 HS256 서명 및 만료를 검증하도록 변경하였습니다.
- 검증 성공 시 `sub` 클레임을 `client.data.userId`에, `role` 클레임을 `client.data.userRole`에 저장합니다.
- 검증 실패 시 `exception` 이벤트를 emit한 후 연결을 끊습니다.

**cowork-chat — ChatModule**
- `JwtModule.registerAsync`를 등록하여 `JWT_SECRET` 환경변수로 HS256 검증 모듈을 초기화하도록 추가하였습니다.

**cowork-config**
- `cowork-chat-local.yml`, `cowork-chat-dev.yml`에 `JWT_SECRET: ${JWT_SECRET}` 항목을 추가하였습니다.

### Gateway 예외 근거

브라우저 WebSocket은 HTTP 업그레이드 요청에 커스텀 헤더를 설정할 수 없는 브라우저 보안 제한이 있습니다. Socket.io의 `auth` 데이터는 Socket.io 프로토콜 CONNECT 패킷에 포함되며 HTTP 레벨에서는 보이지 않습니다. 이에 따라 WebSocket 엔드포인트에 한해 Gateway 인증을 우회하고 chat 서비스에서 동일한 `JWT_SECRET`과 알고리즘(HS256)으로 직접 검증하는 방식을 채택하였습니다.
