### PR TITLE
[chat] 외부 응답 파싱 및 채널 검증 보강

### DIFF
--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -30,6 +30,7 @@ import { SearchMessagesResponseDto } from './dto/search-message-response.dto';
 import { FileListResponseDto } from './dto/file-list.dto';
 
 const SYSTEM_AUTHOR_ID = 0;
+const SYSTEM_AUTHOR_NAME = 'System';
 const FILE_SHARE_VIEW_TYPE = 'FILE_SHARE';
 const FILE_ATTACHMENT_LIMIT = 100;
 
@@ -467,7 +468,7 @@ export class ChatService {
         const uniqueUploaderIds = [...new Set(items.map((item) => item.uploaderId))];
         const entries = await Promise.all(
             uniqueUploaderIds.map(async (uploaderId) => {
-                if (uploaderId <= 0) return [uploaderId, 'System'] as const;
+                if (uploaderId <= SYSTEM_AUTHOR_ID) return [uploaderId, SYSTEM_AUTHOR_NAME] as const;
                 const name = await this.userClient.getDisplayName(uploaderId);
                 return [uploaderId, name] as const;
             }),

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -294,6 +294,9 @@ export class ChatService {
         await this.checkMembership(channelId, userId);
         const message = await this.messageModel.findById(messageId);
         if (!message) throw new NotFoundException('메시지를 찾을 수 없습니다');
+        if (message.channelId !== channelId) {
+            throw new ForbiddenException('해당 채널의 메시지가 아닙니다');
+        }
         if (message.authorId !== userId && !this.isAdmin(userRole)) {
             throw new ForbiddenException('본인 메시지만 삭제할 수 있습니다');
         }
@@ -463,7 +466,11 @@ export class ChatService {
     private async loadUploaderNames(items: Array<{ uploaderId: number }>): Promise<Map<number, string>> {
         const uniqueUploaderIds = [...new Set(items.map((item) => item.uploaderId))];
         const entries = await Promise.all(
-            uniqueUploaderIds.map(async (uploaderId) => [uploaderId, await this.userClient.getDisplayName(uploaderId)] as const),
+            uniqueUploaderIds.map(async (uploaderId) => {
+                if (uploaderId <= 0) return [uploaderId, 'System'] as const;
+                const name = await this.userClient.getDisplayName(uploaderId);
+                return [uploaderId, name] as const;
+            }),
         );
 
         return new Map(entries);

--- a/cowork-chat/src/chat/service/channel.client.ts
+++ b/cowork-chat/src/chat/service/channel.client.ts
@@ -27,7 +27,7 @@ export class ChannelClient {
             throw new Error(`channel-service 오류: ${res.status}${message ? ` - ${message}` : ''}`);
         }
 
-        const body = await res.json() as { id?: number; viewType?: string };
+        const body = await this.readJsonBody(res);
         if (typeof body.id !== 'number' || typeof body.viewType !== 'string') {
             throw new Error('channel-service 응답 형식이 올바르지 않습니다');
         }
@@ -44,6 +44,15 @@ export class ChannelClient {
         } catch (err) {
             this.logger.warn(`channel-service 오류 응답 본문 읽기 실패: ${String(err)}`);
             return null;
+        }
+    }
+
+    private async readJsonBody(res: Response): Promise<{ id?: number; viewType?: string }> {
+        try {
+            return await res.json() as { id?: number; viewType?: string };
+        } catch (err) {
+            this.logger.warn(`channel-service JSON 응답 파싱 실패: ${String(err)}`);
+            throw new Error('channel-service 응답 본문 파싱에 실패했습니다');
         }
     }
 }

--- a/cowork-chat/src/chat/service/user.client.ts
+++ b/cowork-chat/src/chat/service/user.client.ts
@@ -21,7 +21,7 @@ export class UserClient {
             throw new Error(`user-service 오류: ${res.status}${message ? ` - ${message}` : ''}`);
         }
 
-        const body = await res.json() as { name?: string; nickname?: string | null };
+        const body = await this.readJsonBody(res);
         if (typeof body.name !== 'string' || body.name.length === 0) {
             throw new Error('user-service 응답 형식이 올바르지 않습니다');
         }
@@ -39,6 +39,15 @@ export class UserClient {
         } catch (err) {
             this.logger.warn(`user-service 오류 응답 본문 읽기 실패: ${String(err)}`);
             return null;
+        }
+    }
+
+    private async readJsonBody(res: Response): Promise<{ name?: string; nickname?: string | null }> {
+        try {
+            return await res.json() as { name?: string; nickname?: string | null };
+        } catch (err) {
+            this.logger.warn(`user-service JSON 응답 파싱 실패: ${String(err)}`);
+            throw new Error('user-service 응답 본문 파싱에 실패했습니다');
         }
     }
 }


### PR DESCRIPTION
## 개요

chat 서비스에서 외부 서비스 응답 파싱 실패 시 예외가 제어되도록 보강하였습니다.
메시지 삭제 시 요청 채널과 메시지 소속 채널이 일치하는지 검증하도록 수정하였습니다.
시스템 업로더 식별자에 대해서는 사용자 서비스 조회 없이 표시 이름을 반환하도록 보완하였습니다.

## 본문

- `channel.client.ts`, `user.client.ts`
  - 외부 서비스 성공 응답을 `res.json()`으로 파싱하는 구간을 `try-catch`로 감싸도록 수정하였습니다.
  - 유효하지 않은 JSON 응답이 들어와도 경고 로그를 남기고 제어된 에러를 반환하도록 변경하였습니다.
- `chat.service.ts`
  - 메시지 삭제 전에 `channelId`와 메시지의 소속 채널이 일치하는지 확인하도록 검증 로직을 추가하였습니다.
  - 업로더 ID가 0 이하인 시스템 데이터는 `user-service` 호출 없이 `System` 이름을 사용하도록 처리하였습니다.
