### PR TITLE
[chat] FILE_SHARE 채널 파일 목록 조회 API 추가

### DIFF
--- a/cowork-chat/README.md
+++ b/cowork-chat/README.md
@@ -5,6 +5,7 @@
 - Socket.io 기반 실시간 메시지 송수신
 - 채팅 메시지 저장/조회
 - MinIO presigned URL 기반 첨부파일 업로드
+- `FILE_SHARE` 채널 파일 목록 조회
 
 ## 스택
 - NestJS 11 + TypeScript
@@ -25,6 +26,8 @@
 |---|---|
 | `MONGODB_URI` | MongoDB 연결 URI |
 | `KAFKA_BOOTSTRAP_SERVERS` | Kafka 브로커 주소 |
+| `CHANNEL_SERVICE_URL` | cowork-channel URL |
+| `USER_SERVICE_URL` | cowork-user URL |
 | `MINIO_INTERNAL_ENDPOINT` | MinIO 내부 엔드포인트 |
 | `MINIO_ACCESS_KEY` | MinIO 액세스 키 |
 | `MINIO_SECRET_KEY` | MinIO 시크릿 키 |

--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -17,7 +17,13 @@ const userRole = 'ROLE_USER';
 const mockChatService = {
     checkMembership: jest.fn(),
     checkMembershipAndGetTeamId: jest.fn(),
+    createFileUploadUrl: jest.fn(),
+    confirmFileUpload: jest.fn(),
+    getFileList: jest.fn(),
     getMessages: jest.fn(),
+    publishGithubIssueCreateCommand: jest.fn(),
+    handleSlashCommand: jest.fn(),
+    sendMessage: jest.fn(),
     editMessage: jest.fn(),
     deleteMessage: jest.fn(),
 };
