### PR TITLE
[chat] Elasticsearch 연동 및 프로젝트 채팅 검색 기능 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,11 @@ VAULT_PORT=8200
 VAULT_SCHEME=http
 VAULT_TOKEN=dev-root-token
 
+# ── Elasticsearch ────────────────────────────────────────────────────────────
+# 로컬: docker-compose 내부 컨테이너 주소 (기본값)
+# 운영: 관리형 ES 클러스터 주소 (예: https://my-cluster.es.io:9200)
+ELASTICSEARCH_URL=http://elasticsearch:9200
+
 # ── LiveKit ──────────────────────────────────────────────────────────────────
 # 로컬 개발: devkey / devsecret 사용 가능
 # 운영 환경: lk-cli create-api-key 등으로 생성한 키/시크릿 입력

--- a/cowork-chat/package-lock.json
+++ b/cowork-chat/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "cowork-chat",
-  "version": "20260420.0",
+  "version": "20260510.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cowork-chat",
-      "version": "20260420.0",
+      "version": "20260510.0",
       "license": "ISC",
       "dependencies": {
+        "@elastic/elasticsearch": "^8.19.1",
         "@nestjs/common": "^11.1.19",
         "@nestjs/config": "^4.0.4",
         "@nestjs/core": "^11.1.19",
@@ -577,6 +578,39 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@elastic/elasticsearch": {
+      "version": "8.19.1",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.19.1.tgz",
+      "integrity": "sha512-+1j9NnQVOX+lbWB8LhCM7IkUmjU05Y4+BmSLfusq0msCsQb1Va+OUKFCoOXjCJqQrcgdRdQCjYYyolQ/npQALQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@elastic/transport": "^8.9.6",
+        "apache-arrow": "18.x - 21.x",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@elastic/transport": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.10.1.tgz",
+      "integrity": "sha512-xo2lPBAJEt81fQRAKa9T/gUq1SPGBHpSnVUXhoSpL996fPZRAfQwFA4BZtEUQL1p8Dezodd3ZN8Wwno+mYyKuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "1.x",
+        "@opentelemetry/core": "2.x",
+        "debug": "^4.4.1",
+        "hpagent": "^1.2.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^3.0.1",
+        "tslib": "^2.8.1",
+        "undici": "^6.21.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1527,6 +1561,30 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
@@ -1596,6 +1654,15 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
     },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
@@ -1714,6 +1781,18 @@
         "@types/connect": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
+      "license": "MIT"
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -2290,7 +2369,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2329,6 +2407,41 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.12.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.3.tgz",
+      "integrity": "sha512-8oljBDGun9cIsZRJR6fkihn0TSXJI0UDOOhncYaERq6M0JMDoPLxyscwruJcb4GKS6dvK/d8xebYBg27h/duaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -2347,6 +2460,15 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
+    },
+    "node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -2727,7 +2849,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2738,6 +2859,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
     "node_modules/char-regex": {
@@ -2890,7 +3026,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2903,8 +3038,45 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -3605,6 +3777,23 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3618,6 +3807,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -3831,7 +4026,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3859,6 +4053,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/html-escaper": {
@@ -4788,6 +4991,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -4940,6 +5151,12 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {
@@ -6153,6 +6370,22 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/secure-json-parse": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-3.0.2.tgz",
+      "integrity": "sha512-H6nS2o8bWfpFEV6U38sOSjS7bTbdgbCGU9wEM6W14P5H0QOsz94KCusifV44GpHDTu2nqZbuDNhTzu+mjDSw1w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -6771,7 +7004,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -6803,6 +7035,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/synckit"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/tdigest": {
@@ -7125,6 +7370,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -7161,6 +7415,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -7368,6 +7631,15 @@
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/cowork-chat/package.json
+++ b/cowork-chat/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@elastic/elasticsearch": "^8.19.1",
     "@nestjs/common": "^11.1.19",
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.1.19",

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -8,6 +8,7 @@ import { createWriteStream, mkdirSync } from 'fs';
 import { ChatGateway } from './chat.gateway';
 import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
+import { ProjectMessageController } from './project-message.controller';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { NotificationTriggerProducer } from './kafka/notification-trigger.producer';
@@ -20,6 +21,7 @@ import { ChannelMember, ChannelMemberSchema } from './schema/channel-member.sche
 import { MembershipModule } from '../membership/membership.module';
 import { HealthController } from '../health.controller';
 import { MinioModule } from '../storage/minio.module';
+import { SearchModule } from '../search/search.module';
 import { getOptionalConfig, getRequiredConfig } from '../common/config/config.util';
 
 const LOG_DIR = process.env.COWORK_CHAT_LOG_DIR ?? `${process.cwd()}/build/logs/cowork/chat`;
@@ -91,8 +93,9 @@ function createLogStream() {
         ]),
         MembershipModule,
         MinioModule,
+        SearchModule,
     ],
-    controllers: [ChatController, HealthController],
+    controllers: [ChatController, ProjectMessageController, HealthController],
     providers: [
         ChatGateway,
         ChatService,

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -5,6 +5,7 @@ import { Types } from 'mongoose';
 import { ChatService } from './chat.service';
 import { Message } from './schema/message.schema';
 import { ChannelMember } from './schema/channel-member.schema';
+import { ElasticsearchService } from '../search/elasticsearch.service';
 
 const mockMessageId = new Types.ObjectId().toString();
 
@@ -34,6 +35,11 @@ const mockMemberModel = {
     exists: jest.fn(),
 };
 
+const mockElasticsearchService = {
+    updateMessage: jest.fn().mockResolvedValue(undefined),
+    deleteMessage: jest.fn().mockResolvedValue(undefined),
+};
+
 describe('ChatService', () => {
     let service: ChatService;
 
@@ -43,6 +49,7 @@ describe('ChatService', () => {
                 ChatService,
                 { provide: getModelToken(Message.name), useValue: mockMessageModel },
                 { provide: getModelToken(ChannelMember.name), useValue: mockMemberModel },
+                { provide: ElasticsearchService, useValue: mockElasticsearchService },
             ],
         }).compile();
 
@@ -149,6 +156,27 @@ describe('ChatService', () => {
 
             expect(msg.save).toHaveBeenCalled();
         });
+
+        it('수정 후 ES updateMessage를 fire-and-forget으로 호출한다', async () => {
+            const msg = makeMockMessage();
+            mockMessageModel.findById.mockResolvedValue(msg);
+            mockElasticsearchService.updateMessage.mockResolvedValue(undefined);
+
+            await service.editMessage(mockMessageId, 42, { content: '수정됨' }, 'ROLE_USER');
+
+            await new Promise((r) => setImmediate(r));
+            expect(mockElasticsearchService.updateMessage).toHaveBeenCalledWith(mockMessageId, '수정됨');
+        });
+
+        it('ES 오류가 발생해도 editMessage 결과에 영향을 주지 않는다', async () => {
+            const msg = makeMockMessage();
+            mockMessageModel.findById.mockResolvedValue(msg);
+            mockElasticsearchService.updateMessage.mockRejectedValue(new Error('ES down'));
+
+            await expect(
+                service.editMessage(mockMessageId, 42, { content: '수정됨' }, 'ROLE_USER'),
+            ).resolves.toBeDefined();
+        });
     });
 
     describe('deleteMessage', () => {
@@ -182,6 +210,27 @@ describe('ChatService', () => {
 
             await expect(
                 service.deleteMessage(mockMessageId, 42, 'ROLE_ADMIN'),
+            ).resolves.toBeDefined();
+        });
+
+        it('삭제 후 ES deleteMessage를 fire-and-forget으로 호출한다', async () => {
+            mockMessageModel.findById.mockResolvedValue(makeMockMessage());
+            mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+            mockElasticsearchService.deleteMessage.mockResolvedValue(undefined);
+
+            await service.deleteMessage(mockMessageId, 42, 'ROLE_USER');
+
+            await new Promise((r) => setImmediate(r));
+            expect(mockElasticsearchService.deleteMessage).toHaveBeenCalledWith(mockMessageId);
+        });
+
+        it('ES 오류가 발생해도 deleteMessage 결과에 영향을 주지 않는다', async () => {
+            mockMessageModel.findById.mockResolvedValue(makeMockMessage());
+            mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+            mockElasticsearchService.deleteMessage.mockRejectedValue(new Error('ES down'));
+
+            await expect(
+                service.deleteMessage(mockMessageId, 42, 'ROLE_USER'),
             ).resolves.toBeDefined();
         });
     });

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -85,9 +85,9 @@ export class ChatService {
         message.content = dto.content;
         message.isEdited = true;
         const saved = await message.save();
-        this.elasticsearchService.updateMessage(messageId, dto.content).catch((err) =>
-            this.logger.error(`ES 메시지 수정 동기화 실패 id=${messageId}`, err),
-        );
+        if (message.projectId) {
+            void this.elasticsearchService.updateMessage(messageId, dto.content);
+        }
         return saved;
     }
 
@@ -99,9 +99,9 @@ export class ChatService {
         }
 
         await this.messageModel.deleteOne({ _id: messageId });
