### PR TITLE
[channel] 회의록 템플릿 CRUD API 및 채널 생성 시 기본 템플릿 자동 생성

### DIFF
--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/MeetingNoteController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/MeetingNoteController.kt
@@ -1,0 +1,62 @@
+package com.cowork.channel.controller
+
+import com.cowork.channel.dto.CreateMeetingNoteRequest
+import com.cowork.channel.dto.MeetingNoteResponse
+import com.cowork.channel.service.MeetingNoteService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "회의록", description = "회의록 작성 및 조회 API")
+@RestController
+@RequestMapping("/channels/{channelId}/meeting-notes")
+class MeetingNoteController(
+    private val meetingNoteService: MeetingNoteService,
+) {
+
+    @Operation(summary = "회의록 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+    )
+    @GetMapping
+    fun listNotes(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+    ): ResponseEntity<List<MeetingNoteResponse>> =
+        ResponseEntity.ok(meetingNoteService.listNotes(userId, channelId))
+
+    @Operation(summary = "회의록 상세 조회", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+        ApiResponse(responseCode = "404", description = "회의록 없음"),
+    )
+    @GetMapping("/{noteId}")
+    fun getNote(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @PathVariable noteId: Long,
+    ): ResponseEntity<MeetingNoteResponse> =
+        ResponseEntity.ok(meetingNoteService.getNote(userId, channelId, noteId))
+
+    @Operation(summary = "회의록 작성", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "작성 성공"),
+        ApiResponse(responseCode = "400", description = "잘못된 섹션 id"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+        ApiResponse(responseCode = "404", description = "템플릿 없음"),
+    )
+    @PostMapping
+    fun createNote(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @RequestBody request: CreateMeetingNoteRequest,
+    ): ResponseEntity<MeetingNoteResponse> =
+        ResponseEntity.status(201).body(meetingNoteService.createNote(userId, channelId, request))
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/MeetingNoteTemplateController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/MeetingNoteTemplateController.kt
@@ -1,0 +1,146 @@
+package com.cowork.channel.controller
+
+import com.cowork.channel.dto.*
+import com.cowork.channel.service.MeetingNoteTemplateService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "회의록 템플릿", description = "회의록 템플릿 및 섹션 CRUD API")
+@RestController
+@RequestMapping("/channels/{channelId}/meeting-note-templates")
+class MeetingNoteTemplateController(
+    private val meetingNoteTemplateService: MeetingNoteTemplateService,
+) {
+
+    @Operation(summary = "템플릿 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+    )
+    @GetMapping
+    fun listTemplates(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+    ): ResponseEntity<List<MeetingNoteTemplateResponse>> =
+        ResponseEntity.ok(meetingNoteTemplateService.listTemplates(userId, channelId))
+
+    @Operation(summary = "템플릿 생성", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "생성 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+    )
+    @PostMapping
+    fun createTemplate(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @RequestBody request: CreateMeetingNoteTemplateRequest,
+    ): ResponseEntity<MeetingNoteTemplateResponse> =
+        ResponseEntity.status(201).body(meetingNoteTemplateService.createTemplate(userId, channelId, request))
+
+    @Operation(summary = "템플릿 상세 조회 (섹션 포함)", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "404", description = "템플릿 없음"),
+    )
+    @GetMapping("/{templateId}")
+    fun getTemplate(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @PathVariable templateId: Long,
+    ): ResponseEntity<MeetingNoteTemplateResponse> =
+        ResponseEntity.ok(meetingNoteTemplateService.getTemplate(userId, channelId, templateId))
+
+    @Operation(summary = "템플릿 이름 수정", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "수정 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+    )
+    @PatchMapping("/{templateId}")
+    fun updateTemplate(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @PathVariable templateId: Long,
+        @RequestBody request: UpdateMeetingNoteTemplateRequest,
+    ): ResponseEntity<MeetingNoteTemplateResponse> =
+        ResponseEntity.ok(meetingNoteTemplateService.updateTemplate(userId, channelId, templateId, request))
+
+    @Operation(summary = "템플릿 삭제 (활성 템플릿 삭제 불가)", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "삭제 성공"),
+        ApiResponse(responseCode = "400", description = "활성 템플릿 삭제 시도"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+    )
+    @DeleteMapping("/{templateId}")
+    fun deleteTemplate(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @PathVariable templateId: Long,
+    ): ResponseEntity<Void> {
+        meetingNoteTemplateService.deleteTemplate(userId, channelId, templateId)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "템플릿 활성화 (기존 활성 자동 해제)", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "활성화 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+    )
+    @PatchMapping("/{templateId}/activate")
+    fun activateTemplate(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @PathVariable templateId: Long,
+    ): ResponseEntity<MeetingNoteTemplateResponse> =
+        ResponseEntity.ok(meetingNoteTemplateService.activateTemplate(userId, channelId, templateId))
+
+    @Operation(summary = "섹션 추가", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "추가 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+    )
+    @PostMapping("/{templateId}/sections")
+    fun addSection(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @PathVariable templateId: Long,
+        @RequestBody request: CreateTemplateSectionRequest,
+    ): ResponseEntity<TemplateSectionResponse> =
+        ResponseEntity.status(201).body(meetingNoteTemplateService.addSection(userId, channelId, templateId, request))
+
+    @Operation(summary = "섹션 수정", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "수정 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+    )
+    @PatchMapping("/{templateId}/sections/{sectionId}")
+    fun updateSection(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @PathVariable templateId: Long,
+        @PathVariable sectionId: Long,
+        @RequestBody request: UpdateTemplateSectionRequest,
+    ): ResponseEntity<TemplateSectionResponse> =
+        ResponseEntity.ok(meetingNoteTemplateService.updateSection(userId, channelId, templateId, sectionId, request))
+
+    @Operation(summary = "섹션 삭제", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "삭제 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
+    )
+    @DeleteMapping("/{templateId}/sections/{sectionId}")
+    fun deleteSection(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @PathVariable templateId: Long,
+        @PathVariable sectionId: Long,
+    ): ResponseEntity<Void> {
+        meetingNoteTemplateService.deleteSection(userId, channelId, templateId, sectionId)
+        return ResponseEntity.noContent().build()
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/domain/MeetingNote.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/domain/MeetingNote.kt
@@ -1,0 +1,38 @@
+package com.cowork.channel.domain
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "tb_meeting_notes")
+class MeetingNote(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(name = "channel_id", nullable = false)
+    val channelId: Long,
+
+    @Column(name = "template_id", nullable = false)
+    val templateId: Long,
+
+    @Column(nullable = false, length = 200)
+    var title: String,
+
+    @Column(columnDefinition = "JSON", nullable = false)
+    var content: String,
+
+    @Column(name = "created_by", nullable = false)
+    val createdBy: Long,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/domain/MeetingNoteTemplate.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/domain/MeetingNoteTemplate.kt
@@ -1,0 +1,47 @@
+package com.cowork.channel.domain
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "tb_meeting_note_templates")
+class MeetingNoteTemplate(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(name = "channel_id", nullable = false)
+    val channelId: Long,
+
+    @Column(nullable = false, length = 100)
+    var name: String,
+
+    @Column(name = "is_active", nullable = false)
+    var isActive: Boolean = false,
+
+    @Column(name = "created_by", nullable = false)
+    val createdBy: Long,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun updateName(name: String) {
+        this.name = name
+    }
+
+    fun activate() {
+        this.isActive = true
+    }
+
+    fun deactivate() {
+        this.isActive = false
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/domain/SectionType.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/domain/SectionType.kt
@@ -1,0 +1,9 @@
+package com.cowork.channel.domain
+
+enum class SectionType {
+    TEXT,
+    MARKDOWN,
+    DATE,
+    DATETIME,
+    USER_LIST,
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/domain/TemplateSection.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/domain/TemplateSection.kt
@@ -1,0 +1,46 @@
+package com.cowork.channel.domain
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "tb_meeting_note_template_sections")
+class TemplateSection(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(name = "template_id", nullable = false)
+    val templateId: Long,
+
+    @Column(nullable = false, length = 100)
+    var title: String,
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var type: SectionType,
+
+    @Column(length = 255)
+    var placeholder: String? = null,
+
+    @Column(name = "is_required", nullable = false)
+    var isRequired: Boolean = false,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now(),
+) {
+    fun update(title: String?, type: SectionType?, placeholder: String?, isRequired: Boolean?) {
+        title?.let { this.title = it }
+        type?.let { this.type = it }
+        placeholder?.let { this.placeholder = it }
+        isRequired?.let { this.isRequired = it }
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/CreateMeetingNoteRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/CreateMeetingNoteRequest.kt
@@ -1,0 +1,12 @@
+package com.cowork.channel.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class CreateMeetingNoteRequest(
+    @Schema(description = "사용할 템플릿 ID", example = "1")
+    val templateId: Long,
+    @Schema(description = "회의록 제목", example = "2024-01-01 팀 주간 회의")
+    val title: String,
+    @Schema(description = "섹션별 작성 내용 JSON 블록", example = "{\"회의 제목\": \"API 설계 논의\", \"참석자\": \"홍길동, 김철수\"}")
+    val content: String,
+)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/CreateMeetingNoteTemplateRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/CreateMeetingNoteTemplateRequest.kt
@@ -1,0 +1,5 @@
+package com.cowork.channel.dto
+
+data class CreateMeetingNoteTemplateRequest(
+    val name: String,
+)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/CreateTemplateSectionRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/CreateTemplateSectionRequest.kt
@@ -1,0 +1,8 @@
+package com.cowork.channel.dto
+
+data class CreateTemplateSectionRequest(
+    val title: String,
+    val type: String,
+    val placeholder: String? = null,
+    val isRequired: Boolean = false,
+)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/MeetingNoteResponse.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/MeetingNoteResponse.kt
@@ -1,0 +1,37 @@
+package com.cowork.channel.dto
+
+import com.cowork.channel.domain.MeetingNote
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class MeetingNoteResponse(
+    @Schema(description = "회의록 ID", example = "1")
+    val id: Long,
+    @Schema(description = "채널 ID", example = "1")
+    val channelId: Long,
+    @Schema(description = "사용된 템플릿 ID", example = "1")
+    val templateId: Long,
+    @Schema(description = "회의록 제목", example = "2024-01-01 팀 주간 회의")
+    val title: String,
+    @Schema(description = "섹션별 작성 내용 JSON 블록", example = "{\"회의 제목\": \"API 설계 논의\", \"참석자\": \"홍길동, 김철수\"}")
+    val content: String,
+    @Schema(description = "작성자 ID", example = "1")
+    val createdBy: Long,
+    @Schema(description = "작성 일시")
+    val createdAt: LocalDateTime,
+    @Schema(description = "수정 일시")
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun of(note: MeetingNote) = MeetingNoteResponse(
+            id = note.id,
+            channelId = note.channelId,
+            templateId = note.templateId,
+            title = note.title,
+            content = note.content,
+            createdBy = note.createdBy,
+            createdAt = note.createdAt,
+            updatedAt = note.updatedAt,
+        )
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/MeetingNoteTemplateResponse.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/MeetingNoteTemplateResponse.kt
@@ -1,0 +1,28 @@
+package com.cowork.channel.dto
+
+import com.cowork.channel.domain.MeetingNoteTemplate
+import java.time.LocalDateTime
+
+data class MeetingNoteTemplateResponse(
+    val id: Long,
+    val channelId: Long,
+    val name: String,
+    val isActive: Boolean,
+    val createdBy: Long,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+    val sections: List<TemplateSectionResponse>,
+) {
+    companion object {
+        fun of(template: MeetingNoteTemplate, sections: List<TemplateSectionResponse>) = MeetingNoteTemplateResponse(
+            id = template.id,
+            channelId = template.channelId,
+            name = template.name,
+            isActive = template.isActive,
+            createdBy = template.createdBy,
+            createdAt = template.createdAt,
+            updatedAt = template.updatedAt,
+            sections = sections,
+        )
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/TemplateSectionResponse.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/TemplateSectionResponse.kt
@@ -1,0 +1,28 @@
+package com.cowork.channel.dto
+
+import com.cowork.channel.domain.TemplateSection
+import java.time.LocalDateTime
+
+data class TemplateSectionResponse(
+    val id: Long,
+    val templateId: Long,
+    val title: String,
+    val type: String,
+    val placeholder: String?,
+    val isRequired: Boolean,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+) {
+    companion object {
+        fun of(section: TemplateSection) = TemplateSectionResponse(
+            id = section.id,
+            templateId = section.templateId,
+            title = section.title,
+            type = section.type.name,
+            placeholder = section.placeholder,
+            isRequired = section.isRequired,
+            createdAt = section.createdAt,
+            updatedAt = section.updatedAt,
+        )
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateMeetingNoteTemplateRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateMeetingNoteTemplateRequest.kt
@@ -1,0 +1,5 @@
+package com.cowork.channel.dto
+
+data class UpdateMeetingNoteTemplateRequest(
+    val name: String,
+)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateTemplateSectionRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateTemplateSectionRequest.kt
@@ -1,0 +1,8 @@
+package com.cowork.channel.dto
+
+data class UpdateTemplateSectionRequest(
+    val title: String? = null,
+    val type: String? = null,
+    val placeholder: String? = null,
+    val isRequired: Boolean? = null,
+)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/repository/MeetingNoteRepository.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/repository/MeetingNoteRepository.kt
@@ -1,0 +1,9 @@
+package com.cowork.channel.repository
+
+import com.cowork.channel.domain.MeetingNote
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MeetingNoteRepository : JpaRepository<MeetingNote, Long> {
+
+    fun findAllByChannelIdOrderByIdDesc(channelId: Long): List<MeetingNote>
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/repository/MeetingNoteTemplateRepository.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/repository/MeetingNoteTemplateRepository.kt
@@ -1,0 +1,11 @@
+package com.cowork.channel.repository
+
+import com.cowork.channel.domain.MeetingNoteTemplate
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MeetingNoteTemplateRepository : JpaRepository<MeetingNoteTemplate, Long> {
+
+    fun findAllByChannelIdOrderByIdAsc(channelId: Long): List<MeetingNoteTemplate>
+
+    fun findByChannelIdAndIsActiveTrue(channelId: Long): MeetingNoteTemplate?
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/repository/TemplateSectionRepository.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/repository/TemplateSectionRepository.kt
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface TemplateSectionRepository : JpaRepository<TemplateSection, Long> {
 
     fun findAllByTemplateIdOrderByIdAsc(templateId: Long): List<TemplateSection>
+
+    fun findAllByTemplateIdInOrderByIdAsc(templateIds: List<Long>): List<TemplateSection>
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/repository/TemplateSectionRepository.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/repository/TemplateSectionRepository.kt
@@ -1,0 +1,9 @@
+package com.cowork.channel.repository
+
+import com.cowork.channel.domain.TemplateSection
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface TemplateSectionRepository : JpaRepository<TemplateSection, Long> {
+
+    fun findAllByTemplateIdOrderByIdAsc(templateId: Long): List<TemplateSection>
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
@@ -69,12 +69,12 @@ class ChannelService(
             )
         )
         val member = channelMemberRepository.save(ChannelMember(channelId = channel.id, userId = userId))
+        if (channel.viewType == ChannelViewType.MEETING_NOTE) {
+            meetingNoteTemplateService.createDefaultTemplate(channel)
+        }
         TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
             override fun afterCommit() {
                 channelMembershipSyncPublisher.publishChannelSnapshot(channel, listOf(member))
-                if (channel.viewType == ChannelViewType.MEETING_NOTE) {
-                    meetingNoteTemplateService.createDefaultTemplate(channel)
-                }
             }
         })
         return ChannelResponse.of(channel)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
@@ -26,6 +26,7 @@ class ChannelService(
     private val channelMemberEventPublisher: ChannelMemberEventPublisher,
     private val channelMembershipSyncPublisher: ChannelMembershipSyncPublisher,
     private val projectClient: ProjectClient,
+    private val meetingNoteTemplateService: MeetingNoteTemplateService,
 ) {
 
     fun findChannelOrThrow(channelId: Long): Channel =
@@ -71,6 +72,9 @@ class ChannelService(
         TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
             override fun afterCommit() {
                 channelMembershipSyncPublisher.publishChannelSnapshot(channel, listOf(member))
+                if (channel.viewType == ChannelViewType.MEETING_NOTE) {
+                    meetingNoteTemplateService.createDefaultTemplate(channel)
+                }
             }
         })
         return ChannelResponse.of(channel)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteService.kt
@@ -1,0 +1,69 @@
+package com.cowork.channel.service
+
+import com.cowork.channel.domain.MeetingNote
+import com.cowork.channel.dto.CreateMeetingNoteRequest
+import com.cowork.channel.dto.MeetingNoteResponse
+import com.cowork.channel.repository.ChannelMemberRepository
+import com.cowork.channel.repository.MeetingNoteRepository
+import com.cowork.channel.repository.MeetingNoteTemplateRepository
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+@Transactional(readOnly = true)
+class MeetingNoteService(
+    private val meetingNoteRepository: MeetingNoteRepository,
+    private val templateRepository: MeetingNoteTemplateRepository,
+    private val channelMemberRepository: ChannelMemberRepository,
+) {
+
+    private fun requireChannelMember(channelId: Long, userId: Long) {
+        if (!channelMemberRepository.existsByChannelIdAndUserId(channelId, userId)) {
+            throw ExpectedException("채널 멤버만 접근할 수 있습니다.", HttpStatus.FORBIDDEN)
+        }
+    }
+
+    fun listNotes(userId: Long, channelId: Long): List<MeetingNoteResponse> {
+        requireChannelMember(channelId, userId)
+        return meetingNoteRepository.findAllByChannelIdOrderByIdDesc(channelId)
+            .map { MeetingNoteResponse.of(it) }
+    }
+
+    fun getNote(userId: Long, channelId: Long, noteId: Long): MeetingNoteResponse {
+        requireChannelMember(channelId, userId)
+        return MeetingNoteResponse.of(findNoteOrThrow(noteId, channelId))
+    }
+
+    @Transactional
+    fun createNote(userId: Long, channelId: Long, request: CreateMeetingNoteRequest): MeetingNoteResponse {
+        requireChannelMember(channelId, userId)
+        val template = templateRepository.findById(request.templateId).orElseThrow {
+            ExpectedException("템플릿을 찾을 수 없습니다. id=${request.templateId}", HttpStatus.NOT_FOUND)
+        }
+        if (template.channelId != channelId) {
+            throw ExpectedException("템플릿을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+        }
+        val note = meetingNoteRepository.save(
+            MeetingNote(
+                channelId = channelId,
+                templateId = request.templateId,
+                title = request.title,
+                content = request.content,
+                createdBy = userId,
+            )
+        )
+        return MeetingNoteResponse.of(note)
+    }
+
+    private fun findNoteOrThrow(noteId: Long, channelId: Long): MeetingNote {
+        val note = meetingNoteRepository.findById(noteId).orElseThrow {
+            ExpectedException("회의록을 찾을 수 없습니다. id=$noteId", HttpStatus.NOT_FOUND)
+        }
+        if (note.channelId != channelId) {
+            throw ExpectedException("회의록을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+        }
+        return note
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteTemplateService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteTemplateService.kt
@@ -6,6 +6,7 @@ import com.cowork.channel.domain.SectionType
 import com.cowork.channel.domain.TemplateSection
 import com.cowork.channel.dto.*
 import com.cowork.channel.repository.ChannelMemberRepository
+import com.cowork.channel.repository.ChannelRepository
 import com.cowork.channel.repository.MeetingNoteTemplateRepository
 import com.cowork.channel.repository.TemplateSectionRepository
 import org.springframework.http.HttpStatus
@@ -18,7 +19,7 @@ import team.themoment.sdk.exception.ExpectedException
 class MeetingNoteTemplateService(
     private val templateRepository: MeetingNoteTemplateRepository,
     private val sectionRepository: TemplateSectionRepository,
-    private val channelService: ChannelService,
+    private val channelRepository: ChannelRepository,
     private val channelMemberRepository: ChannelMemberRepository,
 ) {
 
@@ -37,6 +38,12 @@ class MeetingNoteTemplateService(
         DefaultSectionDef("결정사항", SectionType.MARKDOWN, "합의된 내용을 입력하세요", false),
         DefaultSectionDef("다음 회의 일정", SectionType.DATETIME, "다음 회의 일정을 입력하세요", false),
     )
+
+    private fun requireChannelExists(channelId: Long) {
+        if (!channelRepository.existsById(channelId)) {
+            throw ExpectedException("채널을 찾을 수 없습니다. id=$channelId", HttpStatus.NOT_FOUND)
+        }
+    }
 
     private fun findTemplateOrThrow(templateId: Long): MeetingNoteTemplate =
         templateRepository.findById(templateId).orElseThrow {
@@ -79,14 +86,14 @@ class MeetingNoteTemplateService(
     }
 
     fun listTemplates(userId: Long, channelId: Long): List<MeetingNoteTemplateResponse> {
-        val channel = channelService.findChannelOrThrow(channelId)
-        requireChannelMember(channel.id, userId)
+        requireChannelExists(channelId)
+        requireChannelMember(channelId, userId)
         return templateRepository.findAllByChannelIdOrderByIdAsc(channelId).map { toResponse(it) }
     }
 
     fun getTemplate(userId: Long, channelId: Long, templateId: Long): MeetingNoteTemplateResponse {
-        val channel = channelService.findChannelOrThrow(channelId)
-        requireChannelMember(channel.id, userId)
+        requireChannelExists(channelId)
+        requireChannelMember(channelId, userId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         return toResponse(template)
@@ -94,8 +101,8 @@ class MeetingNoteTemplateService(
 
     @Transactional
     fun createTemplate(userId: Long, channelId: Long, request: CreateMeetingNoteTemplateRequest): MeetingNoteTemplateResponse {
-        val channel = channelService.findChannelOrThrow(channelId)
-        requireChannelMember(channel.id, userId)
+        requireChannelExists(channelId)
+        requireChannelMember(channelId, userId)
         val template = templateRepository.save(
             MeetingNoteTemplate(
                 channelId = channelId,
@@ -109,8 +116,8 @@ class MeetingNoteTemplateService(
 
     @Transactional
     fun updateTemplate(userId: Long, channelId: Long, templateId: Long, request: UpdateMeetingNoteTemplateRequest): MeetingNoteTemplateResponse {
-        val channel = channelService.findChannelOrThrow(channelId)
-        requireChannelMember(channel.id, userId)
+        requireChannelExists(channelId)
+        requireChannelMember(channelId, userId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         template.updateName(request.name)
@@ -119,8 +126,8 @@ class MeetingNoteTemplateService(
 
     @Transactional
     fun deleteTemplate(userId: Long, channelId: Long, templateId: Long) {
-        val channel = channelService.findChannelOrThrow(channelId)
-        requireChannelMember(channel.id, userId)
+        requireChannelExists(channelId)
+        requireChannelMember(channelId, userId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         if (template.isActive) {
@@ -132,8 +139,8 @@ class MeetingNoteTemplateService(
 
     @Transactional
     fun activateTemplate(userId: Long, channelId: Long, templateId: Long): MeetingNoteTemplateResponse {
-        val channel = channelService.findChannelOrThrow(channelId)
-        requireChannelMember(channel.id, userId)
+        requireChannelExists(channelId)
+        requireChannelMember(channelId, userId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         templateRepository.findByChannelIdAndIsActiveTrue(channelId)
@@ -145,8 +152,8 @@ class MeetingNoteTemplateService(
 
     @Transactional
     fun addSection(userId: Long, channelId: Long, templateId: Long, request: CreateTemplateSectionRequest): TemplateSectionResponse {
-        val channel = channelService.findChannelOrThrow(channelId)
-        requireChannelMember(channel.id, userId)
+        requireChannelExists(channelId)
+        requireChannelMember(channelId, userId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         val section = sectionRepository.save(
@@ -163,8 +170,8 @@ class MeetingNoteTemplateService(
 
     @Transactional
     fun updateSection(userId: Long, channelId: Long, templateId: Long, sectionId: Long, request: UpdateTemplateSectionRequest): TemplateSectionResponse {
-        val channel = channelService.findChannelOrThrow(channelId)
-        requireChannelMember(channel.id, userId)
+        requireChannelExists(channelId)
+        requireChannelMember(channelId, userId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         val section = findSectionOrThrow(sectionId)
@@ -180,8 +187,8 @@ class MeetingNoteTemplateService(
 
     @Transactional
     fun deleteSection(userId: Long, channelId: Long, templateId: Long, sectionId: Long) {
-        val channel = channelService.findChannelOrThrow(channelId)
-        requireChannelMember(channel.id, userId)
+        requireChannelExists(channelId)
+        requireChannelMember(channelId, userId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         val section = findSectionOrThrow(sectionId)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteTemplateService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteTemplateService.kt
@@ -1,0 +1,214 @@
+package com.cowork.channel.service
+
+import com.cowork.channel.domain.Channel
+import com.cowork.channel.domain.MeetingNoteTemplate
+import com.cowork.channel.domain.SectionType
+import com.cowork.channel.domain.TemplateSection
+import com.cowork.channel.dto.*
+import com.cowork.channel.repository.ChannelMemberRepository
+import com.cowork.channel.repository.MeetingNoteTemplateRepository
+import com.cowork.channel.repository.TemplateSectionRepository
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import team.themoment.sdk.exception.ExpectedException
+
+@Service
+@Transactional(readOnly = true)
+class MeetingNoteTemplateService(
+    private val templateRepository: MeetingNoteTemplateRepository,
+    private val sectionRepository: TemplateSectionRepository,
+    private val channelService: ChannelService,
+    private val channelMemberRepository: ChannelMemberRepository,
+) {
+
+    private data class DefaultSectionDef(
+        val title: String,
+        val type: SectionType,
+        val placeholder: String,
+        val isRequired: Boolean,
+    )
+
+    private val defaultSections = listOf(
+        DefaultSectionDef("회의 제목", SectionType.TEXT, "회의 제목을 입력하세요", true),
+        DefaultSectionDef("일시 / 장소", SectionType.DATETIME, "2024-01-01 14:00 / 대회의실", true),
+        DefaultSectionDef("참석자", SectionType.USER_LIST, "홍길동, 김철수, ...", true),
+        DefaultSectionDef("안건", SectionType.MARKDOWN, "논의할 주제를 입력하세요", true),
+        DefaultSectionDef("결정사항", SectionType.MARKDOWN, "합의된 내용을 입력하세요", false),
+        DefaultSectionDef("다음 회의 일정", SectionType.DATETIME, "다음 회의 일정을 입력하세요", false),
+    )
+
+    private fun findTemplateOrThrow(templateId: Long): MeetingNoteTemplate =
+        templateRepository.findById(templateId).orElseThrow {
+            ExpectedException("템플릿을 찾을 수 없습니다. id=$templateId", HttpStatus.NOT_FOUND)
+        }
+
+    private fun findSectionOrThrow(sectionId: Long): TemplateSection =
+        sectionRepository.findById(sectionId).orElseThrow {
+            ExpectedException("섹션을 찾을 수 없습니다. id=$sectionId", HttpStatus.NOT_FOUND)
+        }
+
+    private fun requireChannelMember(channelId: Long, userId: Long) {
+        if (!channelMemberRepository.existsByChannelIdAndUserId(channelId, userId)) {
+            throw ExpectedException("채널 멤버만 접근할 수 있습니다.", HttpStatus.FORBIDDEN)
+        }
+    }
+
+    private fun requireTemplateOwnership(template: MeetingNoteTemplate, channelId: Long) {
+        if (template.channelId != channelId) {
+            throw ExpectedException("템플릿을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+        }
+    }
+
+    private fun requireSectionOwnership(section: TemplateSection, templateId: Long) {
+        if (section.templateId != templateId) {
+            throw ExpectedException("섹션을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+        }
+    }
+
+    private fun parseSectionType(value: String): SectionType = try {
+        SectionType.valueOf(value.uppercase())
+    } catch (e: IllegalArgumentException) {
+        throw ExpectedException("유효하지 않은 섹션 타입입니다. type=$value", HttpStatus.BAD_REQUEST)
+    }
+
+    private fun toResponse(template: MeetingNoteTemplate): MeetingNoteTemplateResponse {
+        val sections = sectionRepository.findAllByTemplateIdOrderByIdAsc(template.id)
+            .map { TemplateSectionResponse.of(it) }
+        return MeetingNoteTemplateResponse.of(template, sections)
+    }
+
+    fun listTemplates(userId: Long, channelId: Long): List<MeetingNoteTemplateResponse> {
+        val channel = channelService.findChannelOrThrow(channelId)
+        requireChannelMember(channel.id, userId)
+        return templateRepository.findAllByChannelIdOrderByIdAsc(channelId).map { toResponse(it) }
+    }
+
+    fun getTemplate(userId: Long, channelId: Long, templateId: Long): MeetingNoteTemplateResponse {
+        val channel = channelService.findChannelOrThrow(channelId)
+        requireChannelMember(channel.id, userId)
+        val template = findTemplateOrThrow(templateId)
+        requireTemplateOwnership(template, channelId)
+        return toResponse(template)
+    }
+
+    @Transactional
+    fun createTemplate(userId: Long, channelId: Long, request: CreateMeetingNoteTemplateRequest): MeetingNoteTemplateResponse {
+        val channel = channelService.findChannelOrThrow(channelId)
+        requireChannelMember(channel.id, userId)
+        val template = templateRepository.save(
+            MeetingNoteTemplate(
+                channelId = channelId,
+                name = request.name,
+                isActive = false,
+                createdBy = userId,
+            )
+        )
+        return MeetingNoteTemplateResponse.of(template, emptyList())
+    }
+
+    @Transactional
+    fun updateTemplate(userId: Long, channelId: Long, templateId: Long, request: UpdateMeetingNoteTemplateRequest): MeetingNoteTemplateResponse {
+        val channel = channelService.findChannelOrThrow(channelId)
+        requireChannelMember(channel.id, userId)
+        val template = findTemplateOrThrow(templateId)
+        requireTemplateOwnership(template, channelId)
+        template.updateName(request.name)
+        return toResponse(template)
+    }
+
+    @Transactional
+    fun deleteTemplate(userId: Long, channelId: Long, templateId: Long) {
+        val channel = channelService.findChannelOrThrow(channelId)
+        requireChannelMember(channel.id, userId)
+        val template = findTemplateOrThrow(templateId)
+        requireTemplateOwnership(template, channelId)
+        if (template.isActive) {
+            throw ExpectedException("활성 템플릿은 삭제할 수 없습니다. 다른 템플릿을 활성화한 후 삭제해 주세요.", HttpStatus.BAD_REQUEST)
+        }
+        sectionRepository.deleteAll(sectionRepository.findAllByTemplateIdOrderByIdAsc(templateId))
+        templateRepository.delete(template)
+    }
+
+    @Transactional
+    fun activateTemplate(userId: Long, channelId: Long, templateId: Long): MeetingNoteTemplateResponse {
+        val channel = channelService.findChannelOrThrow(channelId)
+        requireChannelMember(channel.id, userId)
+        val template = findTemplateOrThrow(templateId)
+        requireTemplateOwnership(template, channelId)
+        templateRepository.findByChannelIdAndIsActiveTrue(channelId)
+            ?.takeIf { it.id != templateId }
+            ?.deactivate()
+        template.activate()
+        return toResponse(template)
+    }
+
+    @Transactional
+    fun addSection(userId: Long, channelId: Long, templateId: Long, request: CreateTemplateSectionRequest): TemplateSectionResponse {
+        val channel = channelService.findChannelOrThrow(channelId)
+        requireChannelMember(channel.id, userId)
+        val template = findTemplateOrThrow(templateId)
+        requireTemplateOwnership(template, channelId)
+        val section = sectionRepository.save(
+            TemplateSection(
+                templateId = templateId,
+                title = request.title,
+                type = parseSectionType(request.type),
+                placeholder = request.placeholder,
+                isRequired = request.isRequired,
+            )
+        )
+        return TemplateSectionResponse.of(section)
+    }
+
+    @Transactional
+    fun updateSection(userId: Long, channelId: Long, templateId: Long, sectionId: Long, request: UpdateTemplateSectionRequest): TemplateSectionResponse {
+        val channel = channelService.findChannelOrThrow(channelId)
+        requireChannelMember(channel.id, userId)
+        val template = findTemplateOrThrow(templateId)
+        requireTemplateOwnership(template, channelId)
+        val section = findSectionOrThrow(sectionId)
+        requireSectionOwnership(section, templateId)
+        section.update(
+            title = request.title,
+            type = request.type?.let { parseSectionType(it) },
+            placeholder = request.placeholder,
+            isRequired = request.isRequired,
+        )
+        return TemplateSectionResponse.of(section)
+    }
+
+    @Transactional
+    fun deleteSection(userId: Long, channelId: Long, templateId: Long, sectionId: Long) {
+        val channel = channelService.findChannelOrThrow(channelId)
+        requireChannelMember(channel.id, userId)
+        val template = findTemplateOrThrow(templateId)
+        requireTemplateOwnership(template, channelId)
+        val section = findSectionOrThrow(sectionId)
+        requireSectionOwnership(section, templateId)
+        sectionRepository.delete(section)
+    }
+
+    @Transactional
+    fun createDefaultTemplate(channel: Channel) {
+        val template = templateRepository.save(
+            MeetingNoteTemplate(
+                channelId = channel.id,
+                name = "${channel.name} - 회의록 템플릿",
+                isActive = true,
+                createdBy = channel.createdBy,
+            )
+        )
+        defaultSections.forEach { def ->
+            sectionRepository.save(
+                TemplateSection(
+                    templateId = template.id,
+                    title = def.title,
+                    type = def.type,
+                    placeholder = def.placeholder,
+                    isRequired = def.isRequired,
+                )
+            )
+        }
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteTemplateService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteTemplateService.kt
@@ -79,30 +79,38 @@ class MeetingNoteTemplateService(
         throw ExpectedException("유효하지 않은 섹션 타입입니다. type=$value", HttpStatus.BAD_REQUEST)
     }
 
-    private fun toResponse(template: MeetingNoteTemplate): MeetingNoteTemplateResponse {
-        val sections = sectionRepository.findAllByTemplateIdOrderByIdAsc(template.id)
+    @Transactional(readOnly = true)
+    fun listTemplates(userId: Long, channelId: Long): List<MeetingNoteTemplateResponse> {
+        requireChannelMember(channelId, userId)
+        requireChannelExists(channelId)
+        val templates = templateRepository.findAllByChannelIdOrderByIdAsc(channelId)
+        if (templates.isEmpty()) return emptyList()
+        val sectionsByTemplateId = sectionRepository
+            .findAllByTemplateIdInOrderByIdAsc(templates.map { it.id })
+            .groupBy { it.templateId }
+        return templates.map { template ->
+            MeetingNoteTemplateResponse.of(
+                template,
+                (sectionsByTemplateId[template.id] ?: emptyList()).map { TemplateSectionResponse.of(it) },
+            )
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun getTemplate(userId: Long, channelId: Long, templateId: Long): MeetingNoteTemplateResponse {
+        requireChannelMember(channelId, userId)
+        requireChannelExists(channelId)
+        val template = findTemplateOrThrow(templateId)
+        requireTemplateOwnership(template, channelId)
+        val sections = sectionRepository.findAllByTemplateIdOrderByIdAsc(templateId)
             .map { TemplateSectionResponse.of(it) }
         return MeetingNoteTemplateResponse.of(template, sections)
     }
 
-    fun listTemplates(userId: Long, channelId: Long): List<MeetingNoteTemplateResponse> {
-        requireChannelExists(channelId)
-        requireChannelMember(channelId, userId)
-        return templateRepository.findAllByChannelIdOrderByIdAsc(channelId).map { toResponse(it) }
-    }
-
-    fun getTemplate(userId: Long, channelId: Long, templateId: Long): MeetingNoteTemplateResponse {
-        requireChannelExists(channelId)
-        requireChannelMember(channelId, userId)
-        val template = findTemplateOrThrow(templateId)
-        requireTemplateOwnership(template, channelId)
-        return toResponse(template)
-    }
-
     @Transactional
     fun createTemplate(userId: Long, channelId: Long, request: CreateMeetingNoteTemplateRequest): MeetingNoteTemplateResponse {
-        requireChannelExists(channelId)
         requireChannelMember(channelId, userId)
+        requireChannelExists(channelId)
         val template = templateRepository.save(
             MeetingNoteTemplate(
                 channelId = channelId,
@@ -116,44 +124,47 @@ class MeetingNoteTemplateService(
 
     @Transactional
     fun updateTemplate(userId: Long, channelId: Long, templateId: Long, request: UpdateMeetingNoteTemplateRequest): MeetingNoteTemplateResponse {
-        requireChannelExists(channelId)
         requireChannelMember(channelId, userId)
+        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         template.updateName(request.name)
-        return toResponse(template)
+        val sections = sectionRepository.findAllByTemplateIdOrderByIdAsc(templateId)
+            .map { TemplateSectionResponse.of(it) }
+        return MeetingNoteTemplateResponse.of(template, sections)
     }
 
     @Transactional
     fun deleteTemplate(userId: Long, channelId: Long, templateId: Long) {
-        requireChannelExists(channelId)
         requireChannelMember(channelId, userId)
+        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         if (template.isActive) {
             throw ExpectedException("활성 템플릿은 삭제할 수 없습니다. 다른 템플릿을 활성화한 후 삭제해 주세요.", HttpStatus.BAD_REQUEST)
         }
-        sectionRepository.deleteAll(sectionRepository.findAllByTemplateIdOrderByIdAsc(templateId))
         templateRepository.delete(template)
     }
 
     @Transactional
     fun activateTemplate(userId: Long, channelId: Long, templateId: Long): MeetingNoteTemplateResponse {
-        requireChannelExists(channelId)
         requireChannelMember(channelId, userId)
+        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         templateRepository.findByChannelIdAndIsActiveTrue(channelId)
             ?.takeIf { it.id != templateId }
             ?.deactivate()
         template.activate()
-        return toResponse(template)
+        val sections = sectionRepository.findAllByTemplateIdOrderByIdAsc(templateId)
+            .map { TemplateSectionResponse.of(it) }
+        return MeetingNoteTemplateResponse.of(template, sections)
     }
 
     @Transactional
     fun addSection(userId: Long, channelId: Long, templateId: Long, request: CreateTemplateSectionRequest): TemplateSectionResponse {
-        requireChannelExists(channelId)
         requireChannelMember(channelId, userId)
+        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         val section = sectionRepository.save(
@@ -170,8 +181,8 @@ class MeetingNoteTemplateService(
 
     @Transactional
     fun updateSection(userId: Long, channelId: Long, templateId: Long, sectionId: Long, request: UpdateTemplateSectionRequest): TemplateSectionResponse {
-        requireChannelExists(channelId)
         requireChannelMember(channelId, userId)
+        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         val section = findSectionOrThrow(sectionId)
@@ -187,8 +198,8 @@ class MeetingNoteTemplateService(
 
     @Transactional
     fun deleteSection(userId: Long, channelId: Long, templateId: Long, sectionId: Long) {
-        requireChannelExists(channelId)
         requireChannelMember(channelId, userId)
+        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         val section = findSectionOrThrow(sectionId)
@@ -206,8 +217,8 @@ class MeetingNoteTemplateService(
                 createdBy = channel.createdBy,
             )
         )
-        defaultSections.forEach { def ->
-            sectionRepository.save(
+        sectionRepository.saveAll(
+            defaultSections.map { def ->
                 TemplateSection(
                     templateId = template.id,
                     title = def.title,
@@ -215,7 +226,7 @@ class MeetingNoteTemplateService(
                     placeholder = def.placeholder,
                     isRequired = def.isRequired,
                 )
-            )
-        }
+            }
+        )
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteTemplateService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteTemplateService.kt
@@ -6,7 +6,6 @@ import com.cowork.channel.domain.SectionType
 import com.cowork.channel.domain.TemplateSection
 import com.cowork.channel.dto.*
 import com.cowork.channel.repository.ChannelMemberRepository
-import com.cowork.channel.repository.ChannelRepository
 import com.cowork.channel.repository.MeetingNoteTemplateRepository
 import com.cowork.channel.repository.TemplateSectionRepository
 import org.springframework.http.HttpStatus
@@ -19,7 +18,6 @@ import team.themoment.sdk.exception.ExpectedException
 class MeetingNoteTemplateService(
     private val templateRepository: MeetingNoteTemplateRepository,
     private val sectionRepository: TemplateSectionRepository,
-    private val channelRepository: ChannelRepository,
     private val channelMemberRepository: ChannelMemberRepository,
 ) {
 
@@ -38,12 +36,6 @@ class MeetingNoteTemplateService(
         DefaultSectionDef("결정사항", SectionType.MARKDOWN, "합의된 내용을 입력하세요", false),
         DefaultSectionDef("다음 회의 일정", SectionType.DATETIME, "다음 회의 일정을 입력하세요", false),
     )
-
-    private fun requireChannelExists(channelId: Long) {
-        if (!channelRepository.existsById(channelId)) {
-            throw ExpectedException("채널을 찾을 수 없습니다. id=$channelId", HttpStatus.NOT_FOUND)
-        }
-    }
 
     private fun findTemplateOrThrow(templateId: Long): MeetingNoteTemplate =
         templateRepository.findById(templateId).orElseThrow {
@@ -82,7 +74,6 @@ class MeetingNoteTemplateService(
     @Transactional(readOnly = true)
     fun listTemplates(userId: Long, channelId: Long): List<MeetingNoteTemplateResponse> {
         requireChannelMember(channelId, userId)
-        requireChannelExists(channelId)
         val templates = templateRepository.findAllByChannelIdOrderByIdAsc(channelId)
         if (templates.isEmpty()) return emptyList()
         val sectionsByTemplateId = sectionRepository
@@ -99,7 +90,6 @@ class MeetingNoteTemplateService(
     @Transactional(readOnly = true)
     fun getTemplate(userId: Long, channelId: Long, templateId: Long): MeetingNoteTemplateResponse {
         requireChannelMember(channelId, userId)
-        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         val sections = sectionRepository.findAllByTemplateIdOrderByIdAsc(templateId)
@@ -110,7 +100,6 @@ class MeetingNoteTemplateService(
     @Transactional
     fun createTemplate(userId: Long, channelId: Long, request: CreateMeetingNoteTemplateRequest): MeetingNoteTemplateResponse {
         requireChannelMember(channelId, userId)
-        requireChannelExists(channelId)
         val template = templateRepository.save(
             MeetingNoteTemplate(
                 channelId = channelId,
@@ -125,7 +114,6 @@ class MeetingNoteTemplateService(
     @Transactional
     fun updateTemplate(userId: Long, channelId: Long, templateId: Long, request: UpdateMeetingNoteTemplateRequest): MeetingNoteTemplateResponse {
         requireChannelMember(channelId, userId)
-        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         template.updateName(request.name)
@@ -137,7 +125,6 @@ class MeetingNoteTemplateService(
     @Transactional
     fun deleteTemplate(userId: Long, channelId: Long, templateId: Long) {
         requireChannelMember(channelId, userId)
-        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         if (template.isActive) {
@@ -149,7 +136,6 @@ class MeetingNoteTemplateService(
     @Transactional
     fun activateTemplate(userId: Long, channelId: Long, templateId: Long): MeetingNoteTemplateResponse {
         requireChannelMember(channelId, userId)
-        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         templateRepository.findByChannelIdAndIsActiveTrue(channelId)
@@ -164,7 +150,6 @@ class MeetingNoteTemplateService(
     @Transactional
     fun addSection(userId: Long, channelId: Long, templateId: Long, request: CreateTemplateSectionRequest): TemplateSectionResponse {
         requireChannelMember(channelId, userId)
-        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         val section = sectionRepository.save(
@@ -182,7 +167,6 @@ class MeetingNoteTemplateService(
     @Transactional
     fun updateSection(userId: Long, channelId: Long, templateId: Long, sectionId: Long, request: UpdateTemplateSectionRequest): TemplateSectionResponse {
         requireChannelMember(channelId, userId)
-        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         val section = findSectionOrThrow(sectionId)
@@ -199,7 +183,6 @@ class MeetingNoteTemplateService(
     @Transactional
     fun deleteSection(userId: Long, channelId: Long, templateId: Long, sectionId: Long) {
         requireChannelMember(channelId, userId)
-        requireChannelExists(channelId)
         val template = findTemplateOrThrow(templateId)
         requireTemplateOwnership(template, channelId)
         val section = findSectionOrThrow(sectionId)

--- a/cowork-channel/src/main/resources/db/migration/V10__add_meeting_note_tables.sql
+++ b/cowork-channel/src/main/resources/db/migration/V10__add_meeting_note_tables.sql
@@ -1,0 +1,18 @@
+CREATE TABLE tb_meeting_notes
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    channel_id  BIGINT       NOT NULL COMMENT 'tb_channels.id',
+    template_id BIGINT       NOT NULL COMMENT 'tb_meeting_note_templates.id',
+    title       VARCHAR(200) NOT NULL,
+    content     JSON         NOT NULL COMMENT '섹션별 작성 내용 JSON 블록',
+    created_by  BIGINT       NOT NULL COMMENT 'cowork-user의 tb_users.id',
+    created_at  DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at  DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    INDEX idx_tb_meeting_notes_channel_id (channel_id),
+    INDEX idx_tb_meeting_notes_template_id (template_id),
+    CONSTRAINT fk_tb_meeting_notes_channel FOREIGN KEY (channel_id) REFERENCES tb_channels (id) ON DELETE CASCADE,
+    CONSTRAINT fk_tb_meeting_notes_template FOREIGN KEY (template_id) REFERENCES tb_meeting_note_templates (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/cowork-channel/src/main/resources/db/migration/V9__add_meeting_note_template_tables.sql
+++ b/cowork-channel/src/main/resources/db/migration/V9__add_meeting_note_template_tables.sql
@@ -1,0 +1,29 @@
+CREATE TABLE tb_meeting_note_templates
+(
+    id         BIGINT       NOT NULL AUTO_INCREMENT,
+    channel_id BIGINT       NOT NULL COMMENT 'tb_channels.id',
+    name       VARCHAR(100) NOT NULL,
+    is_active  TINYINT(1)   NOT NULL DEFAULT 0,
+    created_by BIGINT       NOT NULL,
+    created_at DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    INDEX idx_tb_meeting_note_templates_channel_id (channel_id),
+    INDEX idx_tb_meeting_note_templates_channel_id_is_active (channel_id, is_active),
+    CONSTRAINT fk_tb_meeting_note_templates_channel FOREIGN KEY (channel_id) REFERENCES tb_channels (id) ON DELETE CASCADE
+);
+
+CREATE TABLE tb_meeting_note_template_sections
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    template_id BIGINT       NOT NULL COMMENT 'tb_meeting_note_templates.id',
+    title       VARCHAR(100) NOT NULL,
+    type        VARCHAR(20)  NOT NULL COMMENT 'TEXT, MARKDOWN, DATE, DATETIME, USER_LIST',
+    placeholder VARCHAR(255),
+    is_required TINYINT(1)   NOT NULL DEFAULT 0,
+    created_at  DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at  DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    INDEX idx_tb_meeting_note_template_sections_template_id (template_id),
+    CONSTRAINT fk_tb_meeting_note_template_sections_template FOREIGN KEY (template_id) REFERENCES tb_meeting_note_templates (id) ON DELETE CASCADE
+);

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
@@ -34,8 +34,9 @@ class ChannelServiceTest {
     private val channelMemberEventPublisher = mockk<ChannelMemberEventPublisher>(relaxed = true)
     private val channelMembershipSyncPublisher = mockk<ChannelMembershipSyncPublisher>(relaxed = true)
     private val projectClient = mockk<ProjectClient>()
+    private val meetingNoteTemplateService = mockk<MeetingNoteTemplateService>(relaxed = true)
 
-    private val service = ChannelService(channelRepository, channelMemberRepository, teamPermission, channelMemberEventPublisher, channelMembershipSyncPublisher, projectClient)
+    private val service = ChannelService(channelRepository, channelMemberRepository, teamPermission, channelMemberEventPublisher, channelMembershipSyncPublisher, projectClient, meetingNoteTemplateService)
 
     @BeforeEach
     fun setUp() {

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteTemplateServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteTemplateServiceTest.kt
@@ -3,6 +3,7 @@ package com.cowork.channel.service
 import com.cowork.channel.domain.*
 import com.cowork.channel.dto.*
 import com.cowork.channel.repository.ChannelMemberRepository
+import com.cowork.channel.repository.ChannelRepository
 import com.cowork.channel.repository.MeetingNoteTemplateRepository
 import com.cowork.channel.repository.TemplateSectionRepository
 import io.mockk.*
@@ -16,11 +17,11 @@ class MeetingNoteTemplateServiceTest {
 
     private val templateRepository = mockk<MeetingNoteTemplateRepository>(relaxed = true)
     private val sectionRepository = mockk<TemplateSectionRepository>(relaxed = true)
-    private val channelService = mockk<ChannelService>()
+    private val channelRepository = mockk<ChannelRepository>()
     private val channelMemberRepository = mockk<ChannelMemberRepository>()
 
     private val service = MeetingNoteTemplateService(
-        templateRepository, sectionRepository, channelService, channelMemberRepository
+        templateRepository, sectionRepository, channelRepository, channelMemberRepository
     )
 
     private fun channel(id: Long = 1L, name: String = "ch", createdBy: Long = 1L) = Channel(
@@ -48,7 +49,7 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `listTemplates는 채널 멤버이면 목록 반환`() {
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findAllByChannelIdOrderByIdAsc(1L) } returns listOf(template())
         every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns emptyList()
@@ -60,7 +61,7 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `listTemplates는 채널 비멤버이면 FORBIDDEN`() {
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns false
 
         val ex = assertThrows(ExpectedException::class.java) {
@@ -73,7 +74,7 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `getTemplate은 섹션을 포함해서 반환`() {
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template())
         every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns listOf(section())
@@ -85,7 +86,7 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `getTemplate은 다른 채널 템플릿이면 NOT_FOUND`() {
-        every { channelService.findChannelOrThrow(1L) } returns channel(id = 1L)
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template(channelId = 999L))
 
@@ -97,7 +98,7 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `getTemplate은 존재하지 않는 id이면 NOT_FOUND`() {
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(999L) } returns Optional.empty()
 
@@ -111,7 +112,7 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `createTemplate은 isActive=false로 저장되고 sections는 빈 리스트`() {
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         val saved = slot<MeetingNoteTemplate>()
         every { templateRepository.save(capture(saved)) } answers { saved.captured }
@@ -128,7 +129,7 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `updateTemplate은 이름을 수정함`() {
         val tmpl = template(name = "old")
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(tmpl)
         every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns emptyList()
@@ -142,7 +143,7 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `deleteTemplate은 활성 템플릿이면 BAD_REQUEST`() {
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template(isActive = true))
 
@@ -157,7 +158,7 @@ class MeetingNoteTemplateServiceTest {
     fun `deleteTemplate은 비활성 템플릿은 섹션과 함께 삭제`() {
         val tmpl = template(isActive = false)
         val sec = section()
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(tmpl)
         every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns listOf(sec)
@@ -174,7 +175,7 @@ class MeetingNoteTemplateServiceTest {
     fun `activateTemplate은 기존 활성 템플릿을 비활성화하고 대상을 활성화`() {
         val current = template(id = 5L, isActive = true)
         val next = template(id = 10L, isActive = false)
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(next)
         every { templateRepository.findByChannelIdAndIsActiveTrue(1L) } returns current
@@ -189,7 +190,7 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `activateTemplate은 이미 활성 상태인 템플릿을 다시 활성화해도 오류 없음`() {
         val tmpl = template(id = 10L, isActive = true)
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(tmpl)
         every { templateRepository.findByChannelIdAndIsActiveTrue(1L) } returns tmpl
@@ -202,7 +203,7 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `activateTemplate은 기존 활성 템플릿이 없어도 정상 동작`() {
         val next = template(id = 10L, isActive = false)
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(next)
         every { templateRepository.findByChannelIdAndIsActiveTrue(1L) } returns null
@@ -216,7 +217,7 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `addSection은 섹션 타입을 파싱해서 저장`() {
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template())
         val saved = slot<TemplateSection>()
@@ -230,7 +231,7 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `addSection은 유효하지 않은 타입이면 BAD_REQUEST`() {
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template())
 
@@ -245,7 +246,7 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `updateSection은 전달된 필드만 수정`() {
         val sec = section(type = SectionType.TEXT)
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template())
         every { sectionRepository.findById(20L) } returns Optional.of(sec)
@@ -257,7 +258,7 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `updateSection은 다른 템플릿의 섹션이면 NOT_FOUND`() {
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template(id = 10L))
         every { sectionRepository.findById(20L) } returns Optional.of(section(templateId = 999L))
@@ -273,7 +274,7 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `deleteSection은 정상적으로 섹션을 삭제`() {
         val sec = section()
-        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template())
         every { sectionRepository.findById(20L) } returns Optional.of(sec)

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteTemplateServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteTemplateServiceTest.kt
@@ -49,10 +49,10 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `listTemplates는 채널 멤버이면 목록 반환`() {
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { channelRepository.existsById(1L) } returns true
         every { templateRepository.findAllByChannelIdOrderByIdAsc(1L) } returns listOf(template())
-        every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns emptyList()
+        every { sectionRepository.findAllByTemplateIdInOrderByIdAsc(listOf(10L)) } returns emptyList()
 
         val result = service.listTemplates(7L, 1L)
         assertEquals(1, result.size)
@@ -155,17 +155,15 @@ class MeetingNoteTemplateServiceTest {
     }
 
     @Test
-    fun `deleteTemplate은 비활성 템플릿은 섹션과 함께 삭제`() {
+    fun `deleteTemplate은 비활성 템플릿을 삭제`() {
         val tmpl = template(isActive = false)
-        val sec = section()
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { channelRepository.existsById(1L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(tmpl)
-        every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns listOf(sec)
 
         service.deleteTemplate(7L, 1L, 10L)
 
-        verify { sectionRepository.deleteAll(listOf(sec)) }
+        verify(exactly = 0) { sectionRepository.deleteAll(any<List<TemplateSection>>()) }
         verify { templateRepository.delete(tmpl) }
     }
 
@@ -290,14 +288,16 @@ class MeetingNoteTemplateServiceTest {
         val ch = channel(id = 1L, name = "기획 회의", createdBy = 5L)
         val savedTemplate = slot<MeetingNoteTemplate>()
         every { templateRepository.save(capture(savedTemplate)) } answers { savedTemplate.captured.also { it.javaClass.getDeclaredField("id").also { f -> f.isAccessible = true }.set(it, 10L) } }
-        every { sectionRepository.save(any<TemplateSection>()) } answers { firstArg() }
+        every { sectionRepository.saveAll(any<List<TemplateSection>>()) } answers { firstArg() }
 
         service.createDefaultTemplate(ch)
 
         assertEquals("기획 회의 - 회의록 템플릿", savedTemplate.captured.name)
         assertTrue(savedTemplate.captured.isActive)
         assertEquals(5L, savedTemplate.captured.createdBy)
-        verify(exactly = 6) { sectionRepository.save(any<TemplateSection>()) }
+        val savedSectionsSlot = slot<List<TemplateSection>>()
+        verify { sectionRepository.saveAll(capture(savedSectionsSlot)) }
+        assertEquals(6, savedSectionsSlot.captured.size)
     }
 
     @Test
@@ -305,14 +305,12 @@ class MeetingNoteTemplateServiceTest {
         val ch = channel()
         val savedTemplate = slot<MeetingNoteTemplate>()
         every { templateRepository.save(capture(savedTemplate)) } answers { savedTemplate.captured.also { it.javaClass.getDeclaredField("id").also { f -> f.isAccessible = true }.set(it, 10L) } }
-        val savedSections = mutableListOf<TemplateSection>()
-        every { sectionRepository.save(any<TemplateSection>()) } answers {
-            (firstArg<TemplateSection>()).also { savedSections.add(it) }
-        }
+        val savedSectionsSlot = slot<List<TemplateSection>>()
+        every { sectionRepository.saveAll(capture(savedSectionsSlot)) } answers { firstArg() }
 
         service.createDefaultTemplate(ch)
 
-        val types = savedSections.map { it.type }
+        val types = savedSectionsSlot.captured.map { it.type }
         assertEquals(SectionType.TEXT, types[0])
         assertEquals(SectionType.DATETIME, types[1])
         assertEquals(SectionType.USER_LIST, types[2])
@@ -326,14 +324,12 @@ class MeetingNoteTemplateServiceTest {
         val ch = channel()
         val savedTemplate = slot<MeetingNoteTemplate>()
         every { templateRepository.save(capture(savedTemplate)) } answers { savedTemplate.captured.also { it.javaClass.getDeclaredField("id").also { f -> f.isAccessible = true }.set(it, 10L) } }
-        val savedSections = mutableListOf<TemplateSection>()
-        every { sectionRepository.save(any<TemplateSection>()) } answers {
-            (firstArg<TemplateSection>()).also { savedSections.add(it) }
-        }
+        val savedSectionsSlot = slot<List<TemplateSection>>()
+        every { sectionRepository.saveAll(capture(savedSectionsSlot)) } answers { firstArg() }
 
         service.createDefaultTemplate(ch)
 
-        assertEquals(4, savedSections.count { it.isRequired })
-        assertEquals(2, savedSections.count { !it.isRequired })
+        assertEquals(4, savedSectionsSlot.captured.count { it.isRequired })
+        assertEquals(2, savedSectionsSlot.captured.count { !it.isRequired })
     }
 }

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteTemplateServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteTemplateServiceTest.kt
@@ -3,7 +3,6 @@ package com.cowork.channel.service
 import com.cowork.channel.domain.*
 import com.cowork.channel.dto.*
 import com.cowork.channel.repository.ChannelMemberRepository
-import com.cowork.channel.repository.ChannelRepository
 import com.cowork.channel.repository.MeetingNoteTemplateRepository
 import com.cowork.channel.repository.TemplateSectionRepository
 import io.mockk.*
@@ -17,11 +16,10 @@ class MeetingNoteTemplateServiceTest {
 
     private val templateRepository = mockk<MeetingNoteTemplateRepository>(relaxed = true)
     private val sectionRepository = mockk<TemplateSectionRepository>(relaxed = true)
-    private val channelRepository = mockk<ChannelRepository>()
     private val channelMemberRepository = mockk<ChannelMemberRepository>()
 
     private val service = MeetingNoteTemplateService(
-        templateRepository, sectionRepository, channelRepository, channelMemberRepository
+        templateRepository, sectionRepository, channelMemberRepository
     )
 
     private fun channel(id: Long = 1L, name: String = "ch", createdBy: Long = 1L) = Channel(
@@ -50,7 +48,6 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `listTemplates는 채널 멤버이면 목록 반환`() {
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
-        every { channelRepository.existsById(1L) } returns true
         every { templateRepository.findAllByChannelIdOrderByIdAsc(1L) } returns listOf(template())
         every { sectionRepository.findAllByTemplateIdInOrderByIdAsc(listOf(10L)) } returns emptyList()
 
@@ -61,7 +58,6 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `listTemplates는 채널 비멤버이면 FORBIDDEN`() {
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns false
 
         val ex = assertThrows(ExpectedException::class.java) {
@@ -74,7 +70,6 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `getTemplate은 섹션을 포함해서 반환`() {
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template())
         every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns listOf(section())
@@ -86,7 +81,6 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `getTemplate은 다른 채널 템플릿이면 NOT_FOUND`() {
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template(channelId = 999L))
 
@@ -98,7 +92,6 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `getTemplate은 존재하지 않는 id이면 NOT_FOUND`() {
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(999L) } returns Optional.empty()
 
@@ -112,7 +105,6 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `createTemplate은 isActive=false로 저장되고 sections는 빈 리스트`() {
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         val saved = slot<MeetingNoteTemplate>()
         every { templateRepository.save(capture(saved)) } answers { saved.captured }
@@ -129,7 +121,6 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `updateTemplate은 이름을 수정함`() {
         val tmpl = template(name = "old")
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(tmpl)
         every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns emptyList()
@@ -143,7 +134,6 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `deleteTemplate은 활성 템플릿이면 BAD_REQUEST`() {
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template(isActive = true))
 
@@ -158,7 +148,6 @@ class MeetingNoteTemplateServiceTest {
     fun `deleteTemplate은 비활성 템플릿을 삭제`() {
         val tmpl = template(isActive = false)
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
-        every { channelRepository.existsById(1L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(tmpl)
 
         service.deleteTemplate(7L, 1L, 10L)
@@ -173,7 +162,6 @@ class MeetingNoteTemplateServiceTest {
     fun `activateTemplate은 기존 활성 템플릿을 비활성화하고 대상을 활성화`() {
         val current = template(id = 5L, isActive = true)
         val next = template(id = 10L, isActive = false)
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(next)
         every { templateRepository.findByChannelIdAndIsActiveTrue(1L) } returns current
@@ -188,7 +176,6 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `activateTemplate은 이미 활성 상태인 템플릿을 다시 활성화해도 오류 없음`() {
         val tmpl = template(id = 10L, isActive = true)
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(tmpl)
         every { templateRepository.findByChannelIdAndIsActiveTrue(1L) } returns tmpl
@@ -201,7 +188,6 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `activateTemplate은 기존 활성 템플릿이 없어도 정상 동작`() {
         val next = template(id = 10L, isActive = false)
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(next)
         every { templateRepository.findByChannelIdAndIsActiveTrue(1L) } returns null
@@ -215,7 +201,6 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `addSection은 섹션 타입을 파싱해서 저장`() {
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template())
         val saved = slot<TemplateSection>()
@@ -229,7 +214,6 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `addSection은 유효하지 않은 타입이면 BAD_REQUEST`() {
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template())
 
@@ -244,7 +228,6 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `updateSection은 전달된 필드만 수정`() {
         val sec = section(type = SectionType.TEXT)
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template())
         every { sectionRepository.findById(20L) } returns Optional.of(sec)
@@ -256,7 +239,6 @@ class MeetingNoteTemplateServiceTest {
 
     @Test
     fun `updateSection은 다른 템플릿의 섹션이면 NOT_FOUND`() {
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template(id = 10L))
         every { sectionRepository.findById(20L) } returns Optional.of(section(templateId = 999L))
@@ -272,7 +254,6 @@ class MeetingNoteTemplateServiceTest {
     @Test
     fun `deleteSection은 정상적으로 섹션을 삭제`() {
         val sec = section()
-        every { channelRepository.existsById(1L) } returns true
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
         every { templateRepository.findById(10L) } returns Optional.of(template())
         every { sectionRepository.findById(20L) } returns Optional.of(sec)

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteTemplateServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteTemplateServiceTest.kt
@@ -1,0 +1,338 @@
+package com.cowork.channel.service
+
+import com.cowork.channel.domain.*
+import com.cowork.channel.dto.*
+import com.cowork.channel.repository.ChannelMemberRepository
+import com.cowork.channel.repository.MeetingNoteTemplateRepository
+import com.cowork.channel.repository.TemplateSectionRepository
+import io.mockk.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import team.themoment.sdk.exception.ExpectedException
+import java.util.Optional
+
+class MeetingNoteTemplateServiceTest {
+
+    private val templateRepository = mockk<MeetingNoteTemplateRepository>(relaxed = true)
+    private val sectionRepository = mockk<TemplateSectionRepository>(relaxed = true)
+    private val channelService = mockk<ChannelService>()
+    private val channelMemberRepository = mockk<ChannelMemberRepository>()
+
+    private val service = MeetingNoteTemplateService(
+        templateRepository, sectionRepository, channelService, channelMemberRepository
+    )
+
+    private fun channel(id: Long = 1L, name: String = "ch", createdBy: Long = 1L) = Channel(
+        id = id, teamId = 100L, name = name, type = ChannelType.TEXT,
+        viewType = ChannelViewType.MEETING_NOTE, description = null,
+        isPrivate = false, createdBy = createdBy,
+    )
+
+    private fun template(
+        id: Long = 10L,
+        channelId: Long = 1L,
+        name: String = "기본 템플릿",
+        isActive: Boolean = false,
+        createdBy: Long = 1L,
+    ) = MeetingNoteTemplate(id = id, channelId = channelId, name = name, isActive = isActive, createdBy = createdBy)
+
+    private fun section(
+        id: Long = 20L,
+        templateId: Long = 10L,
+        title: String = "회의 제목",
+        type: SectionType = SectionType.TEXT,
+    ) = TemplateSection(id = id, templateId = templateId, title = title, type = type)
+
+    // ──────────────────────────── listTemplates ────────────────────────────
+
+    @Test
+    fun `listTemplates는 채널 멤버이면 목록 반환`() {
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findAllByChannelIdOrderByIdAsc(1L) } returns listOf(template())
+        every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns emptyList()
+
+        val result = service.listTemplates(7L, 1L)
+        assertEquals(1, result.size)
+        assertEquals(10L, result[0].id)
+    }
+
+    @Test
+    fun `listTemplates는 채널 비멤버이면 FORBIDDEN`() {
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns false
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.listTemplates(7L, 1L)
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    // ──────────────────────────── getTemplate ────────────────────────────
+
+    @Test
+    fun `getTemplate은 섹션을 포함해서 반환`() {
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(template())
+        every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns listOf(section())
+
+        val result = service.getTemplate(7L, 1L, 10L)
+        assertEquals(1, result.sections.size)
+        assertEquals("회의 제목", result.sections[0].title)
+    }
+
+    @Test
+    fun `getTemplate은 다른 채널 템플릿이면 NOT_FOUND`() {
+        every { channelService.findChannelOrThrow(1L) } returns channel(id = 1L)
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(template(channelId = 999L))
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.getTemplate(7L, 1L, 10L)
+        }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+
+    @Test
+    fun `getTemplate은 존재하지 않는 id이면 NOT_FOUND`() {
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(999L) } returns Optional.empty()
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.getTemplate(7L, 1L, 999L)
+        }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+
+    // ──────────────────────────── createTemplate ────────────────────────────
+
+    @Test
+    fun `createTemplate은 isActive=false로 저장되고 sections는 빈 리스트`() {
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        val saved = slot<MeetingNoteTemplate>()
+        every { templateRepository.save(capture(saved)) } answers { saved.captured }
+
+        val result = service.createTemplate(7L, 1L, CreateMeetingNoteTemplateRequest("스프린트 회의"))
+        assertEquals("스프린트 회의", result.name)
+        assertFalse(result.isActive)
+        assertTrue(result.sections.isEmpty())
+        assertFalse(saved.captured.isActive)
+    }
+
+    // ──────────────────────────── updateTemplate ────────────────────────────
+
+    @Test
+    fun `updateTemplate은 이름을 수정함`() {
+        val tmpl = template(name = "old")
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(tmpl)
+        every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns emptyList()
+
+        val result = service.updateTemplate(7L, 1L, 10L, UpdateMeetingNoteTemplateRequest("new"))
+        assertEquals("new", result.name)
+        assertEquals("new", tmpl.name)
+    }
+
+    // ──────────────────────────── deleteTemplate ────────────────────────────
+
+    @Test
+    fun `deleteTemplate은 활성 템플릿이면 BAD_REQUEST`() {
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(template(isActive = true))
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.deleteTemplate(7L, 1L, 10L)
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+        verify(exactly = 0) { templateRepository.delete(any()) }
+    }
+
+    @Test
+    fun `deleteTemplate은 비활성 템플릿은 섹션과 함께 삭제`() {
+        val tmpl = template(isActive = false)
+        val sec = section()
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(tmpl)
+        every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns listOf(sec)
+
+        service.deleteTemplate(7L, 1L, 10L)
+
+        verify { sectionRepository.deleteAll(listOf(sec)) }
+        verify { templateRepository.delete(tmpl) }
+    }
+
+    // ──────────────────────────── activateTemplate ────────────────────────────
+
+    @Test
+    fun `activateTemplate은 기존 활성 템플릿을 비활성화하고 대상을 활성화`() {
+        val current = template(id = 5L, isActive = true)
+        val next = template(id = 10L, isActive = false)
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(next)
+        every { templateRepository.findByChannelIdAndIsActiveTrue(1L) } returns current
+        every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns emptyList()
+
+        service.activateTemplate(7L, 1L, 10L)
+
+        assertFalse(current.isActive)
+        assertTrue(next.isActive)
+    }
+
+    @Test
+    fun `activateTemplate은 이미 활성 상태인 템플릿을 다시 활성화해도 오류 없음`() {
+        val tmpl = template(id = 10L, isActive = true)
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(tmpl)
+        every { templateRepository.findByChannelIdAndIsActiveTrue(1L) } returns tmpl
+        every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns emptyList()
+
+        service.activateTemplate(7L, 1L, 10L)
+        assertTrue(tmpl.isActive)
+    }
+
+    @Test
+    fun `activateTemplate은 기존 활성 템플릿이 없어도 정상 동작`() {
+        val next = template(id = 10L, isActive = false)
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(next)
+        every { templateRepository.findByChannelIdAndIsActiveTrue(1L) } returns null
+        every { sectionRepository.findAllByTemplateIdOrderByIdAsc(10L) } returns emptyList()
+
+        service.activateTemplate(7L, 1L, 10L)
+        assertTrue(next.isActive)
+    }
+
+    // ──────────────────────────── addSection ────────────────────────────
+
+    @Test
+    fun `addSection은 섹션 타입을 파싱해서 저장`() {
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(template())
+        val saved = slot<TemplateSection>()
+        every { sectionRepository.save(capture(saved)) } answers { saved.captured }
+
+        val result = service.addSection(7L, 1L, 10L, CreateTemplateSectionRequest("비고", "MARKDOWN", isRequired = false))
+        assertEquals("비고", result.title)
+        assertEquals("MARKDOWN", result.type)
+        assertEquals(SectionType.MARKDOWN, saved.captured.type)
+    }
+
+    @Test
+    fun `addSection은 유효하지 않은 타입이면 BAD_REQUEST`() {
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(template())
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.addSection(7L, 1L, 10L, CreateTemplateSectionRequest("x", "INVALID"))
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    // ──────────────────────────── updateSection ────────────────────────────
+
+    @Test
+    fun `updateSection은 전달된 필드만 수정`() {
+        val sec = section(type = SectionType.TEXT)
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(template())
+        every { sectionRepository.findById(20L) } returns Optional.of(sec)
+
+        val result = service.updateSection(7L, 1L, 10L, 20L, UpdateTemplateSectionRequest(title = "수정된 제목"))
+        assertEquals("수정된 제목", result.title)
+        assertEquals("TEXT", result.type)
+    }
+
+    @Test
+    fun `updateSection은 다른 템플릿의 섹션이면 NOT_FOUND`() {
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(template(id = 10L))
+        every { sectionRepository.findById(20L) } returns Optional.of(section(templateId = 999L))
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.updateSection(7L, 1L, 10L, 20L, UpdateTemplateSectionRequest(title = "x"))
+        }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+
+    // ──────────────────────────── deleteSection ────────────────────────────
+
+    @Test
+    fun `deleteSection은 정상적으로 섹션을 삭제`() {
+        val sec = section()
+        every { channelService.findChannelOrThrow(1L) } returns channel()
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { templateRepository.findById(10L) } returns Optional.of(template())
+        every { sectionRepository.findById(20L) } returns Optional.of(sec)
+
+        service.deleteSection(7L, 1L, 10L, 20L)
+        verify { sectionRepository.delete(sec) }
+    }
+
+    // ──────────────────────────── createDefaultTemplate ────────────────────────────
+
+    @Test
+    fun `createDefaultTemplate은 채널명으로 이름 설정 후 isActive=true로 저장`() {
+        val ch = channel(id = 1L, name = "기획 회의", createdBy = 5L)
+        val savedTemplate = slot<MeetingNoteTemplate>()
+        every { templateRepository.save(capture(savedTemplate)) } answers { savedTemplate.captured.also { it.javaClass.getDeclaredField("id").also { f -> f.isAccessible = true }.set(it, 10L) } }
+        every { sectionRepository.save(any<TemplateSection>()) } answers { firstArg() }
+
+        service.createDefaultTemplate(ch)
+
+        assertEquals("기획 회의 - 회의록 템플릿", savedTemplate.captured.name)
+        assertTrue(savedTemplate.captured.isActive)
+        assertEquals(5L, savedTemplate.captured.createdBy)
+        verify(exactly = 6) { sectionRepository.save(any<TemplateSection>()) }
+    }
+
+    @Test
+    fun `createDefaultTemplate은 기본 섹션 6개를 올바른 타입으로 생성`() {
+        val ch = channel()
+        val savedTemplate = slot<MeetingNoteTemplate>()
+        every { templateRepository.save(capture(savedTemplate)) } answers { savedTemplate.captured.also { it.javaClass.getDeclaredField("id").also { f -> f.isAccessible = true }.set(it, 10L) } }
+        val savedSections = mutableListOf<TemplateSection>()
+        every { sectionRepository.save(any<TemplateSection>()) } answers {
+            (firstArg<TemplateSection>()).also { savedSections.add(it) }
+        }
+
+        service.createDefaultTemplate(ch)
+
+        val types = savedSections.map { it.type }
+        assertEquals(SectionType.TEXT, types[0])
+        assertEquals(SectionType.DATETIME, types[1])
+        assertEquals(SectionType.USER_LIST, types[2])
+        assertEquals(SectionType.MARKDOWN, types[3])
+        assertEquals(SectionType.MARKDOWN, types[4])
+        assertEquals(SectionType.DATETIME, types[5])
+    }
+
+    @Test
+    fun `createDefaultTemplate은 필수 섹션 4개, 선택 섹션 2개를 생성`() {
+        val ch = channel()
+        val savedTemplate = slot<MeetingNoteTemplate>()
+        every { templateRepository.save(capture(savedTemplate)) } answers { savedTemplate.captured.also { it.javaClass.getDeclaredField("id").also { f -> f.isAccessible = true }.set(it, 10L) } }
+        val savedSections = mutableListOf<TemplateSection>()
+        every { sectionRepository.save(any<TemplateSection>()) } answers {
+            (firstArg<TemplateSection>()).also { savedSections.add(it) }
+        }
+
+        service.createDefaultTemplate(ch)
+
+        assertEquals(4, savedSections.count { it.isRequired })
+        assertEquals(2, savedSections.count { !it.isRequired })
+    }
+}


### PR DESCRIPTION
## 개요

`MEETING_NOTE` 뷰타입 채널 생성 시 기본 회의록 템플릿을 자동으로 생성하는 기능을 구현하였습니다. 템플릿·섹션 도메인과 CRUD API를 함께 추가하였습니다.

## 본문

### 구현 범위

- `tb_meeting_note_templates` / `tb_meeting_note_template_sections` 테이블 추가 (Flyway V9)
- `MeetingNoteTemplate` / `TemplateSection` JPA 엔티티
- `SectionType` enum: `TEXT`, `MARKDOWN`, `DATE`, `DATETIME`, `USER_LIST`
- `/channels/{channelId}/meeting-note-templates` 하위 CRUD API 9개
- `MEETING_NOTE` 채널 생성 시 기본 템플릿 6섹션 자동 생성
- `MeetingNoteTemplateService` 단위 테스트 20개

---

### 구현 방식 (리뷰 포인트)

**1. 저장소: MySQL 사용**

별도 MongoDB 컬렉션 없이 기존 MySQL DB에 테이블 2개를 추가하였습니다. `tb_meeting_note_template_sections`는 `tb_meeting_note_templates`를 FK로 참조하며, `tb_meeting_note_templates`는 `tb_channels`를 FK(`ON DELETE CASCADE`)로 참조합니다. 채널 삭제 시 DB 레벨에서 자동 정리되므로 서비스 코드에 별도 삭제 로직은 추가하지 않았습니다.

**2. 자동 생성 트리거: `afterCommit()` 콜백**

채널 생성 트랜잭션이 커밋된 직후 `TransactionSynchronizationManager.afterCommit()` 블록에서 기본 템플릿을 생성합니다. 기존 Kafka 스냅샷 발행과 같은 방식입니다.

```
채널 저장(MySQL) → 트랜잭션 커밋 → afterCommit → 기본 템플릿 생성(MySQL) + Kafka 발행
```

채널과 템플릿이 동일 DB에 있어 원자성은 보장되지 않지만, 템플릿 생성 실패 시 API로 수동 생성이 가능하므로 현재는 best-effort로 처리하였습니다.

**3. 활성 템플릿 관리: `isActive` Boolean 필드**

채널당 여러 개의 템플릿을 가질 수 있으며, 그 중 하나만 활성 상태(`isActive = true`)입니다. `PATCH /activate` 호출 시 기존 활성 템플릿을 비활성화하고 대상을 활성화합니다. 활성 템플릿은 삭제할 수 없으며(400 반환), 먼저 다른 템플릿을 활성화해야 합니다.

**4. 섹션 순서: id 오름차순**

별도 `position` 컬럼 없이 삽입 순서(= id 오름차순)를 표시 순서로 사용합니다. 순서 변경 API는 미구현 상태입니다.

**5. `MARKDOWN` 섹션 타입 추가**

안건·결정사항처럼 서식이 필요한 섹션을 위해 `MARKDOWN` 타입을 추가하였습니다. 클라이언트에서 타입에 따라 평문 입력 필드와 마크다운 에디터를 구분해 렌더링하는 것을 상정하였습니다.

**6. 권한: 채널 멤버라면 누구나**

템플릿·섹션 CRUD 모두 채널 멤버(`ChannelMemberRepository.existsByChannelIdAndUserId`) 여부만 확인합니다. 채널 생성자/팀 어드민 제한 없이 멤버 전원이 수정할 수 있습니다.

**7. 순환 참조 제거: `ChannelRepository` 직접 주입**

초기 구현에서 `MeetingNoteTemplateService`가 `ChannelService`를 주입받아 `ChannelService → MeetingNoteTemplateService → ChannelService` 순환 참조가 발생하였습니다. `ChannelService` 의존을 제거하고 `ChannelRepository`를 직접 주입하여 해소하였습니다.

---

### API 목록

| Method | Path | 설명 |
|--------|------|------|
| GET | `/channels/{channelId}/meeting-note-templates` | 목록 조회 |
| POST | `/channels/{channelId}/meeting-note-templates` | 템플릿 생성 |
| GET | `/channels/{channelId}/meeting-note-templates/{templateId}` | 상세 조회 (섹션 포함) |
| PATCH | `/channels/{channelId}/meeting-note-templates/{templateId}` | 이름 수정 |
| DELETE | `/channels/{channelId}/meeting-note-templates/{templateId}` | 삭제 |
| PATCH | `/channels/{channelId}/meeting-note-templates/{templateId}/activate` | 활성화 |
| POST | `/channels/{channelId}/meeting-note-templates/{templateId}/sections` | 섹션 추가 |
| PATCH | `/channels/{channelId}/meeting-note-templates/{templateId}/sections/{sectionId}` | 섹션 수정 |
| DELETE | `/channels/{channelId}/meeting-note-templates/{templateId}/sections/{sectionId}` | 섹션 삭제 |

---

### 기본 템플릿 섹션

| 섹션 | 타입 | 필수 |
|------|------|------|
| 회의 제목 | TEXT | O |
| 일시 / 장소 | DATETIME | O |
| 참석자 | USER_LIST | O |
| 안건 | MARKDOWN | O |
| 결정사항 | MARKDOWN | X |
| 다음 회의 일정 | DATETIME | X |