@@ -66,12 +72,12 @@ describe('ChatController', () => {
 
     describe('createFileUploadUrl', () => {
         it('멤버십 검증 후 MinIO presigned URL을 발급한다', async () => {
-            mockChatService.checkMembership.mockResolvedValue(undefined);
-            mockMinioService.createPresignedUpload.mockResolvedValue({
+            mockChatService.createFileUploadUrl.mockResolvedValue({
                 objectKey: 'chat-files/1/42/file.png',
                 uploadUrl: 'http://localhost:9000/upload',
                 fileUrl: 'http://localhost:9000/cowork-bucket/chat-files/1/42/file.png',
                 expiresInSeconds: 600,
+                headers: { 'Content-Type': 'image/png' },
             });
 
             const result = await controller.createFileUploadUrl(
@@ -80,15 +86,38 @@ describe('ChatController', () => {
                 userId,
             );
 
-            expect(mockChatService.checkMembership).toHaveBeenCalledWith(1, 42);
-            expect(mockMinioService.createPresignedUpload).toHaveBeenCalledWith({
-                channelId: 1,
-                userId: 42,
+            expect(mockChatService.createFileUploadUrl).toHaveBeenCalledWith(1, {
                 filename: 'file.png',
                 contentType: 'image/png',
                 size: 1024,
-            });
+            }, 42);
             expect(result.headers).toEqual({ 'Content-Type': 'image/png' });
+        });
+    });
+
+    describe('getFiles', () => {
+        it('FILE_SHARE 채널 파일 목록 조회를 서비스에 위임한다', async () => {
+            mockChatService.getFileList.mockResolvedValue({
+                files: [
+                    {
+                        messageId: mockMessageId,
+                        fileName: 'report.pdf',
+                        fileSize: 1024,
+                        fileUrl: 'http://localhost:9000/cowork-bucket/chat-files/1/42/report.pdf',
+                        mimeType: 'application/pdf',
+                        uploaderId: 42,
+                        uploaderName: '홍길동',
+                        uploadedAt: '2026-05-12T00:00:00.000Z',
+                    },
+                ],
+                nextCursor: null,
+            });
+
+            const result = await controller.getFiles(1, { limit: 20, before: undefined } as any, userId);
+
+            expect(mockChatService.getFileList).toHaveBeenCalledWith(1, 42, undefined, 20);
+            expect(result.files).toHaveLength(1);
+            expect(result.files[0].uploaderName).toBe('홍길동');
         });
     });
 
@@ -96,24 +125,20 @@ describe('ChatController', () => {
         const dto = { teamId: 10, content: '안녕하세요' };
 
         it('멤버십 검증 후 Kafka로 메시지를 발행한다', async () => {
-            mockChatService.checkMembership.mockResolvedValue(undefined);
-            mockProducer.sendMessage.mockResolvedValue(undefined);
+            mockChatService.sendMessage.mockResolvedValue(undefined);
 
             const result = await controller.sendMessage(1, dto as any, userId, userRole);
 
-            expect(mockChatService.checkMembership).toHaveBeenCalledWith(1, 42);
-            expect(mockProducer.sendMessage).toHaveBeenCalledWith(1, dto, 42, 'ROLE_USER');
+            expect(mockChatService.sendMessage).toHaveBeenCalledWith(1, dto, 42, 'ROLE_USER');
             expect(result).toEqual({ queued: true });
         });
 
         it('채널 멤버가 아니면 ForbiddenException이 전파된다', async () => {
-            mockChatService.checkMembership.mockRejectedValue(new ForbiddenException());
+            mockChatService.sendMessage.mockRejectedValue(new ForbiddenException());
 
             await expect(
                 controller.sendMessage(1, dto as any, userId, userRole),
             ).rejects.toThrow(ForbiddenException);
-
-            expect(mockProducer.sendMessage).not.toHaveBeenCalled();
         });
     });
 
@@ -125,75 +150,52 @@ describe('ChatController', () => {
         };
 
         it('프로젝트 레포 정보를 조회한 뒤 github.issue.create 토픽으로 이벤트를 발행한다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
-            mockGithubIssueProducer.send.mockResolvedValue(undefined);
+            mockChatService.publishGithubIssueCreateCommand.mockResolvedValue(undefined);
 
             const result = await controller.createGithubIssue(1, dto as any, userId);
 
-            expect(mockChatService.checkMembershipAndGetTeamId).toHaveBeenCalledWith(1, 42);
-            expect(mockProjectClient.getGithubRepoInfo).toHaveBeenCalledWith(100);
-            expect(mockGithubIssueProducer.send).toHaveBeenCalledWith({
-                channelId: 1,
-                teamId: 10,
-                projectId: 100,
-                owner: 'my-org',
-                repo: 'backend',
-                title: '로그인 버그',
-                body: '특정 브라우저에서 재현됨',
-                requesterId: 42,
-            });
+            expect(mockChatService.publishGithubIssueCreateCommand).toHaveBeenCalledWith(1, dto, 42);
             expect(result).toEqual({ queued: true });
         });
 
         it('body 없이도 이슈 생성 이벤트를 발행한다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
-            mockGithubIssueProducer.send.mockResolvedValue(undefined);
+            mockChatService.publishGithubIssueCreateCommand.mockResolvedValue(undefined);
 
             await controller.createGithubIssue(1, { ...dto, body: undefined } as any, userId);
 
-            expect(mockGithubIssueProducer.send).toHaveBeenCalledWith(
+            expect(mockChatService.publishGithubIssueCreateCommand).toHaveBeenCalledWith(
+                1,
                 expect.objectContaining({ body: undefined }),
+                42,
             );
         });
 
         it('채널 멤버가 아니면 ForbiddenException이 전파되고 이벤트를 발행하지 않는다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockRejectedValue(new ForbiddenException());
+            mockChatService.publishGithubIssueCreateCommand.mockRejectedValue(new ForbiddenException());
 
             await expect(
                 controller.createGithubIssue(1, dto as any, userId),
             ).rejects.toThrow(ForbiddenException);
-
-            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
         });
 
         it('프로젝트에 GitHub 레포 정보가 없으면 BadRequestException을 던진다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue(null);
+            mockChatService.publishGithubIssueCreateCommand.mockRejectedValue(new BadRequestException('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다'));
 
             await expect(
                 controller.createGithubIssue(1, dto as any, userId),
             ).rejects.toThrow('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
-
-            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
         });
 
         it('프로젝트의 teamId가 채널 teamId와 다르면 ForbiddenException을 던진다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 99, owner: 'other-org', repo: 'backend' });
+            mockChatService.publishGithubIssueCreateCommand.mockRejectedValue(new ForbiddenException('해당 프로젝트는 이 채널의 팀에 속하지 않습니다'));
 
             await expect(
                 controller.createGithubIssue(1, dto as any, userId),
             ).rejects.toThrow('해당 프로젝트는 이 채널의 팀에 속하지 않습니다');
-
-            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
         });
 
         it('producer 오류가 전파된다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
-            mockGithubIssueProducer.send.mockRejectedValue(new Error('Kafka 연결 오류'));
+            mockChatService.publishGithubIssueCreateCommand.mockRejectedValue(new Error('Kafka 연결 오류'));
 
             await expect(
                 controller.createGithubIssue(1, dto as any, userId),
@@ -209,9 +211,7 @@ describe('ChatController', () => {
         };
 
         it('github.issue.create 슬래시 커맨드가 기존과 동일한 Kafka 이벤트를 발행한다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
-            mockGithubIssueProducer.send.mockResolvedValue(undefined);
+            mockChatService.handleSlashCommand.mockResolvedValue(undefined);
 
             const result = await controller.createSlashCommand(
                 1,
@@ -219,25 +219,15 @@ describe('ChatController', () => {
                 userId,
             );
 
-            expect(mockChatService.checkMembershipAndGetTeamId).toHaveBeenCalledWith(1, 42);
-            expect(mockProjectClient.getGithubRepoInfo).toHaveBeenCalledWith(100);
-            expect(mockGithubIssueProducer.send).toHaveBeenCalledWith({
-                channelId: 1,
-                teamId: 10,
-                projectId: 100,
-                owner: 'my-org',
-                repo: 'backend',
-                title: '로그인 버그',
-                body: '특정 브라우저에서 재현됨',
-                requesterId: 42,
-            });
+            expect(mockChatService.handleSlashCommand).toHaveBeenCalledWith(1, {
+                command: SlashCommand.GITHUB_ISSUE_CREATE,
+                payload,
+            }, 42);
             expect(result).toEqual({ queued: true });
         });
 
         it('body 없이도 github.issue.create 이벤트를 발행한다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
-            mockGithubIssueProducer.send.mockResolvedValue(undefined);
+            mockChatService.handleSlashCommand.mockResolvedValue(undefined);
 
             await controller.createSlashCommand(
                 1,
@@ -245,13 +235,15 @@ describe('ChatController', () => {
                 userId,
             );
 
-            expect(mockGithubIssueProducer.send).toHaveBeenCalledWith(
-                expect.objectContaining({ body: undefined }),
+            expect(mockChatService.handleSlashCommand).toHaveBeenCalledWith(
+                1,
+                expect.objectContaining({ payload: expect.objectContaining({ body: undefined }) }),
+                42,
             );
         });
 
         it('채널 멤버가 아니면 ForbiddenException이 전파되고 이벤트를 발행하지 않는다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockRejectedValue(new ForbiddenException());
+            mockChatService.handleSlashCommand.mockRejectedValue(new ForbiddenException());
 
             await expect(
                 controller.createSlashCommand(
@@ -260,13 +252,10 @@ describe('ChatController', () => {
                     userId,
                 ),
             ).rejects.toThrow(ForbiddenException);
-
-            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
         });
 
         it('프로젝트에 GitHub 레포 정보가 없으면 BadRequestException을 던진다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue(null);
+            mockChatService.handleSlashCommand.mockRejectedValue(new BadRequestException('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다'));
 
             await expect(
                 controller.createSlashCommand(
@@ -275,13 +264,10 @@ describe('ChatController', () => {
                     userId,
                 ),
             ).rejects.toThrow('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
-
-            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
         });
 
         it('프로젝트의 teamId가 채널 teamId와 다르면 ForbiddenException을 던진다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 99, owner: 'other-org', repo: 'backend' });
+            mockChatService.handleSlashCommand.mockRejectedValue(new ForbiddenException('해당 프로젝트는 이 채널의 팀에 속하지 않습니다'));
 
             await expect(
                 controller.createSlashCommand(
@@ -290,14 +276,10 @@ describe('ChatController', () => {
                     userId,
                 ),
             ).rejects.toThrow('해당 프로젝트는 이 채널의 팀에 속하지 않습니다');
-
-            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
         });
 
         it('producer 오류가 전파된다', async () => {
-            mockChatService.checkMembershipAndGetTeamId.mockResolvedValue(10);
-            mockProjectClient.getGithubRepoInfo.mockResolvedValue({ teamId: 10, owner: 'my-org', repo: 'backend' });
-            mockGithubIssueProducer.send.mockRejectedValue(new Error('Kafka 연결 오류'));
+            mockChatService.handleSlashCommand.mockRejectedValue(new Error('Kafka 연결 오류'));
 
             await expect(
                 controller.createSlashCommand(
@@ -309,6 +291,8 @@ describe('ChatController', () => {
         });
 
         it('지원하지 않는 command는 BadRequestException을 던지고 이벤트를 발행하지 않는다', async () => {
+            mockChatService.handleSlashCommand.mockRejectedValue(new BadRequestException('지원하지 않는 슬래시 커맨드입니다'));
+
             await expect(
                 controller.createSlashCommand(
                     1,
@@ -316,9 +300,6 @@ describe('ChatController', () => {
                     userId,
                 ),
             ).rejects.toThrow(BadRequestException);
-
-            expect(mockChatService.checkMembershipAndGetTeamId).not.toHaveBeenCalled();
-            expect(mockGithubIssueProducer.send).not.toHaveBeenCalled();
         });
     });
 
@@ -350,19 +331,13 @@ describe('ChatController', () => {
     describe('editMessage', () => {
         it('메시지를 수정하고 Socket.io로 브로드캐스트한다', async () => {
             const updated = { content: '수정됨' };
-            mockChatService.checkMembership.mockResolvedValue(undefined);
             mockChatService.editMessage.mockResolvedValue(updated);
 
             const result = await controller.editMessage(1, mockMessageId, { content: '수정됨' }, userId, userRole);
 
             expect(mockChatService.editMessage).toHaveBeenCalledWith(
-                mockMessageId, 42, { content: '수정됨' }, 'ROLE_USER',
+                1, mockMessageId, 42, { content: '수정됨' }, 'ROLE_USER',
             );
-            expect(mockTo).toHaveBeenCalledWith('chat:1');
-            expect(mockEmit).toHaveBeenCalledWith('message:edited', expect.objectContaining({
-                messageId: mockMessageId,
-                content: '수정됨',
-            }));
             expect(result).toBe(updated);
         });
 
@@ -383,16 +358,14 @@ describe('ChatController', () => {
 
     describe('deleteMessage', () => {
         it('메시지를 삭제하고 Socket.io로 브로드캐스트한다', async () => {
-            mockChatService.checkMembership.mockResolvedValue(undefined);
             mockChatService.deleteMessage.mockResolvedValue({ channelId: 1, messageId: mockMessageId });
 
-            await controller.deleteMessage(1, mockMessageId, userId, userRole);
+            const result = await controller.deleteMessage(1, mockMessageId, userId, userRole);
 
             expect(mockChatService.deleteMessage).toHaveBeenCalledWith(
-                mockMessageId, 42, 'ROLE_USER',
+                1, mockMessageId, 42, 'ROLE_USER',
             );
-            expect(mockTo).toHaveBeenCalledWith('chat:1');
-            expect(mockEmit).toHaveBeenCalledWith('message:deleted', { messageId: mockMessageId });
+            expect(result).toEqual({ channelId: 1, messageId: mockMessageId });
         });
 
         it('본인 메시지가 아니면 ForbiddenException이 전파된다', async () => {

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -11,7 +11,7 @@ import {
     HttpStatus,
     ParseIntPipe,
 } from '@nestjs/common';
-import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ApiHeader, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { ChatService } from './chat.service';
 import { SendMessageDto } from './dto/send-message.dto';
 import { EditMessageDto } from './dto/edit-message.dto';
@@ -32,6 +32,8 @@ import {
     SlashCommandDto,
     SlashCommandResponseDto,
 } from './dto/slash-command.dto';
+import { FileListQueryDto } from './dto/file-list.dto';
+import { FileListResponseDto } from './dto/file-list.dto';
 import { UserId, UserRole } from '../common/decorator/user.decorator';
 
 @ApiTags('Chat')
@@ -69,6 +71,21 @@ export class ChatController {
     ): Promise<ConfirmFileUploadResponseDto> {
         const fileUrl = await this.chatService.confirmFileUpload(channelId, dto.objectKey, userId);
         return { fileUrl };
+    }
+
+    @Get('files')
+    @ApiOperation({ summary: 'FILE_SHARE 채널 파일 목록 조회' })
+    @ApiQuery({ name: 'before', required: false, description: '커서: 이전 응답의 nextCursor 값' })
+    @ApiQuery({ name: 'limit', required: false, description: '페이지 크기 (기본 20, 최대 100)' })
+    @ApiResponse({ status: 200, type: FileListResponseDto })
+    @ApiResponse({ status: 400, description: 'FILE_SHARE 채널이 아님 또는 잘못된 커서/파라미터' })
+    @ApiResponse({ status: 403, description: '채널 멤버 아님' })
+    async getFiles(
+        @Param('channelId', ParseIntPipe) channelId: number,
+        @Query() query: FileListQueryDto,
+        @UserId() userId: number,
+    ): Promise<FileListResponseDto> {
+        return this.chatService.getFileList(channelId, userId, query.before, query.limit);
     }
 
     @Post('messages')

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -16,6 +16,8 @@ import { NotificationOutboxPoller } from './kafka/notification-outbox.poller';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
 import { ProjectClient } from './service/project.client';
+import { ChannelClient } from './service/channel.client';
+import { UserClient } from './service/user.client';
 import { Message, MessageSchema } from './schema/message.schema';
 import { ChannelMember, ChannelMemberSchema } from './schema/channel-member.schema';
 import { MembershipModule } from '../membership/membership.module';
@@ -106,6 +108,8 @@ function createLogStream() {
         GithubIssueProducer,
         GithubIssueResultConsumer,
         ProjectClient,
+        ChannelClient,
+        UserClient,
     ],
 })
 export class ChatModule {}

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -11,6 +11,8 @@ import { MinioService } from '../storage/minio.service';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { ProjectClient } from './service/project.client';
+import { ChannelClient } from './service/channel.client';
+import { UserClient } from './service/user.client';
 
 const mockMessageId = new Types.ObjectId().toString();
 const mockEmit = jest.fn();
@@ -73,6 +75,14 @@ const mockProjectClient = {
     isMember: jest.fn(),
 };
 
+const mockChannelClient = {
+    getChannel: jest.fn(),
+};
+
+const mockUserClient = {
+    getDisplayName: jest.fn(),
+};
+
 const mockChatGateway = {
     server: {
         to: mockTo,
@@ -93,6 +103,8 @@ describe('ChatService', () => {
                 { provide: ChatMessageProducer, useValue: mockChatMessageProducer },
                 { provide: GithubIssueProducer, useValue: mockGithubIssueProducer },
                 { provide: ProjectClient, useValue: mockProjectClient },
+                { provide: ChannelClient, useValue: mockChannelClient },
+                { provide: UserClient, useValue: mockUserClient },
                 { provide: ChatGateway, useValue: mockChatGateway },
             ],
         }).compile();
@@ -161,6 +173,91 @@ describe('ChatService', () => {
             expect(result[0].mentionedMessage).toBeDefined();
             expect(result[0].mentionedMessage?.content).toBe('원본');
             expect(result[1].mentionedMessage).toBeNull();
+        });
+    });
+
+    describe('getFileList', () => {
+        it('FILE_SHARE 채널의 첨부파일을 파일 단위로 반환한다', async () => {
+            const createdAt = new Date('2026-05-12T02:03:04.000Z');
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+            mockChannelClient.getChannel.mockResolvedValue({ id: 1, viewType: 'FILE_SHARE' });
+            mockAggregate.mockResolvedValue([
+                {
+                    _id: new Types.ObjectId('665f00000000000000000001'),
+                    authorId: 42,
+                    createdAt,
+                    attachmentIndex: 0,
+                    attachment: {
+                        name: 'report.pdf',
+                        url: 'http://localhost:9000/cowork-bucket/chat-files/1/42/report.pdf',
+                        size: 2048,
+                        mimeType: 'application/pdf',
+                    },
+                },
+            ]);
+            mockUserClient.getDisplayName.mockResolvedValue('홍길동');
+
+            const result = await service.getFileList(1, 42);
+
+            expect(mockChannelClient.getChannel).toHaveBeenCalledWith(1, 42);
+            expect(mockAggregate).toHaveBeenCalled();
+            expect(mockUserClient.getDisplayName).toHaveBeenCalledWith(42);
+            expect(result.files).toEqual([
+                {
+                    messageId: '665f00000000000000000001',
+                    fileName: 'report.pdf',
+                    fileSize: 2048,
+                    fileUrl: 'http://localhost:9000/cowork-bucket/chat-files/1/42/report.pdf',
+                    mimeType: 'application/pdf',
+                    uploaderId: 42,
+                    uploaderName: '홍길동',
+                    uploadedAt: createdAt.toISOString(),
+                },
+            ]);
+            expect(result.nextCursor).toBeNull();
+        });
+
+        it('FILE_SHARE가 아니면 BadRequestException을 던진다', async () => {
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+            mockChannelClient.getChannel.mockResolvedValue({ id: 1, viewType: 'TEXT' });
+
+            await expect(service.getFileList(1, 42)).rejects.toThrow('FILE_SHARE 채널에서만 파일 목록을 조회할 수 있습니다');
+            expect(mockAggregate).not.toHaveBeenCalled();
+        });
+
+        it('before 커서를 사용해 다음 페이지를 조회한다', async () => {
+            const cursorRow = {
+                _id: new Types.ObjectId('665f00000000000000000002'),
+                createdAt: new Date('2026-05-12T03:00:00.000Z'),
+                attachmentIndex: 1,
+            };
+            const before = Buffer.from(JSON.stringify({
+                uploadedAt: cursorRow.createdAt.toISOString(),
+                messageId: cursorRow._id.toString(),
+                attachmentIndex: cursorRow.attachmentIndex,
+            })).toString('base64');
+
+            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+            mockChannelClient.getChannel.mockResolvedValue({ id: 1, viewType: 'FILE_SHARE' });
+            mockAggregate.mockResolvedValue([]);
+
+            await service.getFileList(1, 42, before, 20);
+
+            const pipeline = mockAggregate.mock.calls[0][0];
+            expect(pipeline[2].$match).toEqual({
+                $or: [
+                    { createdAt: { $lt: new Date(cursorRow.createdAt) } },
+                    {
+                        createdAt: new Date(cursorRow.createdAt),
+                        _id: { $lt: new Types.ObjectId(cursorRow._id.toString()) },
+                    },
+                    {
+                        createdAt: new Date(cursorRow.createdAt),
+                        _id: new Types.ObjectId(cursorRow._id.toString()),
+                        attachmentIndex: { $lt: 1 },
+                    },
+                ],
+            });
         });
     });
 

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -14,10 +14,12 @@ import { ChannelMember } from './schema/channel-member.schema';
 import { EditMessageDto } from './dto/edit-message.dto';
 import { UserRole } from '../common/enum/user-role.enum';
 import { ElasticsearchService } from '../search/elasticsearch.service';
-import { MinioService, PresignedUpload } from '../storage/minio.service';
+import { MinioService } from '../storage/minio.service';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { ProjectClient } from './service/project.client';
+import { ChannelClient } from './service/channel.client';
+import { UserClient } from './service/user.client';
 import { ChatGateway } from './chat.gateway';
 import { SendMessageDto } from './dto/send-message.dto';
 import { CreateFileUploadUrlRequestDto, CreateFileUploadUrlResponseDto } from './dto/create-file-upload-url.dto';
@@ -25,8 +27,22 @@ import { CreateGithubIssueDto } from './dto/create-github-issue.dto';
 import { SlashCommand, SlashCommandDto } from './dto/slash-command.dto';
 import { SearchMessagesDto } from './dto/search-messages.dto';
 import { SearchMessagesResponseDto } from './dto/search-message-response.dto';
+import { FileListResponseDto } from './dto/file-list.dto';
 
 const SYSTEM_AUTHOR_ID = 0;
+const FILE_SHARE_VIEW_TYPE = 'FILE_SHARE';
+const FILE_ATTACHMENT_LIMIT = 100;
+
+type FileAttachmentRow = {
+    messageId: string;
+    fileName: string;
+    fileSize: number;
+    fileUrl: string;
+    mimeType: string;
+    uploaderId: number;
+    uploadedAt: string;
+    attachmentIndex: number;
+};
 
 @Injectable()
 export class ChatService {
@@ -40,6 +56,8 @@ export class ChatService {
         private readonly chatMessageProducer: ChatMessageProducer,
         private readonly githubIssueProducer: GithubIssueProducer,
         private readonly projectClient: ProjectClient,
+        private readonly channelClient: ChannelClient,
+        private readonly userClient: UserClient,
         @Inject(forwardRef(() => ChatGateway))
         private readonly chatGateway: ChatGateway,
     ) {}
@@ -85,6 +103,37 @@ export class ChatService {
     async confirmFileUpload(channelId: number, objectKey: string, userId: number): Promise<string> {
         await this.checkMembership(channelId, userId);
         return this.minioService.confirmUpload(channelId, userId, objectKey);
+    }
+
+    async getFileList(
+        channelId: number,
+        userId: number,
+        before?: string,
+        limit = 20,
+    ): Promise<FileListResponseDto> {
+        await this.checkMembership(channelId, userId);
+
+        const channel = await this.channelClient.getChannel(channelId, userId);
+        if (channel.viewType !== FILE_SHARE_VIEW_TYPE) {
+            throw new BadRequestException('FILE_SHARE 채널에서만 파일 목록을 조회할 수 있습니다');
+        }
+
+        const { items, nextCursor } = await this.queryFileAttachments(channelId, before, limit);
+        const uploaderNames = await this.loadUploaderNames(items);
+
+        return {
+            files: items.map((item) => ({
+                messageId: item.messageId,
+                fileName: item.fileName,
+                fileSize: item.fileSize,
+                fileUrl: item.fileUrl,
+                mimeType: item.mimeType,
+                uploaderId: item.uploaderId,
+                uploaderName: uploaderNames.get(item.uploaderId) ?? String(item.uploaderId),
+                uploadedAt: item.uploadedAt,
+            })),
+            nextCursor,
+        };
     }
 
     async sendMessage(
@@ -283,5 +332,140 @@ export class ChatService {
 
     private isAdmin(role: string): boolean {
         return role === UserRole.ADMIN;
+    }
+
+    private async queryFileAttachments(
+        channelId: number,
+        before: string | undefined,
+        limit: number,
+    ): Promise<{ items: FileAttachmentRow[]; nextCursor: string | null }> {
+        const safeLimit = Math.min(Math.max(limit, 1), FILE_ATTACHMENT_LIMIT);
+        const cursorMatch = before ? this.buildFileCursorMatch(before) : null;
+
+        const pipeline: any[] = [
+            {
+                $match: {
+                    channelId,
+                    type: 'FILE',
+                    'attachments.0': { $exists: true },
+                },
+            },
+            {
+                $unwind: {
+                    path: '$attachments',
+                    includeArrayIndex: 'attachmentIndex',
+                },
+            },
+            ...(cursorMatch ? [{ $match: cursorMatch }] : []),
+            {
+                $sort: {
+                    createdAt: -1,
+                    _id: -1,
+                    attachmentIndex: -1,
+                },
+            },
+            { $limit: safeLimit + 1 },
+            {
+                $project: {
+                    _id: 1,
+                    authorId: 1,
+                    createdAt: 1,
+                    attachmentIndex: 1,
+                    attachment: '$attachments',
+                },
+            },
+        ];
+
+        const rows = await this.messageModel.aggregate(pipeline);
+        const hasNext = rows.length > safeLimit;
+        const pageRows = rows.slice(0, safeLimit);
+        const items: FileAttachmentRow[] = pageRows.map((row: any) => ({
+            messageId: row._id.toString(),
+            fileName: row.attachment.name,
+            fileSize: row.attachment.size,
+            fileUrl: row.attachment.url,
+            mimeType: row.attachment.mimeType,
+            uploaderId: row.authorId,
+            uploadedAt: row.createdAt.toISOString(),
+            attachmentIndex: row.attachmentIndex ?? 0,
+        }));
+
+        return {
+            items,
+            nextCursor: hasNext && pageRows.length > 0
+                ? this.encodeFileCursor(pageRows.at(-1))
+                : null,
+        };
+    }
+
+    private buildFileCursorMatch(before: string): Record<string, unknown> | null {
+        const cursor = this.decodeFileCursor(before);
+        if (!cursor) {
+            return null;
+        }
+
+        return {
+            $or: [
+                { createdAt: { $lt: new Date(cursor.uploadedAt) } },
+                {
+                    createdAt: new Date(cursor.uploadedAt),
+                    _id: { $lt: new Types.ObjectId(cursor.messageId) },
+                },
+                {
+                    createdAt: new Date(cursor.uploadedAt),
+                    _id: new Types.ObjectId(cursor.messageId),
+                    attachmentIndex: { $lt: cursor.attachmentIndex },
+                },
+            ],
+        };
+    }
+
+    private encodeFileCursor(row: any): string | null {
+        if (!row) {
+            return null;
+        }
+
+        return Buffer.from(JSON.stringify({
+            uploadedAt: row.createdAt.toISOString(),
+            messageId: row._id.toString(),
+            attachmentIndex: row.attachmentIndex ?? 0,
+        })).toString('base64');
+    }
+
+    private decodeFileCursor(before: string): { uploadedAt: string; messageId: string; attachmentIndex: number } | null {
+        try {
+            const parsed = JSON.parse(Buffer.from(before, 'base64').toString('utf8')) as {
+                uploadedAt?: unknown;
+                messageId?: unknown;
+                attachmentIndex?: unknown;
+            };
+
+            if (
+                typeof parsed.uploadedAt !== 'string' ||
+                typeof parsed.messageId !== 'string' ||
+                typeof parsed.attachmentIndex !== 'number' ||
+                Number.isNaN(Date.parse(parsed.uploadedAt)) ||
+                !Types.ObjectId.isValid(parsed.messageId)
+            ) {
+                return null;
+            }
+
+            return {
+                uploadedAt: parsed.uploadedAt,
+                messageId: parsed.messageId,
+                attachmentIndex: parsed.attachmentIndex,
+            };
+        } catch {
+            return null;
+        }
+    }
+
+    private async loadUploaderNames(items: Array<{ uploaderId: number }>): Promise<Map<number, string>> {
+        const uniqueUploaderIds = [...new Set(items.map((item) => item.uploaderId))];
+        const entries = await Promise.all(
+            uniqueUploaderIds.map(async (uploaderId) => [uploaderId, await this.userClient.getDisplayName(uploaderId)] as const),
+        );
+
+        return new Map(entries);
     }
 }

--- a/cowork-chat/src/chat/dto/file-list.dto.ts
+++ b/cowork-chat/src/chat/dto/file-list.dto.ts
@@ -1,0 +1,37 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class FileListQueryDto {
+    @ApiPropertyOptional({ description: '커서: 이전 응답의 nextCursor 값' })
+    @IsString()
+    @IsOptional()
+    before?: string;
+
+    @ApiPropertyOptional({ description: '페이지 크기 (기본 20, 최대 100)', default: 20 })
+    @IsInt()
+    @Min(1)
+    @Max(100)
+    @IsOptional()
+    @Type(() => Number)
+    limit?: number;
+}
+
+export class FileListItemDto {
+    @ApiProperty() messageId!: string;
+    @ApiProperty() fileName!: string;
+    @ApiProperty() fileSize!: number;
+    @ApiProperty() fileUrl!: string;
+    @ApiProperty() mimeType!: string;
+    @ApiProperty() uploaderId!: number;
+    @ApiProperty() uploaderName!: string;
+    @ApiProperty() uploadedAt!: string;
+}
+
+export class FileListResponseDto {
+    @ApiProperty({ type: [FileListItemDto] })
+    files!: FileListItemDto[];
+
+    @ApiPropertyOptional({ nullable: true })
+    nextCursor!: string | null;
+}

--- a/cowork-chat/src/chat/service/channel.client.spec.ts
+++ b/cowork-chat/src/chat/service/channel.client.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { ChannelClient } from './channel.client';
+
+describe('ChannelClient', () => {
+    let client: ChannelClient;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ChannelClient,
+                {
+                    provide: ConfigService,
+                    useValue: { get: jest.fn().mockReturnValue('http://localhost:8083') },
+                },
+            ],
+        }).compile();
+
+        client = module.get(ChannelClient);
+    });
+
+    beforeEach(() => {
+        global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('채널 정보를 조회해 반환한다', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue({ id: 1, viewType: 'FILE_SHARE' }),
+        });
+
+        await expect(client.getChannel(1, 42)).resolves.toEqual({ id: 1, viewType: 'FILE_SHARE' });
+        expect(global.fetch).toHaveBeenCalledWith(
+            'http://localhost:8083/channels/1',
+            expect.objectContaining({
+                headers: { 'X-User-Id': '42' },
+                signal: expect.any(AbortSignal),
+            }),
+        );
+    });
+
+    it('비정상 응답이면 예외를 던진다', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: false,
+            status: 403,
+            text: jest.fn().mockResolvedValue('forbidden'),
+        });
+
+        await expect(client.getChannel(1, 42)).rejects.toThrow('channel-service 오류: 403 - forbidden');
+    });
+});

--- a/cowork-chat/src/chat/service/channel.client.ts
+++ b/cowork-chat/src/chat/service/channel.client.ts
@@ -1,0 +1,49 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { getRequiredConfig } from '../../common/config/config.util';
+
+export interface ChannelInfo {
+    id: number;
+    viewType: string;
+}
+
+@Injectable()
+export class ChannelClient {
+    private readonly logger = new Logger(ChannelClient.name);
+    private readonly channelServiceUrl: string;
+
+    constructor(private readonly configService: ConfigService) {
+        this.channelServiceUrl = getRequiredConfig(this.configService, 'CHANNEL_SERVICE_URL').replace(/\/$/, '');
+    }
+
+    async getChannel(channelId: number, userId: number): Promise<ChannelInfo> {
+        const res = await fetch(`${this.channelServiceUrl}/channels/${channelId}`, {
+            headers: { 'X-User-Id': String(userId) },
+            signal: AbortSignal.timeout(3000),
+        });
+
+        if (!res.ok) {
+            const message = await this.readErrorMessage(res);
+            throw new Error(`channel-service 오류: ${res.status}${message ? ` - ${message}` : ''}`);
+        }
+
+        const body = await res.json() as { id?: number; viewType?: string };
+        if (typeof body.id !== 'number' || typeof body.viewType !== 'string') {
+            throw new Error('channel-service 응답 형식이 올바르지 않습니다');
+        }
+
+        return {
+            id: body.id,
+            viewType: body.viewType,
+        };
+    }
+
+    private async readErrorMessage(res: Response): Promise<string | null> {
+        try {
+            return await res.text();
+        } catch (err) {
+            this.logger.warn(`channel-service 오류 응답 본문 읽기 실패: ${String(err)}`);
+            return null;
+        }
+    }
+}

--- a/cowork-chat/src/chat/service/user.client.spec.ts
+++ b/cowork-chat/src/chat/service/user.client.spec.ts
@@ -1,0 +1,57 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { UserClient } from './user.client';
+
+describe('UserClient', () => {
+    let client: UserClient;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                UserClient,
+                {
+                    provide: ConfigService,
+                    useValue: { get: jest.fn().mockReturnValue('http://localhost:8082') },
+                },
+            ],
+        }).compile();
+
+        client = module.get(UserClient);
+    });
+
+    beforeEach(() => {
+        global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('nickname이 있으면 nickname을 반환한다', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue({ name: '홍길동', nickname: '길동이' }),
+        });
+
+        await expect(client.getDisplayName(42)).resolves.toBe('길동이');
+    });
+
+    it('nickname이 없으면 name을 반환한다', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+            json: jest.fn().mockResolvedValue({ name: '홍길동', nickname: null }),
+        });
+
+        await expect(client.getDisplayName(42)).resolves.toBe('홍길동');
+    });
+
+    it('비정상 응답이면 예외를 던진다', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: false,
+            status: 404,
+            text: jest.fn().mockResolvedValue('not found'),
+        });
+
+        await expect(client.getDisplayName(42)).rejects.toThrow('user-service 오류: 404 - not found');
+    });
+});

--- a/cowork-chat/src/chat/service/user.client.ts
+++ b/cowork-chat/src/chat/service/user.client.ts
@@ -1,0 +1,44 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { getRequiredConfig } from '../../common/config/config.util';
+
+@Injectable()
+export class UserClient {
+    private readonly logger = new Logger(UserClient.name);
+    private readonly userServiceUrl: string;
+
+    constructor(private readonly configService: ConfigService) {
+        this.userServiceUrl = getRequiredConfig(this.configService, 'USER_SERVICE_URL').replace(/\/$/, '');
+    }
+
+    async getDisplayName(userId: number): Promise<string> {
+        const res = await fetch(`${this.userServiceUrl}/users/${userId}`, {
+            signal: AbortSignal.timeout(3000),
+        });
+
+        if (!res.ok) {
+            const message = await this.readErrorMessage(res);
+            throw new Error(`user-service 오류: ${res.status}${message ? ` - ${message}` : ''}`);
+        }
+
+        const body = await res.json() as { name?: string; nickname?: string | null };
+        if (typeof body.name !== 'string' || body.name.length === 0) {
+            throw new Error('user-service 응답 형식이 올바르지 않습니다');
+        }
+
+        if (typeof body.nickname === 'string' && body.nickname.length > 0) {
+            return body.nickname;
+        }
+
+        return body.name;
+    }
+
+    private async readErrorMessage(res: Response): Promise<string | null> {
+        try {
+            return await res.text();
+        } catch (err) {
+            this.logger.warn(`user-service 오류 응답 본문 읽기 실패: ${String(err)}`);
+            return null;
+        }
+    }
+}

--- a/cowork-chat/src/main.ts
+++ b/cowork-chat/src/main.ts
@@ -46,6 +46,9 @@ async function bootstrap() {
             '## 메시지 검색\n' +
             '`GET /projects/:projectId/messages/search` — Elasticsearch 기반 프로젝트 채팅 검색.\n' +
             '프로젝트 멤버이고 채널 접근 권한이 있는 메시지만 반환됩니다.\n\n' +
+            '## 파일 목록\n' +
+            '`GET /channels/:channelId/files` — `FILE_SHARE` 채널 전용 파일 목록 조회.\n' +
+            '응답은 파일 단위로 평탄화되며 업로더 표시명과 업로드 시각을 포함합니다.\n\n' +
             '## 인증\n' +
             'REST API: Gateway에서 주입된 `X-User-Id`, `X-User-Role` 헤더 사용.\n' +
             'WebSocket: Socket.io handshake의 `auth.token`에 JWT Bearer 토큰 전달.\n' +


### PR DESCRIPTION
## 개요

`FILE_SHARE` 뷰 타입 채널에서 업로드된 파일 목록을 커서 기반 페이지네이션으로 조회하는 API를 추가하였습니다. `ProjectClient`와 동일한 패턴으로 `ChannelClient`, `UserClient`를 도입하여 채널 정보 및 업로더 표시명을 조회합니다.

## 본문

### 추가된 클라이언트

- **`ChannelClient`**: `cowork-channel`의 `GET /channels/:channelId`를 호출하여 채널 `viewType`을 조회합니다. `X-User-Id` 헤더를 포함하여 멤버십 검증을 위임합니다. (`CHANNEL_SERVICE_URL` 환경변수 필요)
- **`UserClient`**: `cowork-user`의 `GET /users/:userId`를 호출하여 사용자 표시명(닉네임 우선, 없으면 name)을 조회합니다. (`USER_SERVICE_URL` 환경변수 필요)
- 두 클라이언트 모두 기존 `ProjectClient`와 동일하게 `fetch` + `AbortSignal.timeout` 패턴을 따릅니다.

### 파일 목록 조회 API

- **엔드포인트**: `GET /channels/:channelId/files`
- `FILE_SHARE` 채널이 아닌 경우 `400 Bad Request`를 반환합니다.
- MongoDB `aggregate`로 `type: 'FILE'` 메시지의 첨부파일을 `$unwind`하여 파일 단위로 반환합니다.
- 커서는 `(createdAt, _id, attachmentIndex)` 복합 정렬 기준으로 Base64 인코딩됩니다.
- 업로더 ID를 중복 제거 후 `UserClient`로 일괄 조회하여 표시명을 응답에 포함합니다.

### 테스트

- `ChannelClient`, `UserClient` 단위 테스트를 추가하였습니다.
- `ChatService`에 `getFileList` 시나리오(정상, 비 `FILE_SHARE` 채널, 커서 페이지네이션) 테스트를 추가하였습니다.
- 기존 컨트롤러 테스트를 서비스 메서드 단위 모킹 방식으로 개선하였습니다.