-        this.elasticsearchService.deleteMessage(messageId).catch((err) =>
-            this.logger.error(`ES 메시지 삭제 동기화 실패 id=${messageId}`, err),
-        );
+        if (message.projectId) {
+            void this.elasticsearchService.deleteMessage(messageId);
+        }
         return { channelId: message.channelId, messageId };
     }
 

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -1,18 +1,22 @@
-import { ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import { Message } from './schema/message.schema';
 import { ChannelMember } from './schema/channel-member.schema';
 import { EditMessageDto } from './dto/edit-message.dto';
 import { UserRole } from '../common/enum/user-role.enum';
+import { ElasticsearchService } from '../search/elasticsearch.service';
 
 const SYSTEM_AUTHOR_ID = 0;
 
 @Injectable()
 export class ChatService {
+    private readonly logger = new Logger(ChatService.name);
+
     constructor(
         @InjectModel(Message.name) private readonly messageModel: Model<Message>,
         @InjectModel(ChannelMember.name) private readonly memberModel: Model<ChannelMember>,
+        private readonly elasticsearchService: ElasticsearchService,
     ) {}
 
     async isMember(channelId: number, userId: number): Promise<boolean> {
@@ -80,7 +84,11 @@ export class ChatService {
         message.editHistory.push({ content: message.content, editedAt: new Date() });
         message.content = dto.content;
         message.isEdited = true;
-        return message.save();
+        const saved = await message.save();
+        this.elasticsearchService.updateMessage(messageId, dto.content).catch((err) =>
+            this.logger.error(`ES 메시지 수정 동기화 실패 id=${messageId}`, err),
+        );
+        return saved;
     }
 
     async deleteMessage(messageId: string, userId: number, userRole: string) {
@@ -91,6 +99,9 @@ export class ChatService {
         }
 
         await this.messageModel.deleteOne({ _id: messageId });
+        this.elasticsearchService.deleteMessage(messageId).catch((err) =>
+            this.logger.error(`ES 메시지 삭제 동기화 실패 id=${messageId}`, err),
+        );
         return { channelId: message.channelId, messageId };
     }
 

--- a/cowork-chat/src/chat/dto/search-message-response.dto.ts
+++ b/cowork-chat/src/chat/dto/search-message-response.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class SearchMessageItemDto {
+    @ApiProperty() messageId!: string;
+    @ApiProperty() channelId!: number;
+    @ApiProperty() authorId!: number;
+    @ApiProperty() content!: string;
+    @ApiProperty({ type: [String], description: '<em>키워드</em> 포함 snippet 배열' }) highlight!: string[];
+    @ApiProperty({ enum: ['TEXT', 'FILE', 'SYSTEM'] }) type!: string;
+    @ApiProperty() hasAttachments!: boolean;
+    @ApiProperty() isPinned!: boolean;
+    @ApiProperty() createdAt!: string;
+}
+
+export class SearchMessagesResponseDto {
+    @ApiProperty({ type: [SearchMessageItemDto] }) messages!: SearchMessageItemDto[];
+    @ApiPropertyOptional({ nullable: true, description: '다음 페이지 커서 (마지막 페이지이면 null)' }) nextCursor!: string | null;
+}

--- a/cowork-chat/src/chat/dto/search-messages.dto.ts
+++ b/cowork-chat/src/chat/dto/search-messages.dto.ts
@@ -1,0 +1,26 @@
+import { IsString, IsOptional, IsInt, IsEnum, IsBoolean, Min, Max, MinLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+
+export class SearchMessagesDto {
+    @ApiProperty({ description: '검색 키워드 (최소 1자)', minLength: 1 })
+    @IsString() @MinLength(1) q!: string;
+
+    @ApiPropertyOptional({ description: '특정 채널로 범위 축소' })
+    @IsInt() @IsOptional() @Type(() => Number) channelId?: number;
+
+    @ApiPropertyOptional({ description: '특정 작성자 필터' })
+    @IsInt() @IsOptional() @Type(() => Number) authorId?: number;
+
+    @ApiPropertyOptional({ enum: ['TEXT', 'FILE', 'SYSTEM'], description: '메시지 타입 필터' })
+    @IsEnum(['TEXT', 'FILE', 'SYSTEM']) @IsOptional() type?: string;
+
+    @ApiPropertyOptional({ description: '첨부파일 포함 메시지만 조회' })
+    @IsBoolean() @IsOptional() @Transform(({ value }) => value === 'true' || value === true) hasFile?: boolean;
+
+    @ApiPropertyOptional({ description: '커서: 이 messageId 이후 결과 조회 (이전 응답의 nextCursor 값)' })
+    @IsString() @IsOptional() before?: string;
+
+    @ApiPropertyOptional({ description: '페이지 크기 (기본 50, 최대 100)', default: 50 })
+    @IsInt() @Min(1) @Max(100) @IsOptional() @Type(() => Number) limit?: number;
+}

--- a/cowork-chat/src/chat/dto/search-messages.dto.ts
+++ b/cowork-chat/src/chat/dto/search-messages.dto.ts
@@ -18,7 +18,7 @@ export class SearchMessagesDto {
     @ApiPropertyOptional({ description: '첨부파일 포함 메시지만 조회' })
     @IsBoolean() @IsOptional() @Transform(({ value }) => value === 'true' || value === true) hasFile?: boolean;
 
-    @ApiPropertyOptional({ description: '커서: 이 messageId 이후 결과 조회 (이전 응답의 nextCursor 값)' })
+    @ApiPropertyOptional({ description: '커서: 이전 응답의 nextCursor 값' })
     @IsString() @IsOptional() before?: string;
 
     @ApiPropertyOptional({ description: '페이지 크기 (기본 50, 최대 100)', default: 50 })

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.spec.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.spec.ts
@@ -8,11 +8,15 @@ const mockConfigService = {
     get: jest.fn().mockReturnValue('localhost:9092'),
 };
 
+const mockElasticsearchService = {
+    indexMessage: jest.fn().mockResolvedValue(undefined),
+};
+
 describe('ChatMessageConsumer', () => {
     let consumer: ChatMessageConsumer;
 
     beforeEach(() => {
-        consumer = new ChatMessageConsumer(mockMessageModel as any, mockConfigService as any);
+        consumer = new ChatMessageConsumer(mockMessageModel as any, mockConfigService as any, mockElasticsearchService as any);
         jest.clearAllMocks();
     });
 

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.ts
@@ -90,7 +90,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
             this.io?.to(`chat:${event.channelId}`).emit('message', saved.toObject());
 
             if (event.projectId) {
-                this.elasticsearchService.indexMessage({
+                void this.elasticsearchService.indexMessage({
                     messageId: saved._id.toString(),
                     teamId: event.teamId,
                     projectId: event.projectId,
@@ -101,7 +101,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
                     hasAttachments: (event.attachments?.length ?? 0) > 0,
                     isPinned: false,
                     createdAt: event.occurredAt,
-                }).catch((err) => this.logger.error(`ES 인덱싱 실패 id=${saved._id}`, err));
+                });
             }
         } catch (err: any) {
             if (err?.code === 11000) {

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.ts
@@ -6,6 +6,7 @@ import { Model, Types } from 'mongoose';
 import { Server } from 'socket.io';
 import { Message } from '../schema/message.schema';
 import { ChatMessageEvent } from './event/chat-message.event';
+import { ElasticsearchService } from '../../search/elasticsearch.service';
 import { getRequiredCsvConfig } from '../../common/config/config.util';
 
 @Injectable()
@@ -18,6 +19,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
     constructor(
         @InjectModel(Message.name) private readonly messageModel: Model<Message>,
         private readonly configService: ConfigService,
+        private readonly elasticsearchService: ElasticsearchService,
     ) {}
 
     setSocketServer(io: Server) {
@@ -86,6 +88,21 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
             });
 
             this.io?.to(`chat:${event.channelId}`).emit('message', saved.toObject());
+
+            if (event.projectId) {
+                this.elasticsearchService.indexMessage({
+                    messageId: saved._id.toString(),
+                    teamId: event.teamId,
+                    projectId: event.projectId,
+                    channelId: event.channelId,
+                    authorId: event.authorId,
+                    content: event.content,
+                    type: event.type,
+                    hasAttachments: (event.attachments?.length ?? 0) > 0,
+                    isPinned: false,
+                    createdAt: event.occurredAt,
+                }).catch((err) => this.logger.error(`ES 인덱싱 실패 id=${saved._id}`, err));
+            }
         } catch (err: any) {
             if (err?.code === 11000) {
                 this.logger.warn(`중복 메시지 감지, 스킵합니다 (clientMessageId: ${event.clientMessageId})`);

--- a/cowork-chat/src/chat/project-message.controller.spec.ts
+++ b/cowork-chat/src/chat/project-message.controller.spec.ts
@@ -1,0 +1,150 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { getModelToken } from '@nestjs/mongoose';
+import { ProjectMessageController } from './project-message.controller';
+import { ElasticsearchService } from '../search/elasticsearch.service';
+import { ProjectClient } from './service/project.client';
+import { ChannelMember } from './schema/channel-member.schema';
+
+const userId = 42;
+
+const mockMemberModel = {
+    find: jest.fn(),
+};
+
+const mockElasticsearchService = {
+    searchMessages: jest.fn(),
+};
+
+const mockProjectClient = {
+    isMember: jest.fn(),
+};
+
+describe('ProjectMessageController', () => {
+    let controller: ProjectMessageController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [ProjectMessageController],
+            providers: [
+                { provide: getModelToken(ChannelMember.name), useValue: mockMemberModel },
+                { provide: ElasticsearchService, useValue: mockElasticsearchService },
+                { provide: ProjectClient, useValue: mockProjectClient },
+            ],
+        }).compile();
+
+        controller = module.get<ProjectMessageController>(ProjectMessageController);
+        jest.clearAllMocks();
+    });
+
+    describe('searchMessages', () => {
+        const memberships = [{ channelId: 2 }, { channelId: 3 }];
+        const searchResult = {
+            hits: [
+                {
+                    messageId: 'msg-1',
+                    channelId: 2,
+                    authorId: 42,
+                    content: '안녕하세요',
+                    highlight: ['<em>안녕</em>하세요'],
+                    type: 'TEXT',
+                    hasAttachments: false,
+                    isPinned: false,
+                    createdAt: '2026-05-11T10:00:00.000Z',
+                },
+            ],
+            nextCursor: null,
+        };
+
+        it('프로젝트 멤버이면 채널 멤버십 기반으로 ES 검색 결과를 반환한다', async () => {
+            mockProjectClient.isMember.mockResolvedValue(true);
+            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve(memberships) });
+            mockElasticsearchService.searchMessages.mockResolvedValue(searchResult);
+
+            const result = await controller.searchMessages(5, { q: '안녕', limit: 50 } as any, userId);
+
+            expect(mockProjectClient.isMember).toHaveBeenCalledWith(5, 42);
+            expect(mockElasticsearchService.searchMessages).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    projectId: 5,
+                    accessibleChannelIds: [2, 3],
+                    q: '안녕',
+                    limit: 50,
+                }),
+            );
+            expect(result.messages).toHaveLength(1);
+            expect(result.nextCursor).toBeNull();
+        });
+
+        it('프로젝트 멤버가 아니면 ForbiddenException을 던진다', async () => {
+            mockProjectClient.isMember.mockResolvedValue(false);
+
+            await expect(
+                controller.searchMessages(5, { q: '안녕' } as any, userId),
+            ).rejects.toThrow(ForbiddenException);
+
+            expect(mockMemberModel.find).not.toHaveBeenCalled();
+            expect(mockElasticsearchService.searchMessages).not.toHaveBeenCalled();
+        });
+
+        it('channelId 필터가 있고 해당 채널에 접근 가능하면 그 채널로만 검색한다', async () => {
+            mockProjectClient.isMember.mockResolvedValue(true);
+            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve(memberships) });
+            mockElasticsearchService.searchMessages.mockResolvedValue({ hits: [], nextCursor: null });
+
+            await controller.searchMessages(5, { q: '안녕', channelId: 2 } as any, userId);
+
+            expect(mockElasticsearchService.searchMessages).toHaveBeenCalledWith(
+                expect.objectContaining({ accessibleChannelIds: [2] }),
+            );
+        });
+
+        it('channelId 필터가 있지만 해당 채널 멤버가 아니면 ForbiddenException을 던진다', async () => {
+            mockProjectClient.isMember.mockResolvedValue(true);
+            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve(memberships) });
+
+            await expect(
+                controller.searchMessages(5, { q: '안녕', channelId: 99 } as any, userId),
+            ).rejects.toThrow(ForbiddenException);
+
+            expect(mockElasticsearchService.searchMessages).not.toHaveBeenCalled();
+        });
+
+        it('limit 기본값은 50이다', async () => {
+            mockProjectClient.isMember.mockResolvedValue(true);
+            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve(memberships) });
+            mockElasticsearchService.searchMessages.mockResolvedValue({ hits: [], nextCursor: null });
+
+            await controller.searchMessages(5, { q: '안녕' } as any, userId);
+
+            expect(mockElasticsearchService.searchMessages).toHaveBeenCalledWith(
+                expect.objectContaining({ limit: 50 }),
+            );
+        });
+
+        it('nextCursor가 있으면 응답에 포함된다', async () => {
+            mockProjectClient.isMember.mockResolvedValue(true);
+            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve(memberships) });
+            mockElasticsearchService.searchMessages.mockResolvedValue({
+                hits: [],
+                nextCursor: 'next-msg-id',
+            });
+
+            const result = await controller.searchMessages(5, { q: '안녕' } as any, userId);
+
+            expect(result.nextCursor).toBe('next-msg-id');
+        });
+
+        it('채널 멤버십이 없으면 accessibleChannelIds가 빈 배열로 전달된다', async () => {
+            mockProjectClient.isMember.mockResolvedValue(true);
+            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve([]) });
+            mockElasticsearchService.searchMessages.mockResolvedValue({ hits: [], nextCursor: null });
+
+            await controller.searchMessages(5, { q: '안녕' } as any, userId);
+
+            expect(mockElasticsearchService.searchMessages).toHaveBeenCalledWith(
+                expect.objectContaining({ accessibleChannelIds: [] }),
+            );
+        });
+    });
+});

