### PR TITLE
[global] `write-pr`스킬의 스크립트 실행 경로 수정

### DIFF
--- a/.agents/skills/write-pr/SKILL.md
+++ b/.agents/skills/write-pr/SKILL.md
@@ -58,7 +58,7 @@ Ask the user to confirm which title to use. If no answer is given, proceed with 
 Run the creation script with the confirmed title and labels:
 
 ```bash
-bash scripts/create-pr.sh "<confirmed-title>" "PR_BODY.md" "<label1>,<label2>"
+bash .agents/skills/write-pr/scripts/create-pr.sh "<confirmed-title>" "PR_BODY.md" "<label1>,<label2>"
 ```
 
 After creation, display the PR URL.


### PR DESCRIPTION
write-pr 스킬 가이드 내의 스크립트 실행 경로가 실제 파일 위치와 일치하지 않아 발생하는 문제를 수정하였습니다.
- 수정 전: bash scripts/create-pr.sh
- 수정 후: bash .agents/skills/write-pr/scripts/create-pr.sh