### PR TITLE
[chat] 채팅 검색과 권한 로직 통합

### DIFF
--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -10,12 +10,9 @@ import {
     HttpCode,
     HttpStatus,
     ParseIntPipe,
-    BadRequestException,
-    ForbiddenException,
 } from '@nestjs/common';
 import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ChatService } from './chat.service';
-import { ChatGateway } from './chat.gateway';
 import { SendMessageDto } from './dto/send-message.dto';
 import { EditMessageDto } from './dto/edit-message.dto';
 import { GetMessagesDto } from './dto/get-messages.dto';
@@ -32,30 +29,17 @@ import {
 } from './dto/message-response.dto';
 import { CreateGithubIssueDto, CreateGithubIssueResponseDto } from './dto/create-github-issue.dto';
 import {
-    SlashCommand,
     SlashCommandDto,
     SlashCommandResponseDto,
 } from './dto/slash-command.dto';
-import { ChatMessageProducer } from './kafka/chat-message.producer';
-import { GithubIssueProducer } from './kafka/github-issue.producer';
-import { ProjectClient } from './service/project.client';
-import { MessageDocument } from './schema/message.schema';
 import { UserId, UserRole } from '../common/decorator/user.decorator';
-import { MinioService } from '../storage/minio.service';
 
 @ApiTags('Chat')
 @ApiHeader({ name: 'X-User-Id', description: 'Gateway 주입 유저 ID', required: true })
 @ApiHeader({ name: 'X-User-Role', description: 'Gateway 주입 유저 역할 (ADMIN | MEMBER)', required: true })
 @Controller('channels/:channelId')
 export class ChatController {
-    constructor(
-        private readonly chatService: ChatService,
-        private readonly chatGateway: ChatGateway,
-        private readonly producer: ChatMessageProducer,
-        private readonly minioService: MinioService,
-        private readonly githubIssueProducer: GithubIssueProducer,
-        private readonly projectClient: ProjectClient,
-    ) {}
+    constructor(private readonly chatService: ChatService) {}
 
     @Post('files/presigned-url')
     @HttpCode(HttpStatus.CREATED)
@@ -67,21 +51,7 @@ export class ChatController {
         @Body() dto: CreateFileUploadUrlRequestDto,
         @UserId() userId: number,
     ): Promise<CreateFileUploadUrlResponseDto> {
-        await this.chatService.checkMembership(channelId, userId);
-        const upload = await this.minioService.createPresignedUpload({
-            channelId,
-            userId,
-            filename: dto.filename,
-            contentType: dto.contentType,
-            size: dto.size,
-        });
-
-        return {
-            ...upload,
-            headers: {
-                'Content-Type': dto.contentType,
-            },
-        };
+        return this.chatService.createFileUploadUrl(channelId, dto, userId);
     }
 
     @Post('files/confirm')
@@ -97,8 +67,7 @@ export class ChatController {
         @Body() dto: ConfirmFileUploadRequestDto,
         @UserId() userId: number,
     ): Promise<ConfirmFileUploadResponseDto> {
-        await this.chatService.checkMembership(channelId, userId);
-        const fileUrl = await this.minioService.confirmUpload(channelId, userId, dto.objectKey);
+        const fileUrl = await this.chatService.confirmFileUpload(channelId, dto.objectKey, userId);
         return { fileUrl };
     }
 
@@ -113,8 +82,7 @@ export class ChatController {
         @UserId() userId: number,
         @UserRole() userRole: string,
     ): Promise<SendMessageResponseDto> {
-        await this.chatService.checkMembership(channelId, userId);
-        await this.producer.sendMessage(channelId, dto, userId, userRole);
+        await this.chatService.sendMessage(channelId, dto, userId, userRole);
         return { queued: true };
     }
 
@@ -132,7 +100,7 @@ export class ChatController {
         @Body() dto: CreateGithubIssueDto,
         @UserId() userId: number,
     ): Promise<CreateGithubIssueResponseDto> {
-        await this.publishGithubIssueCreateCommand(channelId, dto, userId);
+        await this.chatService.publishGithubIssueCreateCommand(channelId, dto, userId);
         return { queued: true };
     }
 
@@ -150,38 +118,8 @@ export class ChatController {
         @Body() dto: SlashCommandDto,
         @UserId() userId: number,
     ): Promise<SlashCommandResponseDto> {
-        if (dto.command !== SlashCommand.GITHUB_ISSUE_CREATE) {
-            throw new BadRequestException('지원하지 않는 슬래시 커맨드입니다');
-        }
-
-        await this.publishGithubIssueCreateCommand(channelId, dto.payload, userId);
+        await this.chatService.handleSlashCommand(channelId, dto, userId);
         return { queued: true };
-    }
-
-    private async publishGithubIssueCreateCommand(
-        channelId: number,
-        dto: CreateGithubIssueDto,
-        userId: number,
-    ): Promise<void> {
-        const channelTeamId = await this.chatService.checkMembershipAndGetTeamId(channelId, userId);
-        const repoInfo = await this.projectClient.getGithubRepoInfo(dto.projectId);
-        if (!repoInfo) {
-            throw new BadRequestException('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
-        }
-        if (channelTeamId !== repoInfo.teamId) {
-            throw new ForbiddenException('해당 프로젝트는 이 채널의 팀에 속하지 않습니다');
-        }
-
-        await this.githubIssueProducer.send({
-            channelId,
-            teamId: repoInfo.teamId,
-            projectId: dto.projectId,
-            owner: repoInfo.owner,
-            repo: repoInfo.repo,
-            title: dto.title,
-            body: dto.body,
-            requesterId: userId,
-        });
     }
 
     @Get('messages')
@@ -209,18 +147,7 @@ export class ChatController {
         @UserId() userId: number,
         @UserRole() userRole: string,
     ) {
-        await this.chatService.checkMembership(channelId, userId);
-        const updated = await this.chatService.editMessage(messageId, userId, dto, userRole);
-
-        this.chatGateway.server
-            ?.to(`chat:${channelId}`)
-            .emit('message:edited', {
-                messageId,
-                content: updated.content,
-                editedAt: (updated as MessageDocument).updatedAt?.toISOString() ?? new Date().toISOString(),
-            });
-
-        return updated;
+        return this.chatService.editMessage(channelId, messageId, userId, dto, userRole);
     }
 
     @Delete('messages/:messageId')
@@ -234,13 +161,6 @@ export class ChatController {
         @UserId() userId: number,
         @UserRole() userRole: string,
     ) {
-        await this.chatService.checkMembership(channelId, userId);
-        const result = await this.chatService.deleteMessage(messageId, userId, userRole);
-
-        this.chatGateway.server
-            ?.to(`chat:${channelId}`)
-            .emit('message:deleted', { messageId });
-
-        return result;
+        return this.chatService.deleteMessage(channelId, messageId, userId, userRole);
     }
 }

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -1,3 +1,4 @@
+import { forwardRef, Inject, Logger } from '@nestjs/common';
 import {
     WebSocketGateway,
     WebSocketServer,
@@ -8,7 +9,6 @@ import {
     OnGatewayDisconnect,
     OnGatewayInit,
 } from '@nestjs/websockets';
-import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Server, Socket } from 'socket.io';
@@ -33,6 +33,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     @WebSocketServer() server!: Server;
 
     constructor(
+        @Inject(forwardRef(() => ChatService))
         private readonly chatService: ChatService,
         private readonly consumer: ChatMessageConsumer,
         private readonly githubIssueResultConsumer: GithubIssueResultConsumer,

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -13,6 +13,10 @@ import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { ProjectClient } from './service/project.client';
 
 const mockMessageId = new Types.ObjectId().toString();
+const mockEmit = jest.fn();
+const mockTo = jest.fn(() => ({
+    emit: mockEmit,
+}));
 
 const makeMockMessage = (overrides = {}) => ({
     _id: new Types.ObjectId(mockMessageId),
@@ -21,7 +25,12 @@ const makeMockMessage = (overrides = {}) => ({
     content: '안녕하세요',
     isEdited: false,
     editHistory: [] as { content: string; editedAt: Date }[],
-    save: jest.fn().mockResolvedValue({ content: '수정됨', isEdited: true }),
+    updatedAt: new Date('2026-05-12T00:00:00.000Z'),
+    save: jest.fn().mockResolvedValue({
+        content: '수정됨',
+        isEdited: true,
+        updatedAt: new Date('2026-05-12T00:00:00.000Z'),
+    }),
     ...overrides,
 });
 
@@ -66,9 +75,7 @@ const mockProjectClient = {
 
 const mockChatGateway = {
     server: {
-        to: jest.fn(() => ({
-            emit: jest.fn(),
-        })),
+        to: mockTo,
     },
 };
 
@@ -193,13 +200,21 @@ describe('ChatService', () => {
             mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(msg);
 
-            await service.editMessage(1, mockMessageId, 42, { content: '관리자 수정' }, 'ADMIN');
+            await service.editMessage(1, mockMessageId, 42, { content: '관리자 수정' }, 'ROLE_ADMIN');
 
             expect(msg.save).toHaveBeenCalled();
         });
 
         it('수정 후 ES updateMessage를 fire-and-forget으로 호출한다', async () => {
-            const msg = makeMockMessage();
+            const msg = makeMockMessage({
+                projectId: 10,
+                save: jest.fn().mockResolvedValue({
+                    content: '수정됨',
+                    isEdited: true,
+                    projectId: 10,
+                    updatedAt: new Date('2026-05-12T00:00:00.000Z'),
+                }),
+            });
             mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(msg);
             mockElasticsearchService.updateMessage.mockResolvedValue(undefined);
@@ -208,6 +223,50 @@ describe('ChatService', () => {
 
             await new Promise((r) => setImmediate(r));
             expect(mockElasticsearchService.updateMessage).toHaveBeenCalledWith(mockMessageId, '수정됨');
+        });
+
+        it('다른 채널의 메시지를 수정하려 하면 ForbiddenException을 던진다', async () => {
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+            mockMessageModel.findById.mockResolvedValue(makeMockMessage({ channelId: 2 }));
+
+            await expect(
+                service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
+            ).rejects.toThrow(ForbiddenException);
+        });
+
+        it('내용이 동일하면 저장과 이벤트 발행을 생략한다', async () => {
+            const msg = makeMockMessage();
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+            mockMessageModel.findById.mockResolvedValue(msg);
+
+            const result = await service.editMessage(1, mockMessageId, 42, { content: '안녕하세요' }, 'MEMBER');
+
+            expect(msg.save).not.toHaveBeenCalled();
+            expect(mockElasticsearchService.updateMessage).not.toHaveBeenCalled();
+            expect(mockTo).not.toHaveBeenCalled();
+            expect(result).toBe(msg);
+        });
+
+        it('수정 이벤트에는 저장된 updatedAt 값을 사용한다', async () => {
+            const savedAt = new Date('2026-05-12T01:02:03.000Z');
+            const msg = makeMockMessage({
+                save: jest.fn().mockResolvedValue({
+                    content: '수정됨',
+                    isEdited: true,
+                    updatedAt: savedAt,
+                }),
+            });
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+            mockMessageModel.findById.mockResolvedValue(msg);
+
+            await service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER');
+
+            expect(mockTo).toHaveBeenCalledWith('chat:1');
+            expect(mockEmit).toHaveBeenCalledWith('message:edited', {
+                messageId: mockMessageId,
+                content: '수정됨',
+                editedAt: savedAt.toISOString(),
+            });
         });
 
         it('ES 오류가 발생해도 editMessage 결과에 영향을 주지 않는다', async () => {
@@ -256,13 +315,13 @@ describe('ChatService', () => {
             mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
 
             await expect(
-                service.deleteMessage(1, mockMessageId, 42, 'ADMIN'),
+                service.deleteMessage(1, mockMessageId, 42, 'ROLE_ADMIN'),
             ).resolves.toBeDefined();
         });
 
         it('삭제 후 ES deleteMessage를 fire-and-forget으로 호출한다', async () => {
             mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(makeMockMessage());
+            mockMessageModel.findById.mockResolvedValue(makeMockMessage({ projectId: 10 }));
             mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
             mockElasticsearchService.deleteMessage.mockResolvedValue(undefined);
 

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -3,9 +3,14 @@ import { getModelToken } from '@nestjs/mongoose';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Types } from 'mongoose';
 import { ChatService } from './chat.service';
+import { ChatGateway } from './chat.gateway';
 import { Message } from './schema/message.schema';
 import { ChannelMember } from './schema/channel-member.schema';
 import { ElasticsearchService } from '../search/elasticsearch.service';
+import { MinioService } from '../storage/minio.service';
+import { ChatMessageProducer } from './kafka/chat-message.producer';
+import { GithubIssueProducer } from './kafka/github-issue.producer';
+import { ProjectClient } from './service/project.client';
 
 const mockMessageId = new Types.ObjectId().toString();
 
@@ -38,6 +43,33 @@ const mockMemberModel = {
 const mockElasticsearchService = {
     updateMessage: jest.fn().mockResolvedValue(undefined),
     deleteMessage: jest.fn().mockResolvedValue(undefined),
+    searchMessages: jest.fn(),
+};
+
+const mockMinioService = {
+    createPresignedUpload: jest.fn(),
+    confirmUpload: jest.fn(),
+};
+
+const mockChatMessageProducer = {
+    sendMessage: jest.fn(),
+};
+
+const mockGithubIssueProducer = {
+    send: jest.fn(),
+};
+
+const mockProjectClient = {
+    getGithubRepoInfo: jest.fn(),
+    isMember: jest.fn(),
+};
+
+const mockChatGateway = {
+    server: {
+        to: jest.fn(() => ({
+            emit: jest.fn(),
+        })),
+    },
 };
 
 describe('ChatService', () => {
@@ -50,6 +82,11 @@ describe('ChatService', () => {
                 { provide: getModelToken(Message.name), useValue: mockMessageModel },
                 { provide: getModelToken(ChannelMember.name), useValue: mockMemberModel },
                 { provide: ElasticsearchService, useValue: mockElasticsearchService },
+                { provide: MinioService, useValue: mockMinioService },
+                { provide: ChatMessageProducer, useValue: mockChatMessageProducer },
+                { provide: GithubIssueProducer, useValue: mockGithubIssueProducer },
+                { provide: ProjectClient, useValue: mockProjectClient },
+                { provide: ChatGateway, useValue: mockChatGateway },
             ],
         }).compile();
 
@@ -123,9 +160,10 @@ describe('ChatService', () => {
     describe('editMessage', () => {
         it('본인 메시지를 수정하면 editHistory에 이전 내용이 저장된다', async () => {
             const msg = makeMockMessage();
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(msg);
 
-            await service.editMessage(mockMessageId, 42, { content: '수정됨' }, 'ROLE_USER');
+            await service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER');
 
             expect(msg.editHistory).toHaveLength(1);
             expect(msg.editHistory[0].content).toBe('안녕하세요');
@@ -135,34 +173,38 @@ describe('ChatService', () => {
         });
 
         it('메시지가 없으면 NotFoundException을 던진다', async () => {
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(null);
             await expect(
-                service.editMessage(mockMessageId, 42, { content: '수정됨' }, 'ROLE_USER'),
+                service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
             ).rejects.toThrow(NotFoundException);
         });
 
         it('다른 사람의 메시지를 수정하면 ForbiddenException을 던진다', async () => {
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
             await expect(
-                service.editMessage(mockMessageId, 42, { content: '수정됨' }, 'ROLE_USER'),
+                service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
             ).rejects.toThrow(ForbiddenException);
         });
 
         it('ADMIN은 다른 사람의 메시지도 수정할 수 있다', async () => {
             const msg = makeMockMessage({ authorId: 100 });
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(msg);
 
-            await service.editMessage(mockMessageId, 42, { content: '관리자 수정' }, 'ROLE_ADMIN');
+            await service.editMessage(1, mockMessageId, 42, { content: '관리자 수정' }, 'ADMIN');
 
             expect(msg.save).toHaveBeenCalled();
         });
 
         it('수정 후 ES updateMessage를 fire-and-forget으로 호출한다', async () => {
             const msg = makeMockMessage();
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(msg);
             mockElasticsearchService.updateMessage.mockResolvedValue(undefined);
 
-            await service.editMessage(mockMessageId, 42, { content: '수정됨' }, 'ROLE_USER');
+            await service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER');
 
             await new Promise((r) => setImmediate(r));
             expect(mockElasticsearchService.updateMessage).toHaveBeenCalledWith(mockMessageId, '수정됨');
@@ -170,67 +212,74 @@ describe('ChatService', () => {
 
         it('ES 오류가 발생해도 editMessage 결과에 영향을 주지 않는다', async () => {
             const msg = makeMockMessage();
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(msg);
             mockElasticsearchService.updateMessage.mockRejectedValue(new Error('ES down'));
 
             await expect(
-                service.editMessage(mockMessageId, 42, { content: '수정됨' }, 'ROLE_USER'),
+                service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
             ).resolves.toBeDefined();
         });
     });
 
     describe('deleteMessage', () => {
         it('본인 메시지를 삭제한다', async () => {
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(makeMockMessage());
             mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
 
-            const result = await service.deleteMessage(mockMessageId, 42, 'ROLE_USER');
+            const result = await service.deleteMessage(1, mockMessageId, 42, 'MEMBER');
 
             expect(mockMessageModel.deleteOne).toHaveBeenCalledWith({ _id: mockMessageId });
             expect(result.messageId).toBe(mockMessageId);
         });
 
         it('메시지가 없으면 NotFoundException을 던진다', async () => {
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(null);
             await expect(
-                service.deleteMessage(mockMessageId, 42, 'ROLE_USER'),
+                service.deleteMessage(1, mockMessageId, 42, 'MEMBER'),
             ).rejects.toThrow(NotFoundException);
         });
 
         it('다른 사람의 메시지를 삭제하면 ForbiddenException을 던진다', async () => {
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
             await expect(
-                service.deleteMessage(mockMessageId, 42, 'ROLE_USER'),
+                service.deleteMessage(1, mockMessageId, 42, 'MEMBER'),
             ).rejects.toThrow(ForbiddenException);
         });
 
         it('ADMIN은 다른 사람의 메시지도 삭제할 수 있다', async () => {
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
             mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
 
             await expect(
-                service.deleteMessage(mockMessageId, 42, 'ROLE_ADMIN'),
+                service.deleteMessage(1, mockMessageId, 42, 'ADMIN'),
             ).resolves.toBeDefined();
         });
 
         it('삭제 후 ES deleteMessage를 fire-and-forget으로 호출한다', async () => {
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(makeMockMessage());
             mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
             mockElasticsearchService.deleteMessage.mockResolvedValue(undefined);
 
-            await service.deleteMessage(mockMessageId, 42, 'ROLE_USER');
+            await service.deleteMessage(1, mockMessageId, 42, 'MEMBER');
 
             await new Promise((r) => setImmediate(r));
             expect(mockElasticsearchService.deleteMessage).toHaveBeenCalledWith(mockMessageId);
         });
 
         it('ES 오류가 발생해도 deleteMessage 결과에 영향을 주지 않는다', async () => {
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
             mockMessageModel.findById.mockResolvedValue(makeMockMessage());
             mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
             mockElasticsearchService.deleteMessage.mockRejectedValue(new Error('ES down'));
 
             await expect(
-                service.deleteMessage(mockMessageId, 42, 'ROLE_USER'),
+                service.deleteMessage(1, mockMessageId, 42, 'MEMBER'),
             ).resolves.toBeDefined();
         });
     });

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -1,11 +1,30 @@
-import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+    BadRequestException,
+    ForbiddenException,
+    forwardRef,
+    Inject,
+    Injectable,
+    Logger,
+    NotFoundException,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
-import { Message } from './schema/message.schema';
+import { Message, MessageDocument } from './schema/message.schema';
 import { ChannelMember } from './schema/channel-member.schema';
 import { EditMessageDto } from './dto/edit-message.dto';
 import { UserRole } from '../common/enum/user-role.enum';
 import { ElasticsearchService } from '../search/elasticsearch.service';
+import { MinioService, PresignedUpload } from '../storage/minio.service';
+import { ChatMessageProducer } from './kafka/chat-message.producer';
+import { GithubIssueProducer } from './kafka/github-issue.producer';
+import { ProjectClient } from './service/project.client';
+import { ChatGateway } from './chat.gateway';
+import { SendMessageDto } from './dto/send-message.dto';
+import { CreateFileUploadUrlRequestDto, CreateFileUploadUrlResponseDto } from './dto/create-file-upload-url.dto';
+import { CreateGithubIssueDto } from './dto/create-github-issue.dto';
+import { SlashCommand, SlashCommandDto } from './dto/slash-command.dto';
+import { SearchMessagesDto } from './dto/search-messages.dto';
+import { SearchMessagesResponseDto } from './dto/search-message-response.dto';
 
 const SYSTEM_AUTHOR_ID = 0;
 
@@ -17,6 +36,12 @@ export class ChatService {
         @InjectModel(Message.name) private readonly messageModel: Model<Message>,
         @InjectModel(ChannelMember.name) private readonly memberModel: Model<ChannelMember>,
         private readonly elasticsearchService: ElasticsearchService,
+        private readonly minioService: MinioService,
+        private readonly chatMessageProducer: ChatMessageProducer,
+        private readonly githubIssueProducer: GithubIssueProducer,
+        private readonly projectClient: ProjectClient,
+        @Inject(forwardRef(() => ChatGateway))
+        private readonly chatGateway: ChatGateway,
     ) {}
 
     async isMember(channelId: number, userId: number): Promise<boolean> {
@@ -33,6 +58,80 @@ export class ChatService {
         const member = await this.memberModel.findOne({ channelId, userId }, { teamId: 1 });
         if (!member) throw new ForbiddenException('채널 접근 권한이 없습니다');
         return member.teamId;
+    }
+
+    async createFileUploadUrl(
+        channelId: number,
+        dto: CreateFileUploadUrlRequestDto,
+        userId: number,
+    ): Promise<CreateFileUploadUrlResponseDto> {
+        await this.checkMembership(channelId, userId);
+        const upload = await this.minioService.createPresignedUpload({
+            channelId,
+            userId,
+            filename: dto.filename,
+            contentType: dto.contentType,
+            size: dto.size,
+        });
+
+        return {
+            ...upload,
+            headers: {
+                'Content-Type': dto.contentType,
+            },
+        };
+    }
+
+    async confirmFileUpload(channelId: number, objectKey: string, userId: number): Promise<string> {
+        await this.checkMembership(channelId, userId);
+        return this.minioService.confirmUpload(channelId, userId, objectKey);
+    }
+
+    async sendMessage(
+        channelId: number,
+        dto: SendMessageDto,
+        userId: number,
+        userRole: string,
+    ): Promise<void> {
+        await this.checkMembership(channelId, userId);
+        await this.chatMessageProducer.sendMessage(channelId, dto, userId, userRole);
+    }
+
+    async handleSlashCommand(
+        channelId: number,
+        dto: SlashCommandDto,
+        userId: number,
+    ): Promise<void> {
+        if (dto.command !== SlashCommand.GITHUB_ISSUE_CREATE) {
+            throw new BadRequestException('지원하지 않는 슬래시 커맨드입니다');
+        }
+        await this.publishGithubIssueCreateCommand(channelId, dto.payload, userId);
+    }
+
+    async publishGithubIssueCreateCommand(
+        channelId: number,
+        dto: CreateGithubIssueDto,
+        userId: number,
+    ): Promise<void> {
+        const channelTeamId = await this.checkMembershipAndGetTeamId(channelId, userId);
+        const repoInfo = await this.projectClient.getGithubRepoInfo(dto.projectId);
+        if (!repoInfo) {
+            throw new BadRequestException('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
+        }
+        if (channelTeamId !== repoInfo.teamId) {
+            throw new ForbiddenException('해당 프로젝트는 이 채널의 팀에 속하지 않습니다');
+        }
+
+        await this.githubIssueProducer.send({
+            channelId,
+            teamId: repoInfo.teamId,
+            projectId: dto.projectId,
+            owner: repoInfo.owner,
+            repo: repoInfo.repo,
+            title: dto.title,
+            body: dto.body,
+            requesterId: userId,
+        });
     }
 
     async getMessages(channelId: number, before?: string) {
@@ -73,25 +172,72 @@ export class ChatService {
             ]);
     }
 
-    async editMessage(messageId: string, userId: number, dto: EditMessageDto, userRole: string) {
+    async searchProjectMessages(
+        projectId: number,
+        dto: SearchMessagesDto,
+        userId: number,
+    ): Promise<SearchMessagesResponseDto> {
+        const isMember = await this.projectClient.isMember(projectId, userId);
+        if (!isMember) {
+            throw new ForbiddenException('프로젝트 접근 권한이 없습니다');
+        }
+
+        const memberships = await this.memberModel.find({ userId }, { channelId: 1 }).lean();
+        const accessibleChannelIds = memberships.map((membership) => membership.channelId);
+
+        let filteredChannelIds = accessibleChannelIds;
+        if (dto.channelId !== undefined) {
+            if (!accessibleChannelIds.includes(dto.channelId)) {
+                throw new ForbiddenException('채널 접근 권한이 없습니다');
+            }
+            filteredChannelIds = [dto.channelId];
+        }
+
+        const { hits, nextCursor } = await this.elasticsearchService.searchMessages({
+            projectId,
+            accessibleChannelIds: filteredChannelIds,
+            q: dto.q,
+            authorId: dto.authorId,
+            type: dto.type,
+            hasFile: dto.hasFile,
+            before: dto.before,
+            limit: dto.limit ?? 50,
+        });
+
+        return { messages: hits, nextCursor };
+    }
+
+    async editMessage(channelId: number, messageId: string, userId: number, dto: EditMessageDto, userRole: string) {
+        await this.checkMembership(channelId, userId);
         const message = await this.messageModel.findById(messageId);
         if (!message) throw new NotFoundException('메시지를 찾을 수 없습니다');
         if (message.authorId !== userId && !this.isAdmin(userRole)) {
             throw new ForbiddenException('본인 메시지만 수정할 수 있습니다');
         }
 
-        if (message.content === dto.content) return message;
-        message.editHistory.push({ content: message.content, editedAt: new Date() });
-        message.content = dto.content;
-        message.isEdited = true;
-        const saved = await message.save();
-        if (message.projectId) {
-            void this.elasticsearchService.updateMessage(messageId, dto.content);
+        if (message.content !== dto.content) {
+            message.editHistory.push({ content: message.content, editedAt: new Date() });
+            message.content = dto.content;
+            message.isEdited = true;
+            await message.save();
+            if (message.projectId) {
+                void this.elasticsearchService.updateMessage(messageId, dto.content);
+            }
         }
-        return saved;
+
+        this.chatGateway.server
+            ?.to(`chat:${channelId}`)
+            .emit('message:edited', {
+                messageId,
+                content: message.content,
+                editedAt: (message as MessageDocument).updatedAt?.toISOString() ?? new Date().toISOString(),
+            });
+
+        return message;
     }
 
-    async deleteMessage(messageId: string, userId: number, userRole: string) {
+    async deleteMessage(channelId: number, messageId: string, userId: number, userRole: string) {
+        await this.checkMembership(channelId, userId);
         const message = await this.messageModel.findById(messageId);
         if (!message) throw new NotFoundException('메시지를 찾을 수 없습니다');
         if (message.authorId !== userId && !this.isAdmin(userRole)) {
@@ -102,6 +248,11 @@ export class ChatService {
         if (message.projectId) {
             void this.elasticsearchService.deleteMessage(messageId);
         }
+
+        this.chatGateway.server
+            ?.to(`chat:${channelId}`)
+            .emit('message:deleted', { messageId });
+
         return { channelId: message.channelId, messageId };
     }
 

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -211,29 +211,34 @@ export class ChatService {
         await this.checkMembership(channelId, userId);
         const message = await this.messageModel.findById(messageId);
         if (!message) throw new NotFoundException('메시지를 찾을 수 없습니다');
+        if (message.channelId !== channelId) {
+            throw new ForbiddenException('해당 채널의 메시지가 아닙니다');
+        }
         if (message.authorId !== userId && !this.isAdmin(userRole)) {
             throw new ForbiddenException('본인 메시지만 수정할 수 있습니다');
         }
 
-        if (message.content !== dto.content) {
-            message.editHistory.push({ content: message.content, editedAt: new Date() });
-            message.content = dto.content;
-            message.isEdited = true;
-            await message.save();
-            if (message.projectId) {
-                void this.elasticsearchService.updateMessage(messageId, dto.content);
-            }
+        if (message.content === dto.content) {
+            return message;
+        }
+
+        message.editHistory.push({ content: message.content, editedAt: new Date() });
+        message.content = dto.content;
+        message.isEdited = true;
+        const updated = await message.save();
+        if (updated.projectId) {
+            void this.elasticsearchService.updateMessage(messageId, dto.content);
         }
 
         this.chatGateway.server
             ?.to(`chat:${channelId}`)
             .emit('message:edited', {
                 messageId,
-                content: message.content,
-                editedAt: (message as MessageDocument).updatedAt?.toISOString() ?? new Date().toISOString(),
+                content: updated.content,
+                editedAt: (updated as MessageDocument).updatedAt?.toISOString(),
             });
 
-        return message;
+        return updated;
     }
 
     async deleteMessage(channelId: number, messageId: string, userId: number, userRole: string) {

--- a/cowork-chat/src/chat/project-message.controller.spec.ts
+++ b/cowork-chat/src/chat/project-message.controller.spec.ts
@@ -1,23 +1,11 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException } from '@nestjs/common';
-import { getModelToken } from '@nestjs/mongoose';
 import { ProjectMessageController } from './project-message.controller';
-import { ElasticsearchService } from '../search/elasticsearch.service';
-import { ProjectClient } from './service/project.client';
-import { ChannelMember } from './schema/channel-member.schema';
+import { ChatService } from './chat.service';
 
 const userId = 42;
 
-const mockMemberModel = {
-    find: jest.fn(),
-};
-
-const mockElasticsearchService = {
-    searchMessages: jest.fn(),
-};
-
-const mockProjectClient = {
-    isMember: jest.fn(),
+const mockChatService = {
+    searchProjectMessages: jest.fn(),
 };
 
 describe('ProjectMessageController', () => {
@@ -27,9 +15,7 @@ describe('ProjectMessageController', () => {
         const module: TestingModule = await Test.createTestingModule({
             controllers: [ProjectMessageController],
             providers: [
-                { provide: getModelToken(ChannelMember.name), useValue: mockMemberModel },
-                { provide: ElasticsearchService, useValue: mockElasticsearchService },
-                { provide: ProjectClient, useValue: mockProjectClient },
+                { provide: ChatService, useValue: mockChatService },
             ],
         }).compile();
 
@@ -38,113 +24,39 @@ describe('ProjectMessageController', () => {
     });
 
     describe('searchMessages', () => {
-        const memberships = [{ channelId: 2 }, { channelId: 3 }];
-        const searchResult = {
-            hits: [
-                {
-                    messageId: 'msg-1',
-                    channelId: 2,
-                    authorId: 42,
-                    content: '안녕하세요',
-                    highlight: ['<em>안녕</em>하세요'],
-                    type: 'TEXT',
-                    hasAttachments: false,
-                    isPinned: false,
-                    createdAt: '2026-05-11T10:00:00.000Z',
-                },
-            ],
-            nextCursor: null,
-        };
+        it('프로젝트 메시지 검색을 ChatService에 위임한다', async () => {
+            const query = { q: '안녕', channelId: 2, limit: 50 } as any;
+            const expected = {
+                messages: [
+                    {
+                        messageId: 'msg-1',
+                        channelId: 2,
+                        authorId: 42,
+                        content: '안녕하세요',
+                        highlight: ['<em>안녕</em>하세요'],
+                        type: 'TEXT',
+                        hasAttachments: false,
+                        isPinned: false,
+                        createdAt: '2026-05-11T10:00:00.000Z',
+                    },
+                ],
+                nextCursor: 'cursor',
+            };
+            mockChatService.searchProjectMessages.mockResolvedValue(expected);
 
-        it('프로젝트 멤버이면 채널 멤버십 기반으로 ES 검색 결과를 반환한다', async () => {
-            mockProjectClient.isMember.mockResolvedValue(true);
-            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve(memberships) });
-            mockElasticsearchService.searchMessages.mockResolvedValue(searchResult);
+            const result = await controller.searchMessages(5, query, userId);
 
-            const result = await controller.searchMessages(5, { q: '안녕', limit: 50 } as any, userId);
-
-            expect(mockProjectClient.isMember).toHaveBeenCalledWith(5, 42);
-            expect(mockElasticsearchService.searchMessages).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    projectId: 5,
-                    accessibleChannelIds: [2, 3],
-                    q: '안녕',
-                    limit: 50,
-                }),
-            );
-            expect(result.messages).toHaveLength(1);
-            expect(result.nextCursor).toBeNull();
+            expect(mockChatService.searchProjectMessages).toHaveBeenCalledWith(5, query, 42);
+            expect(result).toEqual(expected);
         });
 
-        it('프로젝트 멤버가 아니면 ForbiddenException을 던진다', async () => {
-            mockProjectClient.isMember.mockResolvedValue(false);
+        it('서비스 예외를 그대로 전파한다', async () => {
+            const error = new Error('search failed');
+            mockChatService.searchProjectMessages.mockRejectedValue(error);
 
             await expect(
                 controller.searchMessages(5, { q: '안녕' } as any, userId),
-            ).rejects.toThrow(ForbiddenException);
-
-            expect(mockMemberModel.find).not.toHaveBeenCalled();
-            expect(mockElasticsearchService.searchMessages).not.toHaveBeenCalled();
-        });
-
-        it('channelId 필터가 있고 해당 채널에 접근 가능하면 그 채널로만 검색한다', async () => {
-            mockProjectClient.isMember.mockResolvedValue(true);
-            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve(memberships) });
-            mockElasticsearchService.searchMessages.mockResolvedValue({ hits: [], nextCursor: null });
-
-            await controller.searchMessages(5, { q: '안녕', channelId: 2 } as any, userId);
-
-            expect(mockElasticsearchService.searchMessages).toHaveBeenCalledWith(
-                expect.objectContaining({ accessibleChannelIds: [2] }),
-            );
-        });
-
-        it('channelId 필터가 있지만 해당 채널 멤버가 아니면 ForbiddenException을 던진다', async () => {
-            mockProjectClient.isMember.mockResolvedValue(true);
-            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve(memberships) });
-
-            await expect(
-                controller.searchMessages(5, { q: '안녕', channelId: 99 } as any, userId),
-            ).rejects.toThrow(ForbiddenException);
-
-            expect(mockElasticsearchService.searchMessages).not.toHaveBeenCalled();
-        });
-
-        it('limit 기본값은 50이다', async () => {
-            mockProjectClient.isMember.mockResolvedValue(true);
-            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve(memberships) });
-            mockElasticsearchService.searchMessages.mockResolvedValue({ hits: [], nextCursor: null });
-
-            await controller.searchMessages(5, { q: '안녕' } as any, userId);
-
-            expect(mockElasticsearchService.searchMessages).toHaveBeenCalledWith(
-                expect.objectContaining({ limit: 50 }),
-            );
-        });
-
-        it('nextCursor가 있으면 응답에 포함된다', async () => {
-            mockProjectClient.isMember.mockResolvedValue(true);
-            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve(memberships) });
-            mockElasticsearchService.searchMessages.mockResolvedValue({
-                hits: [],
-                nextCursor: 'next-msg-id',
-            });
-
-            const result = await controller.searchMessages(5, { q: '안녕' } as any, userId);
-
-            expect(result.nextCursor).toBe('next-msg-id');
-        });
-
-        it('채널 멤버십이 없으면 accessibleChannelIds가 빈 배열로 전달된다', async () => {
-            mockProjectClient.isMember.mockResolvedValue(true);
-            mockMemberModel.find.mockReturnValue({ lean: () => Promise.resolve([]) });
-            mockElasticsearchService.searchMessages.mockResolvedValue({ hits: [], nextCursor: null });
-
-            await controller.searchMessages(5, { q: '안녕' } as any, userId);
-
-            expect(mockElasticsearchService.searchMessages).toHaveBeenCalledWith(
-                expect.objectContaining({ accessibleChannelIds: [] }),
-            );
+            ).rejects.toThrow(error);
         });
     });
 });

--- a/cowork-chat/src/chat/project-message.controller.ts
+++ b/cowork-chat/src/chat/project-message.controller.ts
@@ -1,17 +1,12 @@
 import {
     Controller,
-    ForbiddenException,
     Get,
     Param,
     ParseIntPipe,
     Query,
 } from '@nestjs/common';
 import { ApiHeader, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
-import { ChannelMember } from './schema/channel-member.schema';
-import { ElasticsearchService } from '../search/elasticsearch.service';
-import { ProjectClient } from './service/project.client';
+import { ChatService } from './chat.service';
 import { SearchMessagesDto } from './dto/search-messages.dto';
 import { SearchMessagesResponseDto } from './dto/search-message-response.dto';
 import { UserId } from '../common/decorator/user.decorator';
@@ -20,11 +15,7 @@ import { UserId } from '../common/decorator/user.decorator';
 @ApiHeader({ name: 'X-User-Id', description: 'Gateway 주입 유저 ID', required: true })
 @Controller('projects/:projectId')
 export class ProjectMessageController {
-    constructor(
-        @InjectModel(ChannelMember.name) private readonly memberModel: Model<ChannelMember>,
-        private readonly elasticsearchService: ElasticsearchService,
-        private readonly projectClient: ProjectClient,
-    ) {}
+    constructor(private readonly chatService: ChatService) {}
 
     @Get('messages/search')
     @ApiOperation({
@@ -51,31 +42,6 @@ export class ProjectMessageController {
         @Query() dto: SearchMessagesDto,
         @UserId() userId: number,
     ): Promise<SearchMessagesResponseDto> {
-        const isMember = await this.projectClient.isMember(projectId, userId);
-        if (!isMember) throw new ForbiddenException('프로젝트 접근 권한이 없습니다');
-
-        const memberships = await this.memberModel.find({ userId }, { channelId: 1 }).lean();
-        const accessibleChannelIds = memberships.map((m) => m.channelId);
-
-        let filteredChannelIds = accessibleChannelIds;
-        if (dto.channelId !== undefined) {
-            if (!accessibleChannelIds.includes(dto.channelId)) {
-                throw new ForbiddenException('채널 접근 권한이 없습니다');
-            }
-            filteredChannelIds = [dto.channelId];
-        }
-
-        const { hits, nextCursor } = await this.elasticsearchService.searchMessages({
-            projectId,
-            accessibleChannelIds: filteredChannelIds,
-            q: dto.q,
-            authorId: dto.authorId,
-            type: dto.type,
-            hasFile: dto.hasFile,
-            before: dto.before,
-            limit: dto.limit ?? 50,
-        });
-
-        return { messages: hits, nextCursor };
+        return this.chatService.searchProjectMessages(projectId, dto, userId);
     }
 }


### PR DESCRIPTION
## 개요

채팅 모듈의 컨트롤러 책임을 서비스 계층으로 정리하였습니다.
`ProjectMessageController`의 검색 및 권한 검증 로직을 `ChatService`로 이동하였고, `ChatController`도 서비스 위임 중심으로 단순화하였습니다.
추가로 `ChatGateway`와 `ChatService` 간 순환 참조를 안전하게 처리하도록 의존성 주입 구성을 보완하였습니다.

## 본문

`ChatController`에서 파일 업로드 URL 발급, 업로드 확인, 메시지 전송, 슬래시 커맨드 처리, GitHub 이슈 생성, 메시지 수정 및 삭제에 대한 세부 로직을 `ChatService`로 이동하였습니다.
이를 통해 컨트롤러는 요청을 받아 서비스에 위임하는 역할에 집중하도록 정리하였습니다.

`ProjectMessageController`에 있던 프로젝트 멤버 확인, 접근 가능한 채널 계산, 채널 권한 검증, Elasticsearch 검색 호출을 `ChatService.searchProjectMessages`로 통합하였습니다.
검색 관련 정책과 권한 검증 로직이 서비스 계층에 모이도록 하여 재사용성과 응집도를 높였습니다.

`ChatService`가 `ChatGateway`를 사용하게 되면서 순환 참조가 발생할 수 있어 `ChatGateway`의 `ChatService` 주입에도 `forwardRef`를 적용하였습니다.
관련 단위 테스트도 현재 서비스 시그니처와 의존성 구조에 맞게 정리하였습니다.