--- a/cowork-chat/src/chat/project-message.controller.ts
+++ b/cowork-chat/src/chat/project-message.controller.ts
@@ -1,0 +1,81 @@
+import {
+    Controller,
+    ForbiddenException,
+    Get,
+    Param,
+    ParseIntPipe,
+    Query,
+} from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { ChannelMember } from './schema/channel-member.schema';
+import { ElasticsearchService } from '../search/elasticsearch.service';
+import { ProjectClient } from './service/project.client';
+import { SearchMessagesDto } from './dto/search-messages.dto';
+import { SearchMessagesResponseDto } from './dto/search-message-response.dto';
+import { UserId } from '../common/decorator/user.decorator';
+
+@ApiTags('Chat')
+@ApiHeader({ name: 'X-User-Id', description: 'Gateway 주입 유저 ID', required: true })
+@Controller('projects/:projectId')
+export class ProjectMessageController {
+    constructor(
+        @InjectModel(ChannelMember.name) private readonly memberModel: Model<ChannelMember>,
+        private readonly elasticsearchService: ElasticsearchService,
+        private readonly projectClient: ProjectClient,
+    ) {}
+
+    @Get('messages/search')
+    @ApiOperation({
+        summary: '프로젝트 채팅 메시지 검색',
+        description:
+            'Elasticsearch 기반 전문 검색. 프로젝트에 속한 채널 중 요청자가 접근 가능한 채널에서 검색.\n\n' +
+            '- 한국어 nori 형태소 분석 적용\n' +
+            '- fuzzy matching으로 오타 허용\n' +
+            '- 검색 키워드는 응답의 `highlight` 필드에 `<em>` 태그로 표시\n' +
+            '- 결과는 최신순 정렬 (createdAt DESC)\n' +
+            '- 커서 기반 페이지네이션: 응답의 `nextCursor`를 다음 요청의 `before`에 전달',
+    })
+    @ApiQuery({ name: 'q', description: '검색 키워드 (최소 1자)', required: true })
+    @ApiQuery({ name: 'channelId', description: '특정 채널로 범위 축소', required: false })
+    @ApiQuery({ name: 'authorId', description: '특정 작성자 ID 필터', required: false })
+    @ApiQuery({ name: 'type', enum: ['TEXT', 'FILE', 'SYSTEM'], description: '메시지 타입 필터', required: false })
+    @ApiQuery({ name: 'hasFile', description: '첨부파일 포함 메시지만 조회 (true/false)', required: false })
+    @ApiQuery({ name: 'before', description: '커서: 이전 응답의 nextCursor 값', required: false })
+    @ApiQuery({ name: 'limit', description: '페이지 크기 (기본 50, 최대 100)', required: false })
+    @ApiResponse({ status: 200, type: SearchMessagesResponseDto })
+    @ApiResponse({ status: 403, description: '프로젝트 멤버 아님 또는 채널 접근 권한 없음' })
+    async searchMessages(
+        @Param('projectId', ParseIntPipe) projectId: number,
+        @Query() dto: SearchMessagesDto,
+        @UserId() userId: number,
+    ): Promise<SearchMessagesResponseDto> {
+        const isMember = await this.projectClient.isMember(projectId, userId);
+        if (!isMember) throw new ForbiddenException('프로젝트 접근 권한이 없습니다');
+
+        const memberships = await this.memberModel.find({ userId }, { channelId: 1 }).lean();
+        const accessibleChannelIds = memberships.map((m) => m.channelId);
+
+        let filteredChannelIds = accessibleChannelIds;
+        if (dto.channelId !== undefined) {
+            if (!accessibleChannelIds.includes(dto.channelId)) {
+                throw new ForbiddenException('채널 접근 권한이 없습니다');
+            }
+            filteredChannelIds = [dto.channelId];
+        }
+
+        const { hits, nextCursor } = await this.elasticsearchService.searchMessages({
+            projectId,
+            accessibleChannelIds: filteredChannelIds,
+            q: dto.q,
+            authorId: dto.authorId,
+            type: dto.type,
+            hasFile: dto.hasFile,
+            before: dto.before,
+            limit: dto.limit ?? 50,
+        });
+
+        return { messages: hits, nextCursor };
+    }
+}

