### PR TITLE
[global] Gradle wrapper 버전 9.4.1에서 9.5.0으로 업데이트

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=60000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 개요

Gradle wrapper 버전을 9.4.1에서 9.5.0으로 업그레이드하였습니다.

## 본문

`gradle/wrapper/gradle-wrapper.properties`의 `distributionUrl`을 수정하여 Gradle 9.5.0 배포판을 사용하도록 변경하였습니다. 9.5.0은 9.4.1 대비 버그 수정 및 성능 개선이 포함된 마이너 업데이트 버전입니다.
