### PR TITLE
[channel] 채널-프로젝트 귀속 기능 구현

### DIFF
--- a/cowork-channel/build.gradle.kts
+++ b/cowork-channel/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation(libs.spring.boot.starter.data.jpa)
     implementation(libs.spring.cloud.starter.netflix.eureka.client)
     implementation(libs.spring.cloud.starter.config)
+    implementation(libs.spring.cloud.starter.openfeign)
     implementation(libs.spring.kafka)
 
     implementation(libs.mysql.connector.j)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/CoworkChannelApplication.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/CoworkChannelApplication.kt
@@ -3,10 +3,12 @@ package com.cowork.channel
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
+import org.springframework.cloud.openfeign.EnableFeignClients
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
 @ConfigurationPropertiesScan
+@EnableFeignClients
 @EnableScheduling
 class CoworkChannelApplication
 

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/client/ProjectClient.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/client/ProjectClient.kt
@@ -1,0 +1,12 @@
+package com.cowork.channel.client
+
+import org.springframework.cloud.openfeign.FeignClient
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+
+@FeignClient(name = "cowork-project")
+interface ProjectClient {
+
+    @GetMapping("/projects/{projectId}/team-id")
+    fun getTeamId(@PathVariable projectId: Long): Long
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/ChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/ChannelController.kt
@@ -2,8 +2,13 @@ package com.cowork.channel.controller
 
 import com.cowork.channel.dto.*
 import com.cowork.channel.service.ChannelService
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.parameters.RequestBody as SwaggerRequestBody
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
@@ -16,6 +21,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/channels")
 class ChannelController(
     private val channelService: ChannelService,
+    private val objectMapper: ObjectMapper,
 ) {
 
     @Operation(summary = "채널 생성", security = [SecurityRequirement(name = "BearerAuth")])
@@ -51,9 +57,13 @@ class ChannelController(
     fun updateChannel(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
-        @RequestBody request: UpdateChannelRequest,
-    ): ResponseEntity<ChannelResponse> =
-        ResponseEntity.ok(channelService.updateChannel(userId, channelId, request))
+        @SwaggerRequestBody(content = [Content(schema = Schema(implementation = UpdateChannelRequest::class))])
+        @RequestBody body: JsonNode,
+    ): ResponseEntity<ChannelResponse> {
+        val request = objectMapper.convertValue(body, UpdateChannelRequest::class.java)
+        val updateProjectId = body.has("projectId")
+        return ResponseEntity.ok(channelService.updateChannel(userId, channelId, request, updateProjectId))
+    }
 
     @Operation(summary = "채널 삭제", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/ProjectChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/ProjectChannelController.kt
@@ -1,0 +1,36 @@
+package com.cowork.channel.controller
+
+import com.cowork.channel.dto.ChannelResponse
+import com.cowork.channel.service.ChannelService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "프로젝트 채널", description = "프로젝트 채널 조회 API")
+@RestController
+@RequestMapping("/projects")
+class ProjectChannelController(
+    private val channelService: ChannelService,
+) {
+
+    @Operation(summary = "프로젝트 채널 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "403", description = "해당 팀의 멤버가 아님"),
+    )
+    @GetMapping("/{projectId}/channels")
+    fun listProjectChannels(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable projectId: Long,
+    ): ResponseEntity<List<ChannelResponse>> =
+        ResponseEntity.ok(channelService.listProjectChannels(userId, projectId))
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/domain/Channel.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/domain/Channel.kt
@@ -16,6 +16,9 @@ class Channel(
     @Column(name = "team_id", nullable = false)
     val teamId: Long,
 
+    @Column(name = "project_id", nullable = true)
+    var projectId: Long? = null,
+
     @Column(nullable = false, length = 100)
     var name: String,
 
@@ -48,5 +51,9 @@ class Channel(
         name?.let { this.name = it }
         description?.let { this.description = it }
         isPrivate?.let { this.isPrivate = it }
+    }
+
+    fun assignProject(projectId: Long?) {
+        this.projectId = projectId
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/ChannelResponse.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/ChannelResponse.kt
@@ -6,6 +6,7 @@ import java.time.LocalDateTime
 data class ChannelResponse(
     val id: Long,
     val teamId: Long,
+    val projectId: Long?,
     val name: String,
     val type: String,
     val viewType: String,
@@ -19,6 +20,7 @@ data class ChannelResponse(
         fun of(channel: Channel) = ChannelResponse(
             id = channel.id,
             teamId = channel.teamId,
+            projectId = channel.projectId,
             name = channel.name,
             type = channel.type.name,
             viewType = channel.viewType.name,

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateChannelRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateChannelRequest.kt
@@ -4,4 +4,5 @@ data class UpdateChannelRequest(
     val name: String? = null,
     val description: String? = null,
     val isPrivate: Boolean? = null,
+    val projectId: Long? = null,
 )

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/repository/ChannelRepository.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/repository/ChannelRepository.kt
@@ -9,6 +9,8 @@ interface ChannelRepository : JpaRepository<Channel, Long> {
 
     fun findAllByTeamIdOrderByIdAsc(teamId: Long): List<Channel>
 
+    fun findAllByProjectIdOrderByIdAsc(projectId: Long): List<Channel>
+
     fun findAllByTeamIdAndCreatedByOrderByIdAsc(teamId: Long, createdBy: Long): List<Channel>
 
     fun findAllByCreatedBy(createdBy: Long): List<Channel>

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
@@ -1,5 +1,6 @@
 package com.cowork.channel.service
 
+import com.cowork.channel.client.ProjectClient
 import com.cowork.channel.domain.Channel
 import com.cowork.channel.domain.ChannelMember
 import com.cowork.channel.domain.ChannelType
@@ -24,6 +25,7 @@ class ChannelService(
     private val teamPermissionService: TeamPermissionService,
     private val channelMemberEventPublisher: ChannelMemberEventPublisher,
     private val channelMembershipSyncPublisher: ChannelMembershipSyncPublisher,
+    private val projectClient: ProjectClient,
 ) {
 
     fun findChannelOrThrow(channelId: Long): Channel =
@@ -89,11 +91,9 @@ class ChannelService(
     }
 
     fun listProjectChannels(userId: Long, projectId: Long): List<ChannelResponse> {
-        val channels = channelRepository.findAllByProjectIdOrderByIdAsc(projectId)
-        if (channels.isNotEmpty()) {
-            teamPermissionService.requireTeamMember(channels.first().teamId, userId)
-        }
-        return channels.map { ChannelResponse.of(it) }
+        val teamId = projectClient.getTeamId(projectId)
+        teamPermissionService.requireTeamMember(teamId, userId)
+        return channelRepository.findAllByProjectIdOrderByIdAsc(projectId).map { ChannelResponse.of(it) }
     }
 
     @Transactional

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
@@ -80,11 +80,20 @@ class ChannelService(
     }
 
     @Transactional
-    fun updateChannel(userId: Long, channelId: Long, request: UpdateChannelRequest): ChannelResponse {
+    fun updateChannel(userId: Long, channelId: Long, request: UpdateChannelRequest, updateProjectId: Boolean = false): ChannelResponse {
         val channel = findChannelOrThrow(channelId)
         requireChannelManager(channel, userId)
         channel.update(request.name, request.description, request.isPrivate)
+        if (updateProjectId) channel.assignProject(request.projectId)
         return ChannelResponse.of(channel)
+    }
+
+    fun listProjectChannels(userId: Long, projectId: Long): List<ChannelResponse> {
+        val channels = channelRepository.findAllByProjectIdOrderByIdAsc(projectId)
+        if (channels.isNotEmpty()) {
+            teamPermissionService.requireTeamMember(channels.first().teamId, userId)
+        }
+        return channels.map { ChannelResponse.of(it) }
     }
 
     @Transactional

--- a/cowork-channel/src/main/resources/db/migration/V6__add_project_id_to_channels.sql
+++ b/cowork-channel/src/main/resources/db/migration/V6__add_project_id_to_channels.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tb_channels
+    ADD COLUMN project_id BIGINT NULL COMMENT 'cowork-project의 tb_projects.id' AFTER team_id,
+    ADD INDEX idx_tb_channels_project_id (project_id);

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
@@ -52,9 +52,10 @@ class ChannelServiceTest {
         view: ChannelViewType = ChannelViewType.TEXT,
         createdBy: Long = 1L,
         isPrivate: Boolean = false,
+        projectId: Long? = null,
     ) = Channel(
         id = id, teamId = teamId, name = "ch", type = type, viewType = view,
-        description = null, isPrivate = isPrivate, createdBy = createdBy,
+        description = null, isPrivate = isPrivate, createdBy = createdBy, projectId = projectId,
     )
 
     @Test
@@ -103,6 +104,66 @@ class ChannelServiceTest {
             service.updateChannel(1L, 1L, UpdateChannelRequest(name = "x"))
         }
         assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `updateChannel은 updateProjectId=true이면 projectId를 할당함`() {
+        val ch = channel(createdBy = 1L)
+        every { channelRepository.findById(1L) } returns Optional.of(ch)
+
+        val res = service.updateChannel(1L, 1L, UpdateChannelRequest(projectId = 5L), updateProjectId = true)
+        assertEquals(5L, res.projectId)
+    }
+
+    @Test
+    fun `updateChannel은 updateProjectId=false이면 기존 projectId를 유지함`() {
+        val ch = channel(createdBy = 1L, projectId = 99L)
+        every { channelRepository.findById(1L) } returns Optional.of(ch)
+
+        val res = service.updateChannel(1L, 1L, UpdateChannelRequest(), updateProjectId = false)
+        assertEquals(99L, res.projectId)
+    }
+
+    @Test
+    fun `updateChannel은 updateProjectId=true에 projectId=null이면 프로젝트 귀속 해제`() {
+        val ch = channel(createdBy = 1L, projectId = 99L)
+        every { channelRepository.findById(1L) } returns Optional.of(ch)
+
+        val res = service.updateChannel(1L, 1L, UpdateChannelRequest(projectId = null), updateProjectId = true)
+        assertEquals(null, res.projectId)
+    }
+
+    @Test
+    fun `listProjectChannels는 채널이 있으면 팀 멤버 검증 후 반환함`() {
+        val ch = channel(id = 1L, teamId = 100L)
+        every { channelRepository.findAllByProjectIdOrderByIdAsc(5L) } returns listOf(ch)
+        every { teamPermission.requireTeamMember(100L, 1L) } returns Unit
+
+        val result = service.listProjectChannels(1L, 5L)
+        assertEquals(1, result.size)
+        verify { teamPermission.requireTeamMember(100L, 1L) }
+    }
+
+    @Test
+    fun `listProjectChannels는 팀 비멤버이면 FORBIDDEN`() {
+        val ch = channel(id = 1L, teamId = 100L)
+        every { channelRepository.findAllByProjectIdOrderByIdAsc(5L) } returns listOf(ch)
+        every { teamPermission.requireTeamMember(100L, 1L) } throws
+            ExpectedException("팀 멤버만 접근할 수 있습니다.", HttpStatus.FORBIDDEN)
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.listProjectChannels(1L, 5L)
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `listProjectChannels는 채널이 없으면 빈 리스트를 반환하고 팀 멤버 검증을 하지 않음`() {
+        every { channelRepository.findAllByProjectIdOrderByIdAsc(5L) } returns emptyList()
+
+        val result = service.listProjectChannels(1L, 5L)
+        assertEquals(0, result.size)
+        verify(exactly = 0) { teamPermission.requireTeamMember(any(), any()) }
     }
 
     @Test

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
@@ -1,5 +1,6 @@
 package com.cowork.channel.service
 
+import com.cowork.channel.client.ProjectClient
 import com.cowork.channel.domain.Channel
 import com.cowork.channel.domain.ChannelMember
 import com.cowork.channel.domain.ChannelType
@@ -32,8 +33,9 @@ class ChannelServiceTest {
     private val teamPermission = mockk<TeamPermissionService>()
     private val channelMemberEventPublisher = mockk<ChannelMemberEventPublisher>(relaxed = true)
     private val channelMembershipSyncPublisher = mockk<ChannelMembershipSyncPublisher>(relaxed = true)
+    private val projectClient = mockk<ProjectClient>()
 
-    private val service = ChannelService(channelRepository, channelMemberRepository, teamPermission, channelMemberEventPublisher, channelMembershipSyncPublisher)
+    private val service = ChannelService(channelRepository, channelMemberRepository, teamPermission, channelMemberEventPublisher, channelMembershipSyncPublisher, projectClient)
 
     @BeforeEach
     fun setUp() {
@@ -136,8 +138,9 @@ class ChannelServiceTest {
     @Test
     fun `listProjectChannels는 채널이 있으면 팀 멤버 검증 후 반환함`() {
         val ch = channel(id = 1L, teamId = 100L)
-        every { channelRepository.findAllByProjectIdOrderByIdAsc(5L) } returns listOf(ch)
+        every { projectClient.getTeamId(5L) } returns 100L
         every { teamPermission.requireTeamMember(100L, 1L) } returns Unit
+        every { channelRepository.findAllByProjectIdOrderByIdAsc(5L) } returns listOf(ch)
 
         val result = service.listProjectChannels(1L, 5L)
         assertEquals(1, result.size)
@@ -146,8 +149,7 @@ class ChannelServiceTest {
 
     @Test
     fun `listProjectChannels는 팀 비멤버이면 FORBIDDEN`() {
-        val ch = channel(id = 1L, teamId = 100L)
-        every { channelRepository.findAllByProjectIdOrderByIdAsc(5L) } returns listOf(ch)
+        every { projectClient.getTeamId(5L) } returns 100L
         every { teamPermission.requireTeamMember(100L, 1L) } throws
             ExpectedException("팀 멤버만 접근할 수 있습니다.", HttpStatus.FORBIDDEN)
 
@@ -158,12 +160,14 @@ class ChannelServiceTest {
     }
 
     @Test
-    fun `listProjectChannels는 채널이 없으면 빈 리스트를 반환하고 팀 멤버 검증을 하지 않음`() {
+    fun `listProjectChannels는 채널이 없으면 빈 리스트를 반환함`() {
+        every { projectClient.getTeamId(5L) } returns 100L
+        every { teamPermission.requireTeamMember(100L, 1L) } returns Unit
         every { channelRepository.findAllByProjectIdOrderByIdAsc(5L) } returns emptyList()
 
         val result = service.listProjectChannels(1L, 5L)
         assertEquals(0, result.size)
-        verify(exactly = 0) { teamPermission.requireTeamMember(any(), any()) }
+        verify { teamPermission.requireTeamMember(100L, 1L) }
     }
 
     @Test

--- a/cowork-project/src/main/kotlin/com/cowork/project/controller/ProjectController.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/controller/ProjectController.kt
@@ -155,6 +155,20 @@ class ProjectController(
         if (projectService.isMember(projectId, userId)) ResponseEntity.ok().build()
         else ResponseEntity.notFound().build()
 
+    @Operation(
+        summary = "프로젝트의 팀 ID 조회 (내부 서비스용)",
+        description = "프로젝트가 속한 팀 ID를 반환합니다. 서비스 간 권한 위임에 사용됩니다.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "404", description = "프로젝트 없음"),
+    )
+    @GetMapping("/{projectId}/team-id")
+    fun getTeamId(
+        @PathVariable projectId: Long,
+    ): ResponseEntity<Long> =
+        ResponseEntity.ok(projectService.getTeamId(projectId))
+
     @Operation(summary = "프로젝트 멤버 제거", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
         ApiResponse(responseCode = "204", description = "제거 성공"),

--- a/cowork-project/src/main/kotlin/com/cowork/project/service/ProjectService.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/service/ProjectService.kt
@@ -134,6 +134,9 @@ class ProjectService(
         projectRepository.findProjectsByMemberUserId(userId, pageable)
             .map { ProjectResponse.of(it) }
 
+    fun getTeamId(projectId: Long): Long =
+        findProjectOrThrow(projectId).teamId
+
     fun isMember(projectId: Long, userId: Long): Boolean =
         projectMemberRepository.findByProjectIdAndUserId(projectId, userId) != null
 


### PR DESCRIPTION
## 개요

`cowork-channel` 서비스에 채널-프로젝트 귀속 관계를 구현하였습니다. 클라이언트에서 채널을 드래그하여 특정 프로젝트 하위에 귀속시키는 기능을 지원하기 위해, 채널 엔티티에 `projectId` 필드를 추가하고 관련 API를 추가하였습니다.

> 클라이언트 요구사항: [SERVER_TODO.md — #1 채널-프로젝트 귀속 관계](https://github.com/team-cowork/cowork-desktop-app-client/blob/main/SERVER_TODO.md)

## 본문

### DB 변경 (Flyway V6)

`tb_channels` 테이블에 `project_id BIGINT NULL` 컬럼 및 인덱스를 추가하였습니다.

```sql
ALTER TABLE tb_channels
    ADD COLUMN project_id BIGINT NULL COMMENT 'cowork-project의 tb_projects.id' AFTER team_id,
    ADD INDEX idx_tb_channels_project_id (project_id);
```

### API 변경

**`PATCH /channels/{channelId}`**
- 요청 body에 `projectId: Long?` 필드를 추가하였습니다.
- `projectId` 키가 body에 포함된 경우에만 귀속 상태를 갱신합니다 (`JsonNode`로 키 존재 여부를 감지하여 absent와 explicit null을 구분).
  - 값이 존재하면 해당 프로젝트에 귀속, `null`이면 귀속 해제

**`GET /projects/{projectId}/channels`** (신규)
- 특정 프로젝트에 귀속된 채널 목록을 조회하는 엔드포인트를 추가하였습니다.
- 채널이 존재하는 경우 해당 채널의 `teamId`를 기준으로 팀 멤버 권한을 검증합니다.

### 응답 변경

`ChannelResponse`에 `projectId: Long?` 필드를 추가하였습니다.

### 테스트 추가

- `updateChannel` — projectId 할당 / 기존값 유지 / 귀속 해제 시나리오
- `listProjectChannels` — 정상 조회 / 팀 비멤버 FORBIDDEN / 채널 없을 때 빈 리스트 반환