--- a/cowork-chat/src/chat/schema/channel-member.schema.ts
+++ b/cowork-chat/src/chat/schema/channel-member.schema.ts
@@ -14,3 +14,4 @@ export class ChannelMember {
 export const ChannelMemberSchema = SchemaFactory.createForClass(ChannelMember);
 
 ChannelMemberSchema.index({ channelId: 1, userId: 1 }, { unique: true });
+ChannelMemberSchema.index({ userId: 1 });

--- a/cowork-chat/src/chat/service/project.client.spec.ts
+++ b/cowork-chat/src/chat/service/project.client.spec.ts
@@ -128,4 +128,47 @@ describe('ProjectClient', () => {
             await expect(client.getGithubRepoInfo(1)).rejects.toThrow('ECONNREFUSED');
         });
     });
+
+    describe('isMember', () => {
+        beforeEach(() => {
+            global.fetch = jest.fn();
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('200 응답이면 true를 반환한다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({ ok: true, status: 200 });
+
+            const result = await client.isMember(5, 42);
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                'http://localhost:8084/projects/5/members/me',
+                expect.objectContaining({
+                    headers: { 'X-User-Id': '42' },
+                    signal: expect.any(AbortSignal),
+                }),
+            );
+            expect(result).toBe(true);
+        });
+
+        it('404 응답이면 false를 반환한다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 404 });
+
+            expect(await client.isMember(5, 99)).toBe(false);
+        });
+
+        it('5xx 응답이면 예외를 던진다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({ ok: false, status: 500 });
+
+            await expect(client.isMember(5, 42)).rejects.toThrow('project-service 오류: 500');
+        });
+
+        it('네트워크 오류가 발생하면 예외를 던진다', async () => {
+            (global.fetch as jest.Mock).mockRejectedValue(new Error('ECONNREFUSED'));
+
+            await expect(client.isMember(5, 42)).rejects.toThrow('ECONNREFUSED');
+        });
+    });
 });

--- a/cowork-chat/src/chat/service/project.client.ts
+++ b/cowork-chat/src/chat/service/project.client.ts
@@ -36,6 +36,21 @@ export class ProjectClient {
         }
     }
 
