### PR TITLE
[chat] MongoDB 접근 레이어를 레포지토리 패턴으로 분리

### DIFF
--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -20,6 +20,8 @@ import { ChannelClient } from './service/channel.client';
 import { UserClient } from './service/user.client';
 import { Message, MessageSchema } from './schema/message.schema';
 import { ChannelMember, ChannelMemberSchema } from './schema/channel-member.schema';
+import { MessageRepository } from './repository/message.repository';
+import { ChannelMemberRepository } from './repository/channel-member.repository';
 import { MembershipModule } from '../membership/membership.module';
 import { HealthController } from '../health.controller';
 import { MinioModule } from '../storage/minio.module';
@@ -101,6 +103,8 @@ function createLogStream() {
     providers: [
         ChatGateway,
         ChatService,
+        MessageRepository,
+        ChannelMemberRepository,
         ChatMessageProducer,
         ChatMessageConsumer,
         NotificationTriggerProducer,

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -1,11 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { getModelToken } from '@nestjs/mongoose';
 import { ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Types } from 'mongoose';
 import { ChatService } from './chat.service';
 import { ChatGateway } from './chat.gateway';
-import { Message } from './schema/message.schema';
-import { ChannelMember } from './schema/channel-member.schema';
 import { ElasticsearchService } from '../search/elasticsearch.service';
 import { MinioService } from '../storage/minio.service';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
@@ -13,6 +10,8 @@ import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { ProjectClient } from './service/project.client';
 import { ChannelClient } from './service/channel.client';
 import { UserClient } from './service/user.client';
+import { MessageRepository } from './repository/message.repository';
+import { ChannelMemberRepository } from './repository/channel-member.repository';
 
 const mockMessageId = new Types.ObjectId().toString();
 const mockEmit = jest.fn();
@@ -36,19 +35,19 @@ const makeMockMessage = (overrides = {}) => ({
     ...overrides,
 });
 
-const mockAggregate = jest.fn();
-
-const mockMessageModel = {
-    aggregate: mockAggregate,
+const mockMessageRepository = {
+    findMessages: jest.fn(),
+    findFileAttachments: jest.fn(),
     findById: jest.fn(),
-    deleteOne: jest.fn(),
-    create: jest.fn(),
-    collection: { name: 'messages' },
+    deleteById: jest.fn(),
+    createSystemMessage: jest.fn(),
 };
 
 
-const mockMemberModel = {
+const mockChannelMemberRepository = {
     exists: jest.fn(),
+    findTeamIdByChannelAndUser: jest.fn(),
+    findChannelIdsByUser: jest.fn(),
 };
 
 const mockElasticsearchService = {
@@ -96,8 +95,8 @@ describe('ChatService', () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 ChatService,
-                { provide: getModelToken(Message.name), useValue: mockMessageModel },
-                { provide: getModelToken(ChannelMember.name), useValue: mockMemberModel },
+                { provide: MessageRepository, useValue: mockMessageRepository },
+                { provide: ChannelMemberRepository, useValue: mockChannelMemberRepository },
                 { provide: ElasticsearchService, useValue: mockElasticsearchService },
                 { provide: MinioService, useValue: mockMinioService },
                 { provide: ChatMessageProducer, useValue: mockChatMessageProducer },
@@ -115,55 +114,48 @@ describe('ChatService', () => {
 
     describe('isMember', () => {
         it('채널 멤버이면 true를 반환한다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
             await expect(service.isMember(1, 42)).resolves.toBe(true);
         });
 
         it('채널 멤버가 아니면 false를 반환한다', async () => {
-            mockMemberModel.exists.mockResolvedValue(null);
+            mockChannelMemberRepository.exists.mockResolvedValue(false);
             await expect(service.isMember(1, 99)).resolves.toBe(false);
         });
     });
 
     describe('checkMembership', () => {
         it('멤버이면 예외 없이 통과한다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
             await expect(service.checkMembership(1, 42)).resolves.toBeUndefined();
         });
 
         it('멤버가 아니면 ForbiddenException을 던진다', async () => {
-            mockMemberModel.exists.mockResolvedValue(null);
+            mockChannelMemberRepository.exists.mockResolvedValue(false);
             await expect(service.checkMembership(1, 99)).rejects.toThrow(ForbiddenException);
         });
     });
 
     describe('getMessages', () => {
-        it('cursor 없이 aggregate를 실행하고 channelId 조건만 포함한다', async () => {
-            mockAggregate.mockResolvedValue([]);
+        it('메시지 조회를 레포지토리에 위임한다', async () => {
+            mockMessageRepository.findMessages.mockResolvedValue([]);
 
             await service.getMessages(1);
 
-            const pipeline = mockAggregate.mock.calls[0][0];
-            expect(pipeline[0].$match).toEqual({ channelId: 1 });
-            expect(pipeline[1].$sort).toEqual({ _id: -1 });
-            expect(pipeline[2].$limit).toBe(100);
+            expect(mockMessageRepository.findMessages).toHaveBeenCalledWith(1, undefined);
         });
 
-        it('before cursor가 있으면 _id 조건이 추가된다', async () => {
-            mockAggregate.mockResolvedValue([]);
+        it('before cursor를 레포지토리에 전달한다', async () => {
+            mockMessageRepository.findMessages.mockResolvedValue([]);
 
             await service.getMessages(1, mockMessageId);
 
-            const pipeline = mockAggregate.mock.calls[0][0];
-            expect(pipeline[0].$match).toEqual({
-                channelId: 1,
-                _id: { $lt: new Types.ObjectId(mockMessageId) },
-            });
+            expect(mockMessageRepository.findMessages).toHaveBeenCalledWith(1, mockMessageId);
         });
 
-        it('답글에는 $lookup으로 원본 메시지(mentionedMessage)가 embed된다', async () => {
+        it('레포지토리 조회 결과를 그대로 반환한다', async () => {
             const parentId = new Types.ObjectId();
-            mockAggregate.mockResolvedValue([
+            mockMessageRepository.findMessages.mockResolvedValue([
                 { _id: new Types.ObjectId(), content: '답글', parentMessageId: parentId, mentionedMessage: { _id: parentId, content: '원본', authorId: 1 } },
                 { _id: new Types.ObjectId(), content: '일반 메시지', parentMessageId: null, mentionedMessage: null },
             ]);
@@ -179,28 +171,29 @@ describe('ChatService', () => {
     describe('getFileList', () => {
         it('FILE_SHARE 채널의 첨부파일을 파일 단위로 반환한다', async () => {
             const createdAt = new Date('2026-05-12T02:03:04.000Z');
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockChannelClient.getChannel.mockResolvedValue({ id: 1, viewType: 'FILE_SHARE' });
-            mockAggregate.mockResolvedValue([
-                {
-                    _id: new Types.ObjectId('665f00000000000000000001'),
-                    authorId: 42,
-                    createdAt,
-                    attachmentIndex: 0,
-                    attachment: {
-                        name: 'report.pdf',
-                        url: 'http://localhost:9000/cowork-bucket/chat-files/1/42/report.pdf',
-                        size: 2048,
+            mockMessageRepository.findFileAttachments.mockResolvedValue({
+                items: [
+                    {
+                        messageId: '665f00000000000000000001',
+                        uploaderId: 42,
+                        uploadedAt: createdAt.toISOString(),
+                        fileName: 'report.pdf',
+                        fileUrl: 'http://localhost:9000/cowork-bucket/chat-files/1/42/report.pdf',
+                        fileSize: 2048,
                         mimeType: 'application/pdf',
+                        attachmentIndex: 0,
                     },
-                },
-            ]);
+                ],
+                nextCursor: null,
+            });
             mockUserClient.getDisplayName.mockResolvedValue('홍길동');
 
             const result = await service.getFileList(1, 42);
 
             expect(mockChannelClient.getChannel).toHaveBeenCalledWith(1, 42);
-            expect(mockAggregate).toHaveBeenCalled();
+            expect(mockMessageRepository.findFileAttachments).toHaveBeenCalledWith(1, undefined, 20);
             expect(mockUserClient.getDisplayName).toHaveBeenCalledWith(42);
             expect(result.files).toEqual([
                 {
@@ -218,54 +211,30 @@ describe('ChatService', () => {
         });
 
         it('FILE_SHARE가 아니면 BadRequestException을 던진다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockChannelClient.getChannel.mockResolvedValue({ id: 1, viewType: 'TEXT' });
 
             await expect(service.getFileList(1, 42)).rejects.toThrow('FILE_SHARE 채널에서만 파일 목록을 조회할 수 있습니다');
-            expect(mockAggregate).not.toHaveBeenCalled();
+            expect(mockMessageRepository.findFileAttachments).not.toHaveBeenCalled();
         });
 
-        it('before 커서를 사용해 다음 페이지를 조회한다', async () => {
-            const cursorRow = {
-                _id: new Types.ObjectId('665f00000000000000000002'),
-                createdAt: new Date('2026-05-12T03:00:00.000Z'),
-                attachmentIndex: 1,
-            };
-            const before = Buffer.from(JSON.stringify({
-                uploadedAt: cursorRow.createdAt.toISOString(),
-                messageId: cursorRow._id.toString(),
-                attachmentIndex: cursorRow.attachmentIndex,
-            })).toString('base64');
-
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
+        it('before 커서를 레포지토리에 전달한다', async () => {
+            const before = 'cursor';
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockChannelClient.getChannel.mockResolvedValue({ id: 1, viewType: 'FILE_SHARE' });
-            mockAggregate.mockResolvedValue([]);
+            mockMessageRepository.findFileAttachments.mockResolvedValue({ items: [], nextCursor: null });
 
             await service.getFileList(1, 42, before, 20);
 
-            const pipeline = mockAggregate.mock.calls[0][0];
-            expect(pipeline[2].$match).toEqual({
-                $or: [
-                    { createdAt: { $lt: new Date(cursorRow.createdAt) } },
-                    {
-                        createdAt: new Date(cursorRow.createdAt),
-                        _id: { $lt: new Types.ObjectId(cursorRow._id.toString()) },
-                    },
-                    {
-                        createdAt: new Date(cursorRow.createdAt),
-                        _id: new Types.ObjectId(cursorRow._id.toString()),
-                        attachmentIndex: { $lt: 1 },
-                    },
-                ],
-            });
+            expect(mockMessageRepository.findFileAttachments).toHaveBeenCalledWith(1, before, 20);
         });
     });
 
     describe('editMessage', () => {
         it('본인 메시지를 수정하면 editHistory에 이전 내용이 저장된다', async () => {
             const msg = makeMockMessage();
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(msg);
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(msg);
 
             await service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER');
 
@@ -277,16 +246,16 @@ describe('ChatService', () => {
         });
 
         it('메시지가 없으면 NotFoundException을 던진다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(null);
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(null);
             await expect(
                 service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
             ).rejects.toThrow(NotFoundException);
         });
 
         it('다른 사람의 메시지를 수정하면 ForbiddenException을 던진다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
             await expect(
                 service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
             ).rejects.toThrow(ForbiddenException);
@@ -294,8 +263,8 @@ describe('ChatService', () => {
 
         it('ADMIN은 다른 사람의 메시지도 수정할 수 있다', async () => {
             const msg = makeMockMessage({ authorId: 100 });
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(msg);
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(msg);
 
             await service.editMessage(1, mockMessageId, 42, { content: '관리자 수정' }, 'ROLE_ADMIN');
 
@@ -312,8 +281,8 @@ describe('ChatService', () => {
                     updatedAt: new Date('2026-05-12T00:00:00.000Z'),
                 }),
             });
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(msg);
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(msg);
             mockElasticsearchService.updateMessage.mockResolvedValue(undefined);
 
             await service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER');
@@ -323,8 +292,8 @@ describe('ChatService', () => {
         });
 
         it('다른 채널의 메시지를 수정하려 하면 ForbiddenException을 던진다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(makeMockMessage({ channelId: 2 }));
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(makeMockMessage({ channelId: 2 }));
 
             await expect(
                 service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
@@ -333,8 +302,8 @@ describe('ChatService', () => {
 
         it('내용이 동일하면 저장과 이벤트 발행을 생략한다', async () => {
             const msg = makeMockMessage();
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(msg);
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(msg);
 
             const result = await service.editMessage(1, mockMessageId, 42, { content: '안녕하세요' }, 'MEMBER');
 
@@ -353,8 +322,8 @@ describe('ChatService', () => {
                     updatedAt: savedAt,
                 }),
             });
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(msg);
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(msg);
 
             await service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER');
 
@@ -368,8 +337,8 @@ describe('ChatService', () => {
 
         it('ES 오류가 발생해도 editMessage 결과에 영향을 주지 않는다', async () => {
             const msg = makeMockMessage();
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(msg);
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(msg);
             mockElasticsearchService.updateMessage.mockRejectedValue(new Error('ES down'));
 
             await expect(
@@ -380,36 +349,36 @@ describe('ChatService', () => {
 
     describe('deleteMessage', () => {
         it('본인 메시지를 삭제한다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(makeMockMessage());
-            mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(makeMockMessage());
+            mockMessageRepository.deleteById.mockResolvedValue({ deletedCount: 1 });
 
             const result = await service.deleteMessage(1, mockMessageId, 42, 'MEMBER');
 
-            expect(mockMessageModel.deleteOne).toHaveBeenCalledWith({ _id: mockMessageId });
+            expect(mockMessageRepository.deleteById).toHaveBeenCalledWith(mockMessageId);
             expect(result.messageId).toBe(mockMessageId);
         });
 
         it('메시지가 없으면 NotFoundException을 던진다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(null);
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(null);
             await expect(
                 service.deleteMessage(1, mockMessageId, 42, 'MEMBER'),
             ).rejects.toThrow(NotFoundException);
         });
 
         it('다른 사람의 메시지를 삭제하면 ForbiddenException을 던진다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
             await expect(
                 service.deleteMessage(1, mockMessageId, 42, 'MEMBER'),
             ).rejects.toThrow(ForbiddenException);
         });
 
         it('ADMIN은 다른 사람의 메시지도 삭제할 수 있다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
-            mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
+            mockMessageRepository.deleteById.mockResolvedValue({ deletedCount: 1 });
 
             await expect(
                 service.deleteMessage(1, mockMessageId, 42, 'ROLE_ADMIN'),
@@ -417,9 +386,9 @@ describe('ChatService', () => {
         });
 
         it('삭제 후 ES deleteMessage를 fire-and-forget으로 호출한다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(makeMockMessage({ projectId: 10 }));
-            mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(makeMockMessage({ projectId: 10 }));
+            mockMessageRepository.deleteById.mockResolvedValue({ deletedCount: 1 });
             mockElasticsearchService.deleteMessage.mockResolvedValue(undefined);
 
             await service.deleteMessage(1, mockMessageId, 42, 'MEMBER');
@@ -429,9 +398,9 @@ describe('ChatService', () => {
         });
 
         it('ES 오류가 발생해도 deleteMessage 결과에 영향을 주지 않는다', async () => {
-            mockMemberModel.exists.mockResolvedValue({ _id: 'some-id' });
-            mockMessageModel.findById.mockResolvedValue(makeMockMessage());
-            mockMessageModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockMessageRepository.findById.mockResolvedValue(makeMockMessage());
+            mockMessageRepository.deleteById.mockResolvedValue({ deletedCount: 1 });
             mockElasticsearchService.deleteMessage.mockRejectedValue(new Error('ES down'));
 
             await expect(
@@ -442,22 +411,11 @@ describe('ChatService', () => {
 
     describe('saveSystemMessage', () => {
         it('시스템 메시지는 clientMessageId 없이 저장한다', async () => {
-            mockMessageModel.create.mockResolvedValue({ toObject: jest.fn() });
+            mockMessageRepository.createSystemMessage.mockResolvedValue({ toObject: jest.fn() });
 
             await service.saveSystemMessage(10, 1, '이슈가 생성됐어요', 100);
 
-            expect(mockMessageModel.create).toHaveBeenCalledWith({
-                teamId: 10,
-                projectId: 100,
-                channelId: 1,
-                authorId: 0,
-                content: '이슈가 생성됐어요',
-                type: 'SYSTEM',
-                attachments: [],
-                mentions: [],
-                clientMessageId: undefined,
-                notificationStatus: 'SENT',
-            });
+            expect(mockMessageRepository.createSystemMessage).toHaveBeenCalledWith(10, 1, '이슈가 생성됐어요', 100, 0);
         });
     });
 });

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -7,10 +7,7 @@ import {
     Logger,
     NotFoundException,
 } from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model, Types } from 'mongoose';
-import { Message, MessageDocument } from './schema/message.schema';
-import { ChannelMember } from './schema/channel-member.schema';
+import { MessageDocument } from './schema/message.schema';
 import { EditMessageDto } from './dto/edit-message.dto';
 import { UserRole } from '../common/enum/user-role.enum';
 import { ElasticsearchService } from '../search/elasticsearch.service';
@@ -28,30 +25,20 @@ import { SlashCommand, SlashCommandDto } from './dto/slash-command.dto';
 import { SearchMessagesDto } from './dto/search-messages.dto';
 import { SearchMessagesResponseDto } from './dto/search-message-response.dto';
 import { FileListResponseDto } from './dto/file-list.dto';
+import { MessageRepository } from './repository/message.repository';
+import { ChannelMemberRepository } from './repository/channel-member.repository';
 
 const SYSTEM_AUTHOR_ID = 0;
 const SYSTEM_AUTHOR_NAME = 'System';
 const FILE_SHARE_VIEW_TYPE = 'FILE_SHARE';
-const FILE_ATTACHMENT_LIMIT = 100;
-
-type FileAttachmentRow = {
-    messageId: string;
-    fileName: string;
-    fileSize: number;
-    fileUrl: string;
-    mimeType: string;
-    uploaderId: number;
-    uploadedAt: string;
-    attachmentIndex: number;
-};
 
 @Injectable()
 export class ChatService {
     private readonly logger = new Logger(ChatService.name);
 
     constructor(
-        @InjectModel(Message.name) private readonly messageModel: Model<Message>,
-        @InjectModel(ChannelMember.name) private readonly memberModel: Model<ChannelMember>,
+        private readonly messageRepository: MessageRepository,
+        private readonly channelMemberRepository: ChannelMemberRepository,
         private readonly elasticsearchService: ElasticsearchService,
         private readonly minioService: MinioService,
         private readonly chatMessageProducer: ChatMessageProducer,
@@ -64,19 +51,18 @@ export class ChatService {
     ) {}
 
     async isMember(channelId: number, userId: number): Promise<boolean> {
-        const member = await this.memberModel.exists({ channelId, userId });
-        return member !== null;
+        return this.channelMemberRepository.exists(channelId, userId);
     }
 
     async checkMembership(channelId: number, userId: number): Promise<void> {
-        const member = await this.memberModel.exists({ channelId, userId });
-        if (!member) throw new ForbiddenException('채널 접근 권한이 없습니다');
+        const isMember = await this.channelMemberRepository.exists(channelId, userId);
+        if (!isMember) throw new ForbiddenException('채널 접근 권한이 없습니다');
     }
 
     async checkMembershipAndGetTeamId(channelId: number, userId: number): Promise<number> {
-        const member = await this.memberModel.findOne({ channelId, userId }, { teamId: 1 });
-        if (!member) throw new ForbiddenException('채널 접근 권한이 없습니다');
-        return member.teamId;
+        const teamId = await this.channelMemberRepository.findTeamIdByChannelAndUser(channelId, userId);
+        if (teamId === null) throw new ForbiddenException('채널 접근 권한이 없습니다');
+        return teamId;
     }
 
     async createFileUploadUrl(
@@ -119,7 +105,7 @@ export class ChatService {
             throw new BadRequestException('FILE_SHARE 채널에서만 파일 목록을 조회할 수 있습니다');
         }
 
-        const { items, nextCursor } = await this.queryFileAttachments(channelId, before, limit);
+        const { items, nextCursor } = await this.messageRepository.findFileAttachments(channelId, before, limit);
         const uploaderNames = await this.loadUploaderNames(items);
 
         return {
@@ -185,41 +171,7 @@ export class ChatService {
     }
 
     async getMessages(channelId: number, before?: string) {
-        const query: Record<string, unknown> = { channelId };
-        if (before) {
-            query['_id'] = { $lt: new Types.ObjectId(before) };
-        }
-
-        return this.messageModel
-            .aggregate([
-                { $match: query },
-                { $sort: { _id: -1 } },
-                { $limit: 100 },
-                {
-                    $lookup: {
-                        from: this.messageModel.collection.name,
-                        localField: 'parentMessageId',
-                        foreignField: '_id',
-                        as: 'mentionedMessage',
-                        pipeline: [
-                            {
-                                $project: {
-                                    _id: 1,
-                                    authorId: 1,
-                                    content: 1,
-                                    type: 1,
-                                    createdAt: 1,
-                                },
-                            },
-                        ],
-                    },
-                },
-                {
-                    $addFields: {
-                        mentionedMessage: { $arrayElemAt: ['$mentionedMessage', 0] },
-                    },
-                },
-            ]);
+        return this.messageRepository.findMessages(channelId, before);
     }
 
     async searchProjectMessages(
@@ -232,8 +184,7 @@ export class ChatService {
             throw new ForbiddenException('프로젝트 접근 권한이 없습니다');
         }
 
-        const memberships = await this.memberModel.find({ userId }, { channelId: 1 }).lean();
-        const accessibleChannelIds = memberships.map((membership) => membership.channelId);
+        const accessibleChannelIds = await this.channelMemberRepository.findChannelIdsByUser(userId);
 
         let filteredChannelIds = accessibleChannelIds;
         if (dto.channelId !== undefined) {
@@ -259,7 +210,7 @@ export class ChatService {
 
     async editMessage(channelId: number, messageId: string, userId: number, dto: EditMessageDto, userRole: string) {
         await this.checkMembership(channelId, userId);
-        const message = await this.messageModel.findById(messageId);
+        const message = await this.messageRepository.findById(messageId);
         if (!message) throw new NotFoundException('메시지를 찾을 수 없습니다');
         if (message.channelId !== channelId) {
             throw new ForbiddenException('해당 채널의 메시지가 아닙니다');
@@ -293,7 +244,7 @@ export class ChatService {
 
     async deleteMessage(channelId: number, messageId: string, userId: number, userRole: string) {
         await this.checkMembership(channelId, userId);
-        const message = await this.messageModel.findById(messageId);
+        const message = await this.messageRepository.findById(messageId);
         if (!message) throw new NotFoundException('메시지를 찾을 수 없습니다');
         if (message.channelId !== channelId) {
             throw new ForbiddenException('해당 채널의 메시지가 아닙니다');
@@ -302,7 +253,7 @@ export class ChatService {
             throw new ForbiddenException('본인 메시지만 삭제할 수 있습니다');
         }
 
-        await this.messageModel.deleteOne({ _id: messageId });
+        await this.messageRepository.deleteById(messageId);
         if (message.projectId) {
             void this.elasticsearchService.deleteMessage(messageId);
         }
@@ -320,148 +271,11 @@ export class ChatService {
         content: string,
         projectId: number | null = null,
     ) {
-        return this.messageModel.create({
-            teamId,
-            projectId,
-            channelId,
-            authorId: SYSTEM_AUTHOR_ID,
-            content,
-            type: 'SYSTEM',
-            attachments: [],
-            mentions: [],
-            clientMessageId: undefined,
-            notificationStatus: 'SENT',
-        });
+        return this.messageRepository.createSystemMessage(teamId, channelId, content, projectId, SYSTEM_AUTHOR_ID);
     }
 
     private isAdmin(role: string): boolean {
         return role === UserRole.ADMIN;
-    }
-
-    private async queryFileAttachments(
-        channelId: number,
-        before: string | undefined,
-        limit: number,
-    ): Promise<{ items: FileAttachmentRow[]; nextCursor: string | null }> {
-        const safeLimit = Math.min(Math.max(limit, 1), FILE_ATTACHMENT_LIMIT);
-        const cursorMatch = before ? this.buildFileCursorMatch(before) : null;
-
-        const pipeline: any[] = [
-            {
-                $match: {
-                    channelId,
-                    type: 'FILE',
-                    'attachments.0': { $exists: true },
-                },
-            },
-            {
-                $unwind: {
-                    path: '$attachments',
-                    includeArrayIndex: 'attachmentIndex',
-                },
-            },
-            ...(cursorMatch ? [{ $match: cursorMatch }] : []),
-            {
-                $sort: {
-                    createdAt: -1,
-                    _id: -1,
-                    attachmentIndex: -1,
-                },
-            },
-            { $limit: safeLimit + 1 },
-            {
-                $project: {
-                    _id: 1,
-                    authorId: 1,
-                    createdAt: 1,
-                    attachmentIndex: 1,
-                    attachment: '$attachments',
-                },
-            },
-        ];
-
-        const rows = await this.messageModel.aggregate(pipeline);
-        const hasNext = rows.length > safeLimit;
-        const pageRows = rows.slice(0, safeLimit);
-        const items: FileAttachmentRow[] = pageRows.map((row: any) => ({
-            messageId: row._id.toString(),
-            fileName: row.attachment.name,
-            fileSize: row.attachment.size,
-            fileUrl: row.attachment.url,
-            mimeType: row.attachment.mimeType,
-            uploaderId: row.authorId,
-            uploadedAt: row.createdAt.toISOString(),
-            attachmentIndex: row.attachmentIndex ?? 0,
-        }));
-
-        return {
-            items,
-            nextCursor: hasNext && pageRows.length > 0
-                ? this.encodeFileCursor(pageRows.at(-1))
-                : null,
-        };
-    }
-
-    private buildFileCursorMatch(before: string): Record<string, unknown> | null {
-        const cursor = this.decodeFileCursor(before);
-        if (!cursor) {
-            return null;
-        }
-
-        return {
-            $or: [
-                { createdAt: { $lt: new Date(cursor.uploadedAt) } },
-                {
-                    createdAt: new Date(cursor.uploadedAt),
-                    _id: { $lt: new Types.ObjectId(cursor.messageId) },
-                },
-                {
-                    createdAt: new Date(cursor.uploadedAt),
-                    _id: new Types.ObjectId(cursor.messageId),
-                    attachmentIndex: { $lt: cursor.attachmentIndex },
-                },
-            ],
-        };
-    }
-
-    private encodeFileCursor(row: any): string | null {
-        if (!row) {
-            return null;
-        }
-
-        return Buffer.from(JSON.stringify({
-            uploadedAt: row.createdAt.toISOString(),
-            messageId: row._id.toString(),
-            attachmentIndex: row.attachmentIndex ?? 0,
-        })).toString('base64');
-    }
-
-    private decodeFileCursor(before: string): { uploadedAt: string; messageId: string; attachmentIndex: number } | null {
-        try {
-            const parsed = JSON.parse(Buffer.from(before, 'base64').toString('utf8')) as {
-                uploadedAt?: unknown;
-                messageId?: unknown;
-                attachmentIndex?: unknown;
-            };
-
-            if (
-                typeof parsed.uploadedAt !== 'string' ||
-                typeof parsed.messageId !== 'string' ||
-                typeof parsed.attachmentIndex !== 'number' ||
-                Number.isNaN(Date.parse(parsed.uploadedAt)) ||
-                !Types.ObjectId.isValid(parsed.messageId)
-            ) {
-                return null;
-            }
-
-            return {
-                uploadedAt: parsed.uploadedAt,
-                messageId: parsed.messageId,
-                attachmentIndex: parsed.attachmentIndex,
-            };
-        } catch {
-            return null;
-        }
     }
 
     private async loadUploaderNames(items: Array<{ uploaderId: number }>): Promise<Map<number, string>> {

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.spec.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.spec.ts
@@ -1,7 +1,7 @@
 import { ChatMessageConsumer } from './chat-message.consumer';
 
-const mockMessageModel = {
-    create: jest.fn(),
+const mockMessageRepository = {
+    createMessage: jest.fn(),
 };
 
 const mockConfigService = {
@@ -16,12 +16,12 @@ describe('ChatMessageConsumer', () => {
     let consumer: ChatMessageConsumer;
 
     beforeEach(() => {
-        consumer = new ChatMessageConsumer(mockMessageModel as any, mockConfigService as any, mockElasticsearchService as any);
+        consumer = new ChatMessageConsumer(mockMessageRepository as any, mockConfigService as any, mockElasticsearchService as any);
         jest.clearAllMocks();
     });
 
     it('clientMessageId가 없으면 null 대신 undefined로 저장한다', async () => {
-        mockMessageModel.create.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
+        mockMessageRepository.createMessage.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
 
         await (consumer as any).handleMessageEvent({
             teamId: 10,
@@ -36,7 +36,7 @@ describe('ChatMessageConsumer', () => {
             occurredAt: new Date().toISOString(),
         });
 
-        expect(mockMessageModel.create).toHaveBeenCalledWith(
+        expect(mockMessageRepository.createMessage).toHaveBeenCalledWith(
             expect.objectContaining({
                 clientMessageId: undefined,
             }),

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.ts
@@ -1,13 +1,12 @@
 import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Kafka, Consumer } from 'kafkajs';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model, Types } from 'mongoose';
+import { Types } from 'mongoose';
 import { Server } from 'socket.io';
-import { Message } from '../schema/message.schema';
 import { ChatMessageEvent } from './event/chat-message.event';
 import { ElasticsearchService } from '../../search/elasticsearch.service';
 import { getRequiredCsvConfig } from '../../common/config/config.util';
+import { MessageRepository } from '../repository/message.repository';
 
 @Injectable()
 export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
@@ -17,7 +16,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
     private io?: Server;
 
     constructor(
-        @InjectModel(Message.name) private readonly messageModel: Model<Message>,
+        private readonly messageRepository: MessageRepository,
         private readonly configService: ConfigService,
         private readonly elasticsearchService: ElasticsearchService,
     ) {}
@@ -71,7 +70,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
         const mentions = this.parseMentions(event.content);
 
         try {
-            const saved = await this.messageModel.create({
+            const saved = await this.messageRepository.createMessage({
                 teamId: event.teamId,
                 projectId: event.projectId ?? null,
                 channelId: event.channelId,

--- a/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
+++ b/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
@@ -1,9 +1,10 @@
 import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
-import { InjectModel } from '@nestjs/mongoose';
-import { Model, Types } from 'mongoose';
-import { Message, MessageDocument } from '../schema/message.schema';
+import { Types } from 'mongoose';
+import { Message } from '../schema/message.schema';
 import { ChannelMember } from '../schema/channel-member.schema';
 import { NotificationTriggerProducer } from './notification-trigger.producer';
+import { MessageRepository, NotificationMessage } from '../repository/message.repository';
+import { ChannelMemberRepository } from '../repository/channel-member.repository';
 
 const POLL_INTERVAL_MS = 5_000;
 const BATCH_SIZE = 10;
@@ -16,8 +17,8 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
     private isPolling = false;
 
     constructor(
-        @InjectModel(Message.name) private readonly messageModel: Model<Message>,
-        @InjectModel(ChannelMember.name) private readonly memberModel: Model<ChannelMember>,
+        private readonly messageRepository: MessageRepository,
+        private readonly channelMemberRepository: ChannelMemberRepository,
         private readonly triggerProducer: NotificationTriggerProducer,
     ) {}
 
@@ -40,14 +41,9 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
 
     private async poll(): Promise<void> {
         // 1단계: 배치 내 메시지 수집 (PENDING → PROCESSING 원자적 전환)
-        type MsgDoc = Message & { _id: Types.ObjectId; createdAt: Date };
-        const msgs: MsgDoc[] = [];
+        const msgs: NotificationMessage[] = [];
         for (let i = 0; i < BATCH_SIZE; i++) {
-            const msg = await this.messageModel.findOneAndUpdate(
-                { notificationStatus: 'PENDING' },
-                { $set: { notificationStatus: 'PROCESSING' } },
-                { new: true },
-            ).lean() as MsgDoc | null;
+            const msg = await this.messageRepository.findOnePendingAndMarkProcessing();
             if (!msg) break;
             msgs.push(msg);
         }
@@ -60,11 +56,7 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
             msgs.filter((m) => m.parentMessageId != null).map((m) => m.parentMessageId!),
         )];
         if (parentIds.length > 0) {
-            const parents = await this.messageModel
-                .find({ _id: { $in: parentIds } })
-                .select('authorId')
-                .lean() as { _id: Types.ObjectId; authorId: number }[];
-            const parentMap = new Map(parents.map((p) => [p._id.toString(), p]));
+            const parentMap = await this.messageRepository.findParentAuthorsByIds(parentIds);
             for (const id of parentIds) {
                 parentCache.set(id.toString(), parentMap.get(id.toString()) ?? null);
             }
@@ -74,18 +66,12 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
         for (const msg of msgs) {
             try {
                 await this.processMessage(msg, memberCache, parentCache);
-                await this.messageModel.updateOne(
-                    { _id: msg._id },
-                    { $set: { notificationStatus: 'SENT' } },
-                );
+                await this.messageRepository.updateNotificationStatus(msg._id, 'SENT');
             } catch (err) {
                 const retryCount = (msg.notificationRetryCount ?? 0) + 1;
                 const nextStatus = retryCount >= MAX_RETRY ? 'FAILED' : 'PENDING';
                 this.logger.error(`outbox 처리 실패 (messageId: ${msg._id}, retry: ${retryCount}/${MAX_RETRY}), ${nextStatus} 전환`, err);
-                await this.messageModel.updateOne(
-                    { _id: msg._id },
-                    { $set: { notificationStatus: nextStatus, notificationRetryCount: retryCount } },
-                );
+                await this.messageRepository.updateNotificationStatus(msg._id, nextStatus, retryCount);
             }
         }
     }
@@ -98,7 +84,7 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
         const cacheKey = String(msg.channelId);
         let members = memberCache.get(cacheKey);
         if (!members) {
-            members = await this.memberModel.find({ channelId: msg.channelId }).lean() as ChannelMember[];
+            members = await this.channelMemberRepository.findByChannelId(msg.channelId);
             memberCache.set(cacheKey, members);
         }
         const memberIdSet = new Set(members.map((m) => m.userId));

--- a/cowork-chat/src/chat/repository/channel-member.repository.ts
+++ b/cowork-chat/src/chat/repository/channel-member.repository.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { ChannelMember } from '../schema/channel-member.schema';
+
+@Injectable()
+export class ChannelMemberRepository {
+    constructor(
+        @InjectModel(ChannelMember.name) private readonly memberModel: Model<ChannelMember>,
+    ) {}
+
+    async exists(channelId: number, userId: number): Promise<boolean> {
+        const member = await this.memberModel.exists({ channelId, userId });
+        return member !== null;
+    }
+
+    async findTeamIdByChannelAndUser(channelId: number, userId: number): Promise<number | null> {
+        const member = await this.memberModel.findOne({ channelId, userId }, { teamId: 1 });
+        return member?.teamId ?? null;
+    }
+
+    async findChannelIdsByUser(userId: number): Promise<number[]> {
+        const memberships = await this.memberModel.find({ userId }, { channelId: 1 }).lean();
+        return memberships.map((membership) => membership.channelId);
+    }
+
+    findByChannelId(channelId: number): Promise<ChannelMember[]> {
+        return this.memberModel.find({ channelId }).lean() as Promise<ChannelMember[]>;
+    }
+}

--- a/cowork-chat/src/chat/repository/message.repository.spec.ts
+++ b/cowork-chat/src/chat/repository/message.repository.spec.ts
@@ -1,0 +1,129 @@
+import { Types } from 'mongoose';
+import { MessageRepository } from './message.repository';
+
+const mockAggregate = jest.fn();
+
+const mockMessageModel = {
+    aggregate: mockAggregate,
+    collection: { name: 'messages' },
+};
+
+describe('MessageRepository', () => {
+    let repository: MessageRepository;
+
+    beforeEach(() => {
+        repository = new MessageRepository(mockMessageModel as any);
+        jest.clearAllMocks();
+    });
+
+    describe('findMessages', () => {
+        it('cursor 없이 aggregate를 실행하고 channelId 조건만 포함한다', async () => {
+            mockAggregate.mockResolvedValue([]);
+
+            await repository.findMessages(1);
+
+            const pipeline = mockAggregate.mock.calls[0][0];
+            expect(pipeline[0].$match).toEqual({ channelId: 1 });
+            expect(pipeline[1].$sort).toEqual({ _id: -1 });
+            expect(pipeline[2].$limit).toBe(100);
+        });
+
+        it('before cursor가 있으면 _id 조건이 추가된다', async () => {
+            const messageId = new Types.ObjectId().toString();
+            mockAggregate.mockResolvedValue([]);
+
+            await repository.findMessages(1, messageId);
+
+            const pipeline = mockAggregate.mock.calls[0][0];
+            expect(pipeline[0].$match).toEqual({
+                channelId: 1,
+                _id: { $lt: new Types.ObjectId(messageId) },
+            });
+        });
+
+        it('답글 원본 메시지를 mentionedMessage로 조회한다', async () => {
+            mockAggregate.mockResolvedValue([]);
+
+            await repository.findMessages(1);
+
+            const pipeline = mockAggregate.mock.calls[0][0];
+            expect(pipeline[3].$lookup).toEqual(expect.objectContaining({
+                from: 'messages',
+                localField: 'parentMessageId',
+                foreignField: '_id',
+                as: 'mentionedMessage',
+            }));
+            expect(pipeline[4].$addFields).toEqual({
+                mentionedMessage: { $arrayElemAt: ['$mentionedMessage', 0] },
+            });
+        });
+    });
+
+    describe('findFileAttachments', () => {
+        it('첨부파일을 파일 단위로 반환한다', async () => {
+            const createdAt = new Date('2026-05-12T02:03:04.000Z');
+            mockAggregate.mockResolvedValue([
+                {
+                    _id: new Types.ObjectId('665f00000000000000000001'),
+                    authorId: 42,
+                    createdAt,
+                    attachmentIndex: 0,
+                    attachment: {
+                        name: 'report.pdf',
+                        url: 'http://localhost:9000/cowork-bucket/chat-files/1/42/report.pdf',
+                        size: 2048,
+                        mimeType: 'application/pdf',
+                    },
+                },
+            ]);
+
+            const result = await repository.findFileAttachments(1, undefined, 20);
+
+            expect(result.items).toEqual([
+                {
+                    messageId: '665f00000000000000000001',
+                    fileName: 'report.pdf',
+                    fileSize: 2048,
+                    fileUrl: 'http://localhost:9000/cowork-bucket/chat-files/1/42/report.pdf',
+                    mimeType: 'application/pdf',
+                    uploaderId: 42,
+                    uploadedAt: createdAt.toISOString(),
+                    attachmentIndex: 0,
+                },
+            ]);
+            expect(result.nextCursor).toBeNull();
+        });
+
+        it('before 커서를 사용해 다음 페이지를 조회한다', async () => {
+            const cursorRow = {
+                _id: new Types.ObjectId('665f00000000000000000002'),
+                createdAt: new Date('2026-05-12T03:00:00.000Z'),
+                attachmentIndex: 1,
+            };
+            const before = Buffer.from(JSON.stringify({
+                uploadedAt: cursorRow.createdAt.toISOString(),
+                messageId: cursorRow._id.toString(),
+                attachmentIndex: cursorRow.attachmentIndex,
+            })).toString('base64');
+            mockAggregate.mockResolvedValue([]);
+
+            await repository.findFileAttachments(1, before, 20);
+
+            const pipeline = mockAggregate.mock.calls[0][0];
+            expect(pipeline[2].$match).toEqual({
+                $or: [
+                    { createdAt: { $lt: new Date(cursorRow.createdAt) } },
+                    {
+                        createdAt: new Date(cursorRow.createdAt),
+                        _id: { $lt: new Types.ObjectId(cursorRow._id.toString()) },
+                    },
+                    {
+                        createdAt: new Date(cursorRow.createdAt),
+                        _id: new Types.ObjectId(cursorRow._id.toString()),
+                        attachmentIndex: { $lt: 1 },
+                    },
+                ],
+            });
+        });
+    });
+});

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -1,0 +1,270 @@
+import { Injectable } from '@nestjs/common';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model, Types } from 'mongoose';
+import { Message, MessageDocument } from '../schema/message.schema';
+
+const FILE_ATTACHMENT_LIMIT = 100;
+
+export type FileAttachmentRow = {
+    messageId: string;
+    fileName: string;
+    fileSize: number;
+    fileUrl: string;
+    mimeType: string;
+    uploaderId: number;
+    uploadedAt: string;
+    attachmentIndex: number;
+};
+
+export type CreateMessageInput = {
+    teamId: number;
+    projectId: number | null;
+    channelId: number;
+    authorId: number;
+    content: string;
+    type: string;
+    attachments: Array<{
+        name: string;
+        url: string;
+        size: number;
+        mimeType: string;
+    }>;
+    parentMessageId: Types.ObjectId | null;
+    clientMessageId?: string;
+    mentions: number[];
+    notificationStatus: string;
+};
+
+export type NotificationMessage = Message & { _id: Types.ObjectId; createdAt: Date };
+
+@Injectable()
+export class MessageRepository {
+    constructor(
+        @InjectModel(Message.name) private readonly messageModel: Model<Message>,
+    ) {}
+
+    findMessages(channelId: number, before?: string) {
+        const query: Record<string, unknown> = { channelId };
+        if (before) {
+            query['_id'] = { $lt: new Types.ObjectId(before) };
+        }
+
+        return this.messageModel.aggregate([
+            { $match: query },
+            { $sort: { _id: -1 } },
+            { $limit: 100 },
+            {
+                $lookup: {
+                    from: this.messageModel.collection.name,
+                    localField: 'parentMessageId',
+                    foreignField: '_id',
+                    as: 'mentionedMessage',
+                    pipeline: [
+                        {
+                            $project: {
+                                _id: 1,
+                                authorId: 1,
+                                content: 1,
+                                type: 1,
+                                createdAt: 1,
+                            },
+                        },
+                    ],
+                },
+            },
+            {
+                $addFields: {
+                    mentionedMessage: { $arrayElemAt: ['$mentionedMessage', 0] },
+                },
+            },
+        ]);
+    }
+
+    findById(messageId: string): Promise<MessageDocument | null> {
+        return this.messageModel.findById(messageId);
+    }
+
+    deleteById(messageId: string) {
+        return this.messageModel.deleteOne({ _id: messageId });
+    }
+
+    createMessage(input: CreateMessageInput) {
+        return this.messageModel.create(input);
+    }
+
+    createSystemMessage(
+        teamId: number,
+        channelId: number,
+        content: string,
+        projectId: number | null,
+        authorId: number,
+    ) {
+        return this.messageModel.create({
+            teamId,
+            projectId,
+            channelId,
+            authorId,
+            content,
+            type: 'SYSTEM',
+            attachments: [],
+            mentions: [],
+            clientMessageId: undefined,
+            notificationStatus: 'SENT',
+        });
+    }
+
+    async findFileAttachments(
+        channelId: number,
+        before: string | undefined,
+        limit: number,
+    ): Promise<{ items: FileAttachmentRow[]; nextCursor: string | null }> {
+        const safeLimit = Math.min(Math.max(limit, 1), FILE_ATTACHMENT_LIMIT);
+        const cursorMatch = before ? this.buildFileCursorMatch(before) : null;
+
+        const pipeline: any[] = [
+            {
+                $match: {
+                    channelId,
+                    type: 'FILE',
+                    'attachments.0': { $exists: true },
+                },
+            },
+            {
+                $unwind: {
+                    path: '$attachments',
+                    includeArrayIndex: 'attachmentIndex',
+                },
+            },
+            ...(cursorMatch ? [{ $match: cursorMatch }] : []),
+            {
+                $sort: {
+                    createdAt: -1,
+                    _id: -1,
+                    attachmentIndex: -1,
+                },
+            },
+            { $limit: safeLimit + 1 },
+            {
+                $project: {
+                    _id: 1,
+                    authorId: 1,
+                    createdAt: 1,
+                    attachmentIndex: 1,
+                    attachment: '$attachments',
+                },
+            },
+        ];
+
+        const rows = await this.messageModel.aggregate(pipeline);
+        const hasNext = rows.length > safeLimit;
+        const pageRows = rows.slice(0, safeLimit);
+        const items: FileAttachmentRow[] = pageRows.map((row: any) => ({
+            messageId: row._id.toString(),
+            fileName: row.attachment.name,
+            fileSize: row.attachment.size,
+            fileUrl: row.attachment.url,
+            mimeType: row.attachment.mimeType,
+            uploaderId: row.authorId,
+            uploadedAt: row.createdAt.toISOString(),
+            attachmentIndex: row.attachmentIndex ?? 0,
+        }));
+
+        return {
+            items,
+            nextCursor: hasNext && pageRows.length > 0
+                ? this.encodeFileCursor(pageRows.at(-1))
+                : null,
+        };
+    }
+
+    findOnePendingAndMarkProcessing(): Promise<NotificationMessage | null> {
+        return this.messageModel.findOneAndUpdate(
+            { notificationStatus: 'PENDING' },
+            { $set: { notificationStatus: 'PROCESSING' } },
+            { new: true },
+        ).lean() as Promise<NotificationMessage | null>;
+    }
+
+    async findParentAuthorsByIds(parentIds: Types.ObjectId[]): Promise<Map<string, { authorId: number }>> {
+        const parents = await this.messageModel
+            .find({ _id: { $in: parentIds } })
+            .select('authorId')
+            .lean() as { _id: Types.ObjectId; authorId: number }[];
+
+        return new Map(parents.map((parent) => [parent._id.toString(), { authorId: parent.authorId }]));
+    }
+
+    updateNotificationStatus(
+        messageId: Types.ObjectId,
+        notificationStatus: string,
+        notificationRetryCount?: number,
+    ) {
+        const $set: Record<string, unknown> = { notificationStatus };
+        if (notificationRetryCount !== undefined) {
+            $set.notificationRetryCount = notificationRetryCount;
+        }
+        return this.messageModel.updateOne({ _id: messageId }, { $set });
+    }
+
+    private buildFileCursorMatch(before: string): Record<string, unknown> | null {
+        const cursor = this.decodeFileCursor(before);
+        if (!cursor) {
+            return null;
+        }
+
+        return {
+            $or: [
+                { createdAt: { $lt: new Date(cursor.uploadedAt) } },
+                {
+                    createdAt: new Date(cursor.uploadedAt),
+                    _id: { $lt: new Types.ObjectId(cursor.messageId) },
+                },
+                {
+                    createdAt: new Date(cursor.uploadedAt),
+                    _id: new Types.ObjectId(cursor.messageId),
+                    attachmentIndex: { $lt: cursor.attachmentIndex },
+                },
+            ],
+        };
+    }
+
+    private encodeFileCursor(row: any): string | null {
+        if (!row) {
+            return null;
+        }
+
+        return Buffer.from(JSON.stringify({
+            uploadedAt: row.createdAt.toISOString(),
+            messageId: row._id.toString(),
+            attachmentIndex: row.attachmentIndex ?? 0,
+        })).toString('base64');
+    }
+
+    private decodeFileCursor(before: string): { uploadedAt: string; messageId: string; attachmentIndex: number } | null {
+        try {
+            const parsed = JSON.parse(Buffer.from(before, 'base64').toString('utf8')) as {
+                uploadedAt?: unknown;
+                messageId?: unknown;
+                attachmentIndex?: unknown;
+            };
+
+            if (
+                typeof parsed.uploadedAt !== 'string' ||
+                typeof parsed.messageId !== 'string' ||
+                typeof parsed.attachmentIndex !== 'number' ||
+                Number.isNaN(Date.parse(parsed.uploadedAt)) ||
+                !Types.ObjectId.isValid(parsed.messageId)
+            ) {
+                return null;
+            }
+
+            return {
+                uploadedAt: parsed.uploadedAt,
+                messageId: parsed.messageId,
+                attachmentIndex: parsed.attachmentIndex,
+            };
+        } catch {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## 개요

`ChatService`, `ChatMessageConsumer`, `NotificationOutboxPoller`에서 Mongoose 모델을 직접 사용하던 방식을 `MessageRepository`와 `ChannelMemberRepository`로 추출하여 MongoDB 접근 레이어를 분리하였습니다.

## 본문

**변경 배경**

기존 코드에서는 서비스 및 Kafka 컨슈머 클래스가 Mongoose 모델(`Model<Message>`, `Model<ChannelMember>`)을 직접 주입받아 사용하고 있었습니다. 이로 인해 복잡한 집계 파이프라인(파일 목록 커서 페이지네이션, 메시지 lookup 등)이 서비스 레이어에 혼재되어 있었고, 단위 테스트 시 Mongoose 모델 mock의 내부 구현에 의존해야 하는 문제가 있었습니다.

**주요 변경 사항**

- `MessageRepository` 생성: `findMessages`, `findFileAttachments`, `findById`, `deleteById`, `createMessage`, `createSystemMessage`, `findOnePendingAndMarkProcessing`, `findParentAuthorsByIds`, `updateNotificationStatus` 메서드 추출
- `ChannelMemberRepository` 생성: `exists`, `findTeamIdByChannelAndUser`, `findChannelIdsByUser`, `findByChannelId` 메서드 추출
- `ChatService`, `ChatMessageConsumer`, `NotificationOutboxPoller`에서 `@InjectModel` 제거 후 레포지토리 의존성 주입으로 전환
- `chat.module.ts`에 두 레포지토리를 provider로 등록
- 기존 서비스/컨슈머 단위 테스트에서 Mongoose 모델 mock을 레포지토리 mock으로 교체
- `message.repository.spec.ts` 추가 (MongoDB 접근 로직 단위 테스트)
