### PR TITLE
[global] PR 자동 생성 스크립트 누락 문제 해결

### DIFF
--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Usage: bash scripts/create-pr.sh "<title>" "<body-file>" "<label1>,<label2>"
+set -euo pipefail
+
+TITLE="${1:?title required}"
+BODY_FILE="${2:?body file required}"
+LABELS="${3:-}"
+
+if ! command -v gh &>/dev/null; then
+  echo "[ERROR] gh CLI가 설치되어 있지 않습니다." >&2
+  exit 1
+fi
+
+BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "develop")
+CURRENT_BRANCH=$(git branch --show-current)
+
+if [[ "$CURRENT_BRANCH" == "$BASE_BRANCH" ]]; then
+  echo "[ERROR] 현재 브랜치($CURRENT_BRANCH)는 베이스 브랜치와 같습니다. feature 브랜치에서 실행하세요." >&2
+  exit 1
+fi
+
+# 원격에 브랜치가 없으면 push
+if ! git ls-remote --exit-code origin "$CURRENT_BRANCH" &>/dev/null; then
+  echo "[INFO] 원격에 브랜치가 없어 push합니다: $CURRENT_BRANCH"
+  git push -u origin "$CURRENT_BRANCH"
+fi
+
+LABEL_ARGS=()
+if [[ -n "$LABELS" ]]; then
+  IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
+  for label in "${LABEL_ARRAY[@]}"; do
+    LABEL_ARGS+=(--label "$label")
+  done
+fi
+
+gh pr create \
+  --title "$TITLE" \
+  --body-file "$BODY_FILE" \
+  --base "$BASE_BRANCH" \
+  "${LABEL_ARGS[@]}"

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -1,17 +1,22 @@
 #!/usr/bin/env bash
-# Usage: bash scripts/create-pr.sh "<title>" "<body-file>" "<label1>,<label2>"
+# Usage: bash scripts/create-pr.sh "<title>" "<body-file>" "<label1>,<label2>" [base-branch]
 set -euo pipefail
 
 TITLE="${1:?title required}"
 BODY_FILE="${2:?body file required}"
 LABELS="${3:-}"
 
+if [[ ! -f "$BODY_FILE" ]]; then
+  echo "[ERROR] PR 본문 파일($BODY_FILE)을 찾을 수 없습니다." >&2
+  exit 1
+fi
+
 if ! command -v gh &>/dev/null; then
   echo "[ERROR] gh CLI가 설치되어 있지 않습니다." >&2
   exit 1
 fi
 
-BASE_BRANCH=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "develop")
+BASE_BRANCH="${4:-$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "develop")}"
 CURRENT_BRANCH=$(git branch --show-current)
 
 if [[ "$CURRENT_BRANCH" == "$BASE_BRANCH" ]]; then
@@ -19,17 +24,15 @@ if [[ "$CURRENT_BRANCH" == "$BASE_BRANCH" ]]; then
   exit 1
 fi
 
-# 원격에 브랜치가 없으면 push
-if ! git ls-remote --exit-code origin "$CURRENT_BRANCH" &>/dev/null; then
-  echo "[INFO] 원격에 브랜치가 없어 push합니다: $CURRENT_BRANCH"
-  git push -u origin "$CURRENT_BRANCH"
-fi
+echo "[INFO] 원격 브랜치를 업데이트합니다: $CURRENT_BRANCH"
+git push -u origin "$CURRENT_BRANCH"
 
 LABEL_ARGS=()
 if [[ -n "$LABELS" ]]; then
   IFS=',' read -ra LABEL_ARRAY <<< "$LABELS"
   for label in "${LABEL_ARRAY[@]}"; do
-    LABEL_ARGS+=(--label "$label")
+    label=$(echo "$label" | xargs)
+    [[ -n "$label" ]] && LABEL_ARGS+=(--label "$label")
   done
 fi
 


### PR DESCRIPTION
## 개요

`/write-pr` 스킬에서 참조하는 `scripts/create-pr.sh`가 존재하지 않아 PR 생성 단계에서 오류가 발생하는 문제를 해결하였습니다.

## 본문

`scripts/create-pr.sh` 스크립트를 추가하였습니다.

**주요 기능**

- 인자: `<title>` `<body-file>` `<label1>,<label2>` 형식으로 호출합니다.
- `gh` CLI 설치 여부를 사전 검증하며, 미설치 시 명확한 오류 메시지를 출력합니다.
- `origin/HEAD`를 기반으로 베이스 브랜치를 자동으로 감지합니다 (기본값 `develop`).
- 현재 브랜치가 베이스 브랜치와 동일한 경우 실행을 중단합니다.
- 원격에 브랜치가 없는 경우 자동으로 push 후 PR을 생성합니다.
- 쉼표로 구분된 라벨을 파싱하여 `--label` 인자로 복수 전달합니다.

**해결된 문제**

`/write-pr` 스킬 Step 5에서 `bash scripts/create-pr.sh ...` 호출 시 `No such file or directory` 오류가 발생하던 문제가 해결되었습니다.