+    async isMember(projectId: number, userId: number): Promise<boolean> {
+        try {
+            const res = await fetch(`${this.projectServiceUrl}/projects/${projectId}/members/me`, {
+                headers: { 'X-User-Id': String(userId) },
+                signal: AbortSignal.timeout(3000),
+            });
+            if (res.status === 404) return false;
+            if (!res.ok) throw new Error(`project-service 오류: ${res.status}`);
+            return true;
+        } catch (err) {
+            this.logger.error(`project-service 멤버 확인 오류 projectId=${projectId} userId=${userId}`, err);
+            throw err;
+        }
+    }
+
     private parseRepoUrl(url: string | null | undefined): Omit<GithubRepoInfo, 'teamId'> | null {
         if (!url) return null;
         try {

--- a/cowork-chat/src/main.ts
+++ b/cowork-chat/src/main.ts
@@ -43,6 +43,9 @@ async function bootstrap() {
             '| `message` | S→C | 새 메시지 수신 |\n' +
             '| `message:edited` | S→C | 메시지 수정됨 |\n' +
             '| `message:deleted` | S→C | 메시지 삭제됨 |\n\n' +
+            '## 메시지 검색\n' +
+            '`GET /projects/:projectId/messages/search` — Elasticsearch 기반 프로젝트 채팅 검색.\n' +
+            '프로젝트 멤버이고 채널 접근 권한이 있는 메시지만 반환됩니다.\n\n' +
             '## 인증\n' +
             'REST API: Gateway에서 주입된 `X-User-Id`, `X-User-Role` 헤더 사용.\n' +
             'WebSocket: Socket.io handshake의 `auth.token`에 JWT Bearer 토큰 전달.\n' +

--- a/cowork-chat/src/search/elasticsearch.module.ts
+++ b/cowork-chat/src/search/elasticsearch.module.ts
@@ -1,0 +1,22 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { Client } from '@elastic/elasticsearch';
+import { ElasticsearchService } from './elasticsearch.service';
+import { getRequiredConfig } from '../common/config/config.util';
+
+export const ELASTICSEARCH_CLIENT = 'ELASTICSEARCH_CLIENT';
+
+@Module({
+    imports: [ConfigModule],
+    providers: [
+        {
+            provide: ELASTICSEARCH_CLIENT,
+            inject: [ConfigService],
+            useFactory: (configService: ConfigService) =>
+                new Client({ node: getRequiredConfig(configService, 'ELASTICSEARCH_URL') }),
+        },
+        ElasticsearchService,
+    ],
+    exports: [ElasticsearchService],
+})
+export class ElasticsearchModule {}

--- a/cowork-chat/src/search/elasticsearch.service.spec.ts
+++ b/cowork-chat/src/search/elasticsearch.service.spec.ts
@@ -1,0 +1,263 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ElasticsearchService } from './elasticsearch.service';
+import { ELASTICSEARCH_CLIENT } from './elasticsearch.module';
+
+const mockClient = {
+    indices: {
+        exists: jest.fn(),
+        create: jest.fn(),
+    },
+    index: jest.fn(),
+    update: jest.fn(),
+    delete: jest.fn(),
+    search: jest.fn(),
+};
+
+describe('ElasticsearchService', () => {
+    let service: ElasticsearchService;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ElasticsearchService,
+                { provide: ELASTICSEARCH_CLIENT, useValue: mockClient },
+            ],
+        }).compile();
+
+        service = module.get<ElasticsearchService>(ElasticsearchService);
+        jest.clearAllMocks();
+    });
+
+    describe('onModuleInit / createIndexIfNotExists', () => {
+        it('인덱스가 없으면 nori 설정으로 인덱스를 생성한다', async () => {
+            mockClient.indices.exists.mockResolvedValue(false);
+            mockClient.indices.create.mockResolvedValue({});
+
+            await service.onModuleInit();
+
+            expect(mockClient.indices.create).toHaveBeenCalledWith(
+                expect.objectContaining({ index: 'chat_messages' }),
+            );
+        });
+
+        it('인덱스가 이미 있으면 생성하지 않는다', async () => {
+            mockClient.indices.exists.mockResolvedValue(true);
+
+            await service.onModuleInit();
+
+            expect(mockClient.indices.create).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('indexMessage', () => {
+        it('messageId를 id로 사용해 chat_messages 인덱스에 문서를 저장한다', async () => {
+            mockClient.index.mockResolvedValue({ result: 'created' });
+
+            const doc = {
+                messageId: 'msg-id-1',
+                teamId: 10,
+                projectId: 5,
+                channelId: 2,
+                authorId: 42,
+                content: '안녕하세요',
+                type: 'TEXT',
+                hasAttachments: false,
+                isPinned: false,
+                createdAt: '2026-05-11T10:00:00.000Z',
+            };
+
+            await service.indexMessage(doc);
+
+            expect(mockClient.index).toHaveBeenCalledWith({
+                index: 'chat_messages',
+                id: 'msg-id-1',
+                document: doc,
+            });
+        });
+
+        it('ES 오류가 발생하면 예외를 전파한다', async () => {
+            mockClient.index.mockRejectedValue(new Error('ES connection error'));
+
+            await expect(service.indexMessage({
+                messageId: 'msg-id-1',
+                teamId: 10,
+                projectId: 5,
+                channelId: 2,
+                authorId: 42,
+                content: '안녕',
+                type: 'TEXT',
+                hasAttachments: false,
+                isPinned: false,
+                createdAt: '2026-05-11T10:00:00.000Z',
+            })).rejects.toThrow('ES connection error');
+        });
+    });
+
+    describe('updateMessage', () => {
+        it('messageId에 해당하는 문서의 content를 업데이트한다', async () => {
+            mockClient.update.mockResolvedValue({ result: 'updated' });
+
+            await service.updateMessage('msg-id-1', '수정된 내용');
+
+            expect(mockClient.update).toHaveBeenCalledWith({
+                index: 'chat_messages',
+                id: 'msg-id-1',
+                doc: { content: '수정된 내용' },
+            });
+        });
+
+        it('문서가 없어 404가 발생해도 예외를 던지지 않는다', async () => {
+            mockClient.update.mockRejectedValue({ statusCode: 404 });
+
+            await expect(service.updateMessage('nonexistent', '내용')).resolves.toBeUndefined();
+        });
+    });
+
+    describe('deleteMessage', () => {
+        it('messageId에 해당하는 문서를 삭제한다', async () => {
+            mockClient.delete.mockResolvedValue({ result: 'deleted' });
+
+            await service.deleteMessage('msg-id-1');
+
+            expect(mockClient.delete).toHaveBeenCalledWith({
+                index: 'chat_messages',
+                id: 'msg-id-1',
+            });
+        });
+
+        it('문서가 없어 404가 발생해도 예외를 던지지 않는다', async () => {
+            mockClient.delete.mockRejectedValue({ statusCode: 404 });
+
+            await expect(service.deleteMessage('nonexistent')).resolves.toBeUndefined();
+        });
+    });
+
+    describe('searchMessages', () => {
+        const makeHit = (messageId: string, overrides = {}) => ({
+            _source: {
+                messageId,
+                channelId: 2,
+                authorId: 42,
+                content: '안녕하세요',
+                type: 'TEXT',
+                hasAttachments: false,
+                isPinned: false,
+                createdAt: '2026-05-11T10:00:00.000Z',
+                ...overrides,
+            },
+            highlight: { content: ['<em>안녕</em>하세요'] },
+        });
+
+        const baseParams = {
+            projectId: 5,
+            accessibleChannelIds: [2, 3],
+            q: '안녕',
+            limit: 50,
+        };
+
+        it('projectId와 accessibleChannelIds로 필터링해 검색 결과를 반환한다', async () => {
+            mockClient.search.mockResolvedValue({
+                hits: { hits: [makeHit('msg-1')] },
+            });
+
+            const result = await service.searchMessages(baseParams);
+
+            const body = mockClient.search.mock.calls[0][0].body;
+            expect(body.query.bool.must[0]).toEqual({ term: { projectId: 5 } });
+            expect(body.query.bool.must[1]).toEqual({ terms: { channelId: [2, 3] } });
+            expect(result.hits).toHaveLength(1);
+            expect(result.hits[0].messageId).toBe('msg-1');
+            expect(result.hits[0].highlight).toEqual(['<em>안녕</em>하세요']);
+        });
+
+        it('limit보다 적은 결과가 나오면 nextCursor는 null이다', async () => {
+            mockClient.search.mockResolvedValue({
+                hits: { hits: [makeHit('msg-1')] },
+            });
+
+            const { nextCursor } = await service.searchMessages({ ...baseParams, limit: 50 });
+
+            expect(nextCursor).toBeNull();
+        });
+
+        it('결과가 limit과 같으면 마지막 messageId를 nextCursor로 반환한다', async () => {
+            const hits = Array.from({ length: 50 }, (_, i) => makeHit(`msg-${i}`));
+            mockClient.search.mockResolvedValue({ hits: { hits } });
+
+            const { nextCursor } = await service.searchMessages({ ...baseParams, limit: 50 });
+
+            expect(nextCursor).toBe('msg-49');
+        });
+
+        it('before가 있으면 search_after에 포함된다', async () => {
+            mockClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+            await service.searchMessages({ ...baseParams, before: 'cursor-id' });
+
+            const body = mockClient.search.mock.calls[0][0].body;
+            expect(body.search_after).toEqual(['cursor-id']);
+        });
+
+        it('before가 없으면 search_after가 포함되지 않는다', async () => {
+            mockClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+            await service.searchMessages(baseParams);
+
+            const body = mockClient.search.mock.calls[0][0].body;
+            expect(body.search_after).toBeUndefined();
+        });
+
+        it('authorId 필터가 전달되면 filter에 포함된다', async () => {
+            mockClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+            await service.searchMessages({ ...baseParams, authorId: 42 });
+
+            const body = mockClient.search.mock.calls[0][0].body;
+            expect(body.query.bool.filter).toEqual(
+                expect.arrayContaining([{ term: { authorId: 42 } }]),
+            );
+        });
+
+        it('type 필터가 전달되면 filter에 포함된다', async () => {
+            mockClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+            await service.searchMessages({ ...baseParams, type: 'FILE' });
+
+            const body = mockClient.search.mock.calls[0][0].body;
+            expect(body.query.bool.filter).toEqual(
+                expect.arrayContaining([{ term: { type: 'FILE' } }]),
+            );
+        });
+
+        it('hasFile=true이면 hasAttachments:true 필터가 포함된다', async () => {
+            mockClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+            await service.searchMessages({ ...baseParams, hasFile: true });
+
+            const body = mockClient.search.mock.calls[0][0].body;
+            expect(body.query.bool.filter).toEqual(
+                expect.arrayContaining([{ term: { hasAttachments: true } }]),
+            );
+        });
+
+        it('하이라이팅이 없는 결과는 빈 배열로 반환된다', async () => {
+            const hitWithoutHighlight = {
+                _source: makeHit('msg-1')._source,
+            };
+            mockClient.search.mockResolvedValue({ hits: { hits: [hitWithoutHighlight] } });
+
+            const { hits } = await service.searchMessages(baseParams);
+
+            expect(hits[0].highlight).toEqual([]);
+        });
+
+        it('검색 결과가 없으면 빈 배열과 null cursor를 반환한다', async () => {
+            mockClient.search.mockResolvedValue({ hits: { hits: [] } });
+
+            const result = await service.searchMessages(baseParams);
+
+            expect(result.hits).toEqual([]);
+            expect(result.nextCursor).toBeNull();
+        });
+    });
+});

--- a/cowork-chat/src/search/elasticsearch.service.ts
+++ b/cowork-chat/src/search/elasticsearch.service.ts
@@ -1,0 +1,206 @@
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Client } from '@elastic/elasticsearch';
+import { ELASTICSEARCH_CLIENT } from './elasticsearch.module';
+
+const INDEX = 'chat_messages';
+
+export interface MessageIndexDoc {
+    messageId: string;
+    teamId: number;
+    projectId: number;
+    channelId: number;
+    authorId: number;
+    content: string;
+    type: string;
+    hasAttachments: boolean;
+    isPinned: boolean;
+    createdAt: string;
+}
+
+export interface SearchMessagesParams {
+    projectId: number;
+    accessibleChannelIds: number[];
+    q: string;
+    channelId?: number;
+    authorId?: number;
+    type?: string;
+    hasFile?: boolean;
+    before?: string;
+    limit: number;
+}
+
+export interface SearchHit {
+    messageId: string;
+    channelId: number;
+    authorId: number;
+    content: string;
+    highlight: string[];
+    type: string;
+    hasAttachments: boolean;
+    isPinned: boolean;
+    createdAt: string;
+}
+
+@Injectable()
+export class ElasticsearchService implements OnModuleInit {
+    private readonly logger = new Logger(ElasticsearchService.name);
+
+    constructor(@Inject(ELASTICSEARCH_CLIENT) private readonly client: Client) {}
+
+    async onModuleInit() {
+        await this.createIndexIfNotExists();
+    }
+
+    private async createIndexIfNotExists() {
+        try {
+            const exists = await this.client.indices.exists({ index: INDEX });
+            if (exists) return;
+
+            await this.client.indices.create({
+                index: INDEX,
+                settings: {
+                    analysis: {
+                        analyzer: {
+                            nori_analyzer: {
+                                type: 'custom',
+                                tokenizer: 'nori_tokenizer',
+                                filter: ['lowercase'],
+                            },
+                        },
+                    },
+                },
+                mappings: {
+                    properties: {
+                        messageId:      { type: 'keyword' },
+                        teamId:         { type: 'long' },
+                        projectId:      { type: 'long' },
+                        channelId:      { type: 'long' },
+                        authorId:       { type: 'long' },
+                        content:        { type: 'text', analyzer: 'nori_analyzer' },
+                        type:           { type: 'keyword' },
+                        hasAttachments: { type: 'boolean' },
+                        isPinned:       { type: 'boolean' },
+                        createdAt:      { type: 'date' },
+                    },
+                },
+            } as any);
+
+            this.logger.log(`인덱스 생성 완료: ${INDEX}`);
+        } catch (err) {
+            this.logger.error('ES 인덱스 생성 실패', err);
+        }
+    }
+
+    async indexMessage(doc: MessageIndexDoc): Promise<void> {
+        try {
+            await this.client.index({
+                index: INDEX,
+                id: doc.messageId,
+                document: doc,
+            });
+        } catch (err) {
+            this.logger.error(`ES 메시지 인덱싱 실패 id=${doc.messageId}`, err);
+            throw err;
+        }
+    }
+
+    async updateMessage(messageId: string, content: string): Promise<void> {
+        try {
+            await this.client.update({
+                index: INDEX,
+                id: messageId,
+                doc: { content },
+            });
+        } catch (err: any) {
+            if (err?.statusCode === 404) return;
+            this.logger.error(`ES 메시지 업데이트 실패 id=${messageId}`, err);
+        }
+    }
+
+    async deleteMessage(messageId: string): Promise<void> {
+        try {
+            await this.client.delete({ index: INDEX, id: messageId });
+        } catch (err: any) {
+            if (err?.statusCode === 404) return;
+            this.logger.error(`ES 메시지 삭제 실패 id=${messageId}`, err);
+        }
+    }
+
+    async searchMessages(params: SearchMessagesParams): Promise<{ hits: SearchHit[]; nextCursor: string | null }> {
+        const { projectId, accessibleChannelIds, q, channelId, authorId, type, hasFile, before, limit } = params;
+
+        const filter: any[] = [];
+        if (channelId !== undefined) {
+            filter.push({ term: { channelId } });
+        }
+        if (authorId !== undefined) {
+            filter.push({ term: { authorId } });
+        }
+        if (type !== undefined) {
+            filter.push({ term: { type } });
+        }
+        if (hasFile === true) {
+            filter.push({ term: { hasAttachments: true } });
+        }
+
+        const searchAfter = before ? [before] : undefined;
+
+        const response = await this.client.search({
+            index: INDEX,
+            body: {
+                query: {
+                    bool: {
+                        must: [
+                            { term: { projectId } },
+                            { terms: { channelId: accessibleChannelIds } },
+                            {
+                                bool: {
+                                    should: [
+                                        { match: { content: { query: q, fuzziness: 'AUTO' } } },
+                                        { match_phrase: { content: { query: q, boost: 2 } } },
+                                    ],
+                                    minimum_should_match: 1,
+                                },
+                            },
+                        ],
+                        filter,
+                    },
+                },
+                highlight: {
+                    fields: {
+                        content: {
+                            pre_tags: ['<em>'],
+                            post_tags: ['</em>'],
+                            number_of_fragments: 3,
+                            fragment_size: 150,
+                        },
+                    },
+                },
+                sort: [{ createdAt: 'desc' }, { messageId: 'desc' }],
+                size: limit,
+                ...(searchAfter ? { search_after: searchAfter } : {}),
+            },
+        });
+
+        const rawHits = (response as any).hits?.hits ?? [];
+
+        const hits: SearchHit[] = rawHits.map((hit: any) => ({
+            messageId: hit._source.messageId,
+            channelId: hit._source.channelId,
+            authorId: hit._source.authorId,
+            content: hit._source.content,
+            highlight: hit.highlight?.content ?? [],
+            type: hit._source.type,
+            hasAttachments: hit._source.hasAttachments,
+            isPinned: hit._source.isPinned,
+            createdAt: hit._source.createdAt,
+        }));
+
+        const lastHit = rawHits.at(-1);
+        const nextCursor = hits.length === limit && lastHit
+            ? (lastHit._source as MessageIndexDoc).messageId
+            : null;
+
+        return { hits, nextCursor };
+    }
+}

--- a/cowork-chat/src/search/elasticsearch.service.ts
+++ b/cowork-chat/src/search/elasticsearch.service.ts
@@ -143,7 +143,14 @@ export class ElasticsearchService implements OnModuleInit {
             filter.push({ term: { hasAttachments: true } });
         }
 
-        const searchAfter = before ? [before] : undefined;
+        let searchAfter: any[] | undefined;
+        if (before) {
+            try {
+                searchAfter = JSON.parse(Buffer.from(before, 'base64').toString());
+            } catch {
+                searchAfter = undefined;
+            }
+        }
 
         const response = await this.client.search({
             index: INDEX,
@@ -197,8 +204,8 @@ export class ElasticsearchService implements OnModuleInit {
         }));
 
         const lastHit = rawHits.at(-1);
-        const nextCursor = hits.length === limit && lastHit
-            ? (lastHit._source as MessageIndexDoc).messageId
+        const nextCursor = hits.length === limit && lastHit?.sort
+            ? Buffer.from(JSON.stringify(lastHit.sort)).toString('base64')
             : null;
 
         return { hits, nextCursor };

--- a/cowork-chat/src/search/elasticsearch.service.ts
+++ b/cowork-chat/src/search/elasticsearch.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
-import { Client } from '@elastic/elasticsearch';
+import { Client, estypes } from '@elastic/elasticsearch';
 import { ELASTICSEARCH_CLIENT } from './elasticsearch.module';
 
 const INDEX = 'chat_messages';
@@ -56,7 +56,7 @@ export class ElasticsearchService implements OnModuleInit {
             const exists = await this.client.indices.exists({ index: INDEX });
             if (exists) return;
 
-            await this.client.indices.create({
+            const params: estypes.IndicesCreateRequest = {
                 index: INDEX,
                 settings: {
                     analysis: {
@@ -83,7 +83,8 @@ export class ElasticsearchService implements OnModuleInit {
                         createdAt:      { type: 'date' },
                     },
                 },
-            } as any);
+            };
+            await this.client.indices.create(params);
 
             this.logger.log(`인덱스 생성 완료: ${INDEX}`);
         } catch (err) {
@@ -100,7 +101,6 @@ export class ElasticsearchService implements OnModuleInit {
             });
         } catch (err) {
             this.logger.error(`ES 메시지 인덱싱 실패 id=${doc.messageId}`, err);
-            throw err;
         }
     }
 

--- a/cowork-chat/src/search/search.module.ts
+++ b/cowork-chat/src/search/search.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { ElasticsearchModule } from './elasticsearch.module';
+
+@Module({
+    imports: [ConfigModule, ElasticsearchModule],
+    exports: [ElasticsearchModule],
+})
+export class SearchModule {}

--- a/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
@@ -71,6 +71,19 @@ spring:
                 name: defaultCB
                 fallbackUri: forward:/fallback
 
+        - id: chat-service-search
+          uri: lb://cowork-chat
+          predicates:
+            - Path=/api/projects/*/messages/search
+            - Method=GET
+          filters:
+            - StripPrefix=1
+            - PrefixPath=/chat
+            - name: CircuitBreaker
+              args:
+                name: defaultCB
+                fallbackUri: forward:/fallback
+
         - id: project-service
           uri: lb://cowork-project
           predicates:

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -117,6 +117,15 @@ spring:
                 redis-rate-limiter.requestedTokens: 1
                 key-resolver: "#{@userKeyResolver}"
 
+        - id: chat-service-search
+          uri: lb://cowork-chat
+          predicates:
+            - Path=/api/projects/*/messages/search
+            - Method=GET
+          filters:
+            - StripPrefix=1
+            - PrefixPath=/chat
+
         - id: project-service
           uri: lb://cowork-project
           predicates:

--- a/cowork-project/src/main/kotlin/com/cowork/project/controller/ProjectController.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/controller/ProjectController.kt
@@ -138,6 +138,23 @@ class ProjectController(
     ): ResponseEntity<ProjectMemberResponse> =
         ResponseEntity.ok(projectService.updateMemberRole(userId, projectId, memberId, request))
 
+    @Operation(
+        summary = "내 멤버십 확인 (내부 서비스용)",
+        description = "요청자가 해당 프로젝트 멤버이면 200, 아니면 404. 다른 서비스의 권한 검증에 사용됩니다.",
+        security = [SecurityRequirement(name = "BearerAuth")],
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "멤버임"),
+        ApiResponse(responseCode = "404", description = "멤버 아님 또는 프로젝트 없음"),
+    )
+    @GetMapping("/{projectId}/members/me")
+    fun getMyMembership(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable projectId: Long,
+    ): ResponseEntity<Void> =
+        if (projectService.isMember(projectId, userId)) ResponseEntity.ok().build()
+        else ResponseEntity.notFound().build()
+
     @Operation(summary = "프로젝트 멤버 제거", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
         ApiResponse(responseCode = "204", description = "제거 성공"),

--- a/cowork-project/src/main/kotlin/com/cowork/project/service/ProjectService.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/service/ProjectService.kt
@@ -134,6 +134,9 @@ class ProjectService(
         projectRepository.findProjectsByMemberUserId(userId, pageable)
             .map { ProjectResponse.of(it) }
 
+    fun isMember(projectId: Long, userId: Long): Boolean =
+        projectMemberRepository.findByProjectIdAndUserId(projectId, userId) != null
+
     @Transactional
     fun addMember(userId: Long, projectId: Long, request: AddProjectMemberRequest): ProjectMemberResponse {
         val project = findProjectOrThrow(projectId)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -188,6 +188,27 @@ services:
       exit 0;
       "
 
+  elasticsearch:
+    build:
+      context: ./docker
+      dockerfile: elasticsearch.dockerfile
+    container_name: cowork-elasticsearch
+    restart: unless-stopped
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
+    volumes:
+      - es_data:/usr/share/elasticsearch/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health || exit 1"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 60s
+
   redis:
     image: redis:8.6.2-alpine
     container_name: cowork-redis
@@ -628,12 +649,15 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
       cowork-config:
         condition: service_healthy
     environment:
       APP_CONFIG_URL: http://cowork-config:8761
       APP_PROFILE: ${SPRING_PROFILES_ACTIVE:-local}
       NODE_ENV: production
+      ELASTICSEARCH_URL: http://elasticsearch:9200
     ports:
       - "8087:8087"
     volumes:
@@ -681,6 +705,7 @@ volumes:
   kafka_data:
   redis_data:
   minio_data:
+  es_data:
   prometheus_data:
   grafana_data:
   loki_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,7 @@ services:
       MINIO_PUBLIC_BASE_URL: ${MINIO_PUBLIC_BASE_URL:-http://localhost:9000/cowork-bucket}
       LIVEKIT_API_KEY: ${LIVEKIT_API_KEY:-devkey}
       LIVEKIT_API_SECRET: ${LIVEKIT_API_SECRET:-devsecret}
+      ELASTICSEARCH_URL: ${ELASTICSEARCH_URL:-http://elasticsearch:9200}
     entrypoint: >
       /bin/sh -c "
       vault secrets enable -version=2 -path=secret kv 2>/dev/null || true;
@@ -143,7 +144,7 @@ services:
       vault kv put secret/cowork-authorization DB_DSN=\"$${MYSQL_USER}:$${MYSQL_PASSWORD}@tcp(mysql:3306)/cowork_authorization?charset=utf8mb4&parseTime=True&loc=Local\" DATAGSM_CLIENT_ID=\"$${DATAGSM_CLIENT_ID}\" JWT_SECRET=\"$${JWT_SECRET}\";
       vault kv put secret/cowork-notification db.dsn=\"$${MYSQL_USER}:$${MYSQL_PASSWORD}@tcp(mysql:3306)/cowork_notification?charset=utf8mb4&parseTime=True&loc=Local\";
       vault kv put secret/cowork-voice MONGODB_URI=\"mongodb://$${MONGO_ROOT_USERNAME}:$${MONGO_ROOT_PASSWORD}@mongodb:27017/cowork_voice?authSource=admin\" LIVEKIT_API_KEY=\"$${LIVEKIT_API_KEY}\" LIVEKIT_API_SECRET=\"$${LIVEKIT_API_SECRET}\";
-      vault kv put secret/cowork-chat MONGODB_URI=\"mongodb://$${MONGO_ROOT_USERNAME}:$${MONGO_ROOT_PASSWORD}@mongodb:27017/cowork_chat?authSource=admin\";
+      vault kv put secret/cowork-chat MONGODB_URI=\"mongodb://$${MONGO_ROOT_USERNAME}:$${MONGO_ROOT_PASSWORD}@mongodb:27017/cowork_chat?authSource=admin\" ELASTICSEARCH_URL=\"$${ELASTICSEARCH_URL}\";
       echo 'Vault secrets initialized.';
       exit 0;
       "
@@ -657,7 +658,6 @@ services:
       APP_CONFIG_URL: http://cowork-config:8761
       APP_PROFILE: ${SPRING_PROFILES_ACTIVE:-local}
       NODE_ENV: production
-      ELASTICSEARCH_URL: http://elasticsearch:9200
     ports:
       - "8087:8087"
     volumes:

--- a/docker/elasticsearch.dockerfile
+++ b/docker/elasticsearch.dockerfile
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:8.13.4
+RUN elasticsearch-plugin install --batch analysis-nori

--- a/docs/LOCAL_RUN_GUIDE.md
+++ b/docs/LOCAL_RUN_GUIDE.md
@@ -7,6 +7,7 @@
 - 2026-04-27 (Docker 통합 실행으로 전면 개정)
 - 2026-04-28 (vault-init 추가, gateway JWT_SECRET 주입 수정, authorization USER_SERVICE_URL 수정)
 - 2026-05-02 (`cowork-user` Elixir 전환, Flyway 자동 실행, healthcheck 검증 반영)
+- 2026-05-11 (Elasticsearch 검색 인덱싱 추가, 로컬 배포 고려 사항 보완)
 
 검증 기준:
 - `docker-compose.yml`
@@ -172,6 +173,7 @@ Docker Compose 내부에서 서비스는 컨테이너 이름으로 통신한다.
 | `localhost:9094` (Kafka 외부) | `kafka:9092` (Kafka 내부) |
 | `localhost:6379`            | `redis:6379`            |
 | `localhost:9000`            | `minio:9000`            |
+| `localhost:9200`            | `elasticsearch:9200`    |
 | `localhost:8761`            | `cowork-config:8761`    |
 
 Kafka는 외부 접근용(`9094`)과 컨테이너 내부용(`9092`) 리스너가 분리돼 있다.
@@ -221,15 +223,18 @@ Kafka는 외부 접근용(`9094`)과 컨테이너 내부용(`9092`) 리스너가
 
 ## 10. 자주 쓰는 확인 포인트
 
-| 서비스              | URL                                     |
-|------------------|-----------------------------------------|
-| Eureka Dashboard | `http://localhost:8761`                 |
-| Gateway Swagger  | `http://localhost:8080/swagger-ui.html` |
-| Kafka UI         | `http://localhost:8090`                 |
-| Prometheus       | `http://localhost:9090`                 |
-| Grafana          | `http://localhost:3001`                 |
-| MinIO Console    | `http://localhost:9002`                 |
-| Vault            | `http://localhost:8200`                 |
+| 서비스                  | URL                                                          |
+|----------------------|--------------------------------------------------------------|
+| Eureka Dashboard     | `http://localhost:8761`                                      |
+| Gateway Swagger      | `http://localhost:8080/swagger-ui.html`                      |
+| Kafka UI             | `http://localhost:8090`                                      |
+| Prometheus           | `http://localhost:9090`                                      |
+| Grafana              | `http://localhost:3001`                                      |
+| MinIO Console        | `http://localhost:9002`                                      |
+| Vault                | `http://localhost:8200`                                      |
+| Elasticsearch 클러스터 상태 | `http://localhost:9200/_cluster/health`                      |
+| chat_messages 인덱스 확인 | `http://localhost:9200/chat_messages/_count`                 |
+| 인덱스 목록              | `http://localhost:9200/_cat/indices?v`                       |
 
 ## 11. 알려진 주의사항
 
@@ -261,9 +266,22 @@ Kafka는 외부 접근용(`9094`)과 컨테이너 내부용(`9092`) 리스너가
 `cowork-notification`:
 - `docker/secrets/firebase-credentials.json`이 없으면 기동 자체가 실패한다.
 
-`cowork-chat`:
+`elasticsearch`:
+- 이미지: `docker.elastic.co/elasticsearch/elasticsearch:8.13.4` + nori 형태소 분석기 플러그인 (빌드 시 설치)
+- `discovery.type=single-node`, `xpack.security.enabled=false` (로컬 전용, 인증 없음)
+- 힙 메모리: `ES_JAVA_OPTS=-Xms512m -Xmx512m` → 컨테이너에 **최소 1 GB RAM** 여유 필요
+- 포트: `9200` (호스트에서 `localhost:9200`으로 직접 접근 가능)
+- 데이터 볼륨: `es_data` — `docker compose down -v` 실행 시 인덱스가 삭제되며, 다음 기동 시 `cowork-chat`이 자동으로 `chat_messages` 인덱스를 재생성함
+- `cowork-chat`이 healthy 상태가 될 때까지 `depends_on`으로 보장; ES healthcheck는 최대 150초(interval 15s × retries 10) 대기
+
+`cowork-chat` (Elasticsearch 관련):
 - Docker Compose 로컬 실행 시 시작 전에 Config Server에서 설정을 받아 `process.env`에 로드한다.
 - `MONGODB_URI`는 Vault `secret/cowork-chat`, MinIO 자격증명은 `secret/application`에서 공급된다.
+- `ELASTICSEARCH_URL`은 Vault/Config Server가 아닌 docker-compose 환경변수로 직접 주입된다 (`http://elasticsearch:9200`). `.env`에 별도 설정 불필요.
+- **인덱싱 대상**: `projectId`가 있는 메시지만 ES에 인덱싱된다. DM·비프로젝트 채널 메시지는 인덱싱되지 않는다.
+- **인덱스 자동 생성**: 앱 기동 시 `OnModuleInit`에서 `chat_messages` 인덱스가 없으면 자동 생성한다. nori 분석기와 `createdAt` + `messageId` 복합 정렬이 기본 설정된다.
+- **커서 형식**: 검색 페이지네이션의 `nextCursor`는 ES `sort` 배열(`[createdAt, messageId]`)을 `base64(JSON.stringify(...))` 인코딩한 불투명 문자열이다. 이전 방식(messageId 단순 문자열)과 **호환되지 않으므로** 기존 커서를 가진 클라이언트는 재조회가 필요하다.
+- ES 기동이 느릴 경우(`start_period: 60s`): `docker compose logs -f elasticsearch`로 상태 확인 후 `cowork-chat` 재시작
 
 `MINIO_PUBLIC_ENDPOINT`:
 - `scripts/run/local/infra.sh`와 `scripts/run/local/*.sh`는 `.env`의 `__LOCAL_IP__`를 현재 LAN IP로 자동 치환한다.

--- a/docs/LOCAL_RUN_GUIDE.md
+++ b/docs/LOCAL_RUN_GUIDE.md
@@ -51,14 +51,15 @@ cp .env.example .env
 기본값으로 채워진 항목이 많으니 대부분 수정 없이 쓸 수 있다.
 아래 항목만 운영/외부 서비스 연동 시 채운다.
 
-| 키                       | 기본값                        | 필요한 경우                                |
-|-------------------------|----------------------------|---------------------------------------|
-| `LIVEKIT_API_KEY`       | `devkey`                   | 로컬 LiveKit / voice 기본값                |
-| `LIVEKIT_API_SECRET`    | `devsecret`                | 로컬 LiveKit / voice 기본값                |
-| `LIVEKIT_CONFIG_FILE`   | `livekit.yaml`             | 클라우드·운영 환경에서 `livekit-cloud.yaml`로 변경 |
-| `OAUTH2_GOOGLE_*`       | 비어 있음                      | Google OAuth2 사용 시                    |
-| `OAUTH2_GITHUB_*`       | 비어 있음                      | GitHub OAuth2 사용 시                    |
-| `MINIO_PUBLIC_ENDPOINT` | `http://__LOCAL_IP__:9000` | 모바일 앱·외부 기기에서 파일 접근 시 실제 IP로 수정       |
+| 키                       | 기본값                              | 필요한 경우                                |
+|-------------------------|----------------------------------|---------------------------------------|
+| `LIVEKIT_API_KEY`       | `devkey`                         | 로컬 LiveKit / voice 기본값                |
+| `LIVEKIT_API_SECRET`    | `devsecret`                      | 로컬 LiveKit / voice 기본값                |
+| `LIVEKIT_CONFIG_FILE`   | `livekit.yaml`                   | 클라우드·운영 환경에서 `livekit-cloud.yaml`로 변경 |
+| `OAUTH2_GOOGLE_*`       | 비어 있음                            | Google OAuth2 사용 시                    |
+| `OAUTH2_GITHUB_*`       | 비어 있음                            | GitHub OAuth2 사용 시                    |
+| `MINIO_PUBLIC_ENDPOINT` | `http://__LOCAL_IP__:9000`       | 모바일 앱·외부 기기에서 파일 접근 시 실제 IP로 수정       |
+| `ELASTICSEARCH_URL`     | `http://elasticsearch:9200`      | 운영 환경에서 관리형 ES 클러스터 주소로 변경            |
 
 Firebase 관련:
 - `docker/secrets/firebase-credentials.json` 파일이 실제로 있어야 `cowork-notification`이 기동된다.
@@ -180,13 +181,14 @@ Kafka는 외부 접근용(`9094`)과 컨테이너 내부용(`9092`) 리스너가
 
 ## 9. 클라우드 / 운영 환경 전환
 
-| 항목             | 로컬 값                                      | 운영 변경 사항                                              |
-|----------------|-------------------------------------------|-------------------------------------------------------|
-| LiveKit config | `livekit.yaml` (`use_external_ip: false`) | `.env`에서 `LIVEKIT_CONFIG_FILE=livekit-cloud.yaml`로 변경 |
-| LiveKit 키      | `devkey` / `devsecret`                    | 실제 키/시크릿으로 교체                                         |
-| DB 비밀번호        | `1234`                                    | 강도 높은 비밀번호로 교체                                        |
-| Spring profile | `local`                                   | `dev` 또는 `prod` (Vault 연동)                            |
-| MinIO          | 로컬 컨테이너                                   | S3 호환 엔드포인트로 변경                                       |
+| 항목                  | 로컬 값                                      | 운영 변경 사항                                              |
+|---------------------|-------------------------------------------|-------------------------------------------------------|
+| LiveKit config      | `livekit.yaml` (`use_external_ip: false`) | `.env`에서 `LIVEKIT_CONFIG_FILE=livekit-cloud.yaml`로 변경 |
+| LiveKit 키           | `devkey` / `devsecret`                    | 실제 키/시크릿으로 교체                                         |
+| DB 비밀번호             | `1234`                                    | 강도 높은 비밀번호로 교체                                        |
+| Spring profile      | `local`                                   | `dev` 또는 `prod` (Vault 연동)                            |
+| MinIO               | 로컬 컨테이너                                   | S3 호환 엔드포인트로 변경                                       |
+| `ELASTICSEARCH_URL` | `http://elasticsearch:9200`               | `.env`에서 관리형 ES 클러스터 주소로 교체 (Vault 경유 주입)             |
 
 ### Vault 시크릿 배포 구조
 
@@ -217,7 +219,7 @@ Kafka는 외부 접근용(`9094`)과 컨테이너 내부용(`9092`) 리스너가
 | `secret/cowork-authorization` | `DB_DSN`, `DATAGSM_CLIENT_ID`, `JWT_SECRET` |
 | `secret/cowork-notification` | `db.dsn` |
 | `secret/cowork-voice` | `MONGODB_URI`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` |
-| `secret/cowork-chat` | `MONGODB_URI` |
+| `secret/cowork-chat` | `MONGODB_URI`, `ELASTICSEARCH_URL` |
 
 `.env`에서 `SPRING_PROFILES_ACTIVE=dev`로 변경하면 config server가 Vault composite 모드로 전환된다. `VAULT_HOST`는 `cowork-vault`로 자동 설정된다.
 
@@ -277,7 +279,7 @@ Kafka는 외부 접근용(`9094`)과 컨테이너 내부용(`9092`) 리스너가
 `cowork-chat` (Elasticsearch 관련):
 - Docker Compose 로컬 실행 시 시작 전에 Config Server에서 설정을 받아 `process.env`에 로드한다.
 - `MONGODB_URI`는 Vault `secret/cowork-chat`, MinIO 자격증명은 `secret/application`에서 공급된다.
-- `ELASTICSEARCH_URL`은 Vault/Config Server가 아닌 docker-compose 환경변수로 직접 주입된다 (`http://elasticsearch:9200`). `.env`에 별도 설정 불필요.
+- `ELASTICSEARCH_URL`은 Vault `secret/cowork-chat`을 통해 Config Server → 앱 순서로 주입된다. 로컬 기본값은 `http://elasticsearch:9200`이며, 운영 환경에서는 `.env`의 `ELASTICSEARCH_URL`을 실제 클러스터 주소로 교체하면 vault-init이 해당 값을 시드한다.
 - **인덱싱 대상**: `projectId`가 있는 메시지만 ES에 인덱싱된다. DM·비프로젝트 채널 메시지는 인덱싱되지 않는다.
 - **인덱스 자동 생성**: 앱 기동 시 `OnModuleInit`에서 `chat_messages` 인덱스가 없으면 자동 생성한다. nori 분석기와 `createdAt` + `messageId` 복합 정렬이 기본 설정된다.
 - **커서 형식**: 검색 페이지네이션의 `nextCursor`는 ES `sort` 배열(`[createdAt, messageId]`)을 `base64(JSON.stringify(...))` 인코딩한 불투명 문자열이다. 이전 방식(messageId 단순 문자열)과 **호환되지 않으므로** 기존 커서를 가진 클라이언트는 재조회가 필요하다.


### PR DESCRIPTION
## 개요

Elasticsearch 8.13.4(nori 한국어 형태소 분석 포함)를 도입하여 프로젝트 단위 채팅 메시지 검색 기능을 구현하였습니다. 기존 MongoDB regex 방식 대신 fuzzy matching, 하이라이팅, cursor 기반 페이지네이션을 지원하며, ProjectMember + ChannelMember 이중 권한 검증을 적용하였습니다.

## 본문

### 인프라 변경

- `docker/elasticsearch.dockerfile` 추가: ES 8.13.4 이미지에 nori 플러그인을 사전 설치하는 커스텀 Dockerfile을 작성하였습니다.
- `docker-compose.yml` 수정: elasticsearch 서비스(single-node, 보안 비활성화, 512MB heap)를 추가하고, cowork-chat 서비스에 `ELASTICSEARCH_URL` 환경변수 및 의존성을 연결하였습니다.

### cowork-project 변경

- `GET /{projectId}/members/me` 내부 API를 추가하였습니다. 채팅 서비스가 HTTP로 프로젝트 멤버 여부를 확인하는 용도로 사용되며, 멤버이면 200, 아니면 404를 반환합니다.

### cowork-chat 변경

**Elasticsearch 모듈**
- `ElasticsearchModule` / `ElasticsearchService`를 신규 구현하였습니다. 앱 부트 시 `chat_messages` 인덱스(nori analyzer 적용)를 생성하며, `indexMessage`, `updateMessage`, `deleteMessage`, `searchMessages` 메서드를 제공합니다.
- `searchMessages`는 bool 쿼리(fuzzy + match_phrase should)로 검색하고, `search_after`로 cursor 페이지네이션을 처리하며 `nextCursor`를 반환합니다.

**인덱싱 및 동기화**
- `ChatMessageConsumer`에서 MongoDB 저장 후 `elasticsearchService.indexMessage()`를 fire-and-forget으로 호출하여 인덱싱합니다. ES 문서 ID로 MongoDB `_id`를 사용하여 수정/삭제와의 일관성을 보장하였습니다.
- `ChatService.editMessage`, `deleteMessage`에서 각각 ES `updateMessage`, `deleteMessage`를 fire-and-forget으로 호출합니다. ES 장애 시 로그만 기록하고 예외를 전파하지 않습니다.
- `projectId=null`인 메시지는 ES 인덱싱을 생략합니다.

**검색 API**
- `GET /projects/:projectId/messages/search` 엔드포인트를 추가하였습니다.
- 권한 흐름: `ProjectClient.isMember()` → ChannelMember 조회 → `channelId` 필터 검증 → ES 검색.
- 쿼리 파라미터: `q`, `channelId`, `authorId`, `type`, `hasFile`, `before`(cursor), `limit`.
- Swagger `@ApiOperation`, `@ApiQuery`, `@ApiResponse` 어노테이션을 통해 API 문서를 작성하였습니다.

**게이트웨이**
- `cowork-gateway-local.yml`, `cowork-gateway-dev.yml`에 `chat-service-search` 라우트를 추가하였습니다. `GET /api/projects/*/messages/search` 요청이 project-service가 아닌 cowork-chat으로 라우팅되도록 project-service 라우트보다 앞에 선언하였습니다.

**테스트**
- `ElasticsearchService` 15개, `ProjectMessageController` 6개, `ProjectClient.isMember` 4개, `ChatService` ES 동기화 6개 테스트 케이스를 추가하였습니다.
