### PR TITLE
[global] 채널 position 정렬 보조키 적용 및 메시지 limit 상수 추출

### DIFF
--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelEntity.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelEntity.kt
@@ -29,5 +29,8 @@ class ChannelEntity(
 
     @Column(name = "notice", length = 500)
     val notice: String? = null,
+
+    @Column(name = "position", nullable = false)
+    val position: Int = 0,
 ) : BaseEntity()
 

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelRepository.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ChannelRepository.kt
@@ -3,6 +3,6 @@ package com.cowork.channel.channel
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface ChannelRepository : JpaRepository<ChannelEntity, Long> {
-    fun findAllByTeamIdOrderByIdAsc(teamId: Long): List<ChannelEntity>
+    fun findAllByTeamIdOrderByPositionAscIdAsc(teamId: Long): List<ChannelEntity>
 }
 

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ListTeamChannelsService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/channel/ListTeamChannelsService.kt
@@ -16,6 +16,6 @@ class ListTeamChannelsService(
     fun execute(userId: Long, teamId: Long): List<ChannelEntity> {
         val isMember = teamClient.isMember(teamId, userId)["isMember"] == true
         if (!isMember) throw ExpectedException("해당 팀의 멤버가 아닙니다.", HttpStatus.FORBIDDEN)
-        return channelRepository.findAllByTeamIdOrderByIdAsc(teamId)
+        return channelRepository.findAllByTeamIdOrderByPositionAscIdAsc(teamId)
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/repository/SharedAccountRepository.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/repository/SharedAccountRepository.kt
@@ -1,5 +1,6 @@
 package com.cowork.channel.repository
 
+import com.cowork.channel.domain.AccountProvider
 import com.cowork.channel.domain.SharedAccount
 import org.springframework.data.jpa.repository.JpaRepository
 
@@ -8,4 +9,6 @@ interface SharedAccountRepository : JpaRepository<SharedAccount, Long> {
     fun findAllByChannelIdOrderByCreatedAtAsc(channelId: Long): List<SharedAccount>
 
     fun findByIdAndChannelId(id: Long, channelId: Long): SharedAccount?
+
+    fun findByChannelIdAndProviderAndAccountIdentifier(channelId: Long, provider: AccountProvider, accountIdentifier: String?): SharedAccount?
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/CredentialEncryptionService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/CredentialEncryptionService.kt
@@ -14,6 +14,7 @@ class CredentialEncryptionService(
     @Value("\${account-share.encryption-key}") base64Key: String,
 ) {
     private val secretKey: SecretKey
+    private val secureRandom = SecureRandom()
 
     init {
         val keyBytes = Base64.getDecoder().decode(base64Key)
@@ -23,7 +24,7 @@ class CredentialEncryptionService(
 
     // 저장 형식: base64(12-byte IV):base64(ciphertext + 16-byte GCM auth tag)
     fun encrypt(plaintext: String): String {
-        val iv = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val iv = ByteArray(12).also { secureRandom.nextBytes(it) }
         val cipher = Cipher.getInstance("AES/GCM/NoPadding")
         cipher.init(Cipher.ENCRYPT_MODE, secretKey, GCMParameterSpec(128, iv))
         val ciphertext = cipher.doFinal(plaintext.toByteArray(Charsets.UTF_8))

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/OAuthAccountService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/OAuthAccountService.kt
@@ -30,6 +30,10 @@ class OAuthAccountService(
 ) {
     private val restClient = restClientBuilder.build()
 
+    init {
+        require(oAuthProperties.stateSecret.isNotBlank()) { "account-share.oauth.state-secret must not be empty" }
+    }
+
     fun buildAuthorizeUrl(channelId: Long, userId: Long, provider: AccountProvider): String {
         val config = providerConfigOf(provider)
         val state = buildState(channelId, userId, provider)
@@ -98,6 +102,9 @@ class OAuthAccountService(
         val accessToken = exchangeCode(provider, config, code, callbackUrl)
         val identifier = fetchIdentifier(provider, config, accessToken)
 
+        sharedAccountRepository.findByChannelIdAndProviderAndAccountIdentifier(channelId, provider, identifier)
+            ?.let { return it }
+
         return sharedAccountRepository.save(
             SharedAccount(
                 channelId = channelId,
@@ -152,17 +159,17 @@ class OAuthAccountService(
             }
 
             AccountProvider.JIRA, AccountProvider.GOOGLE, AccountProvider.FACEBOOK -> {
-                val requestBody = mapOf(
-                    "grant_type" to "authorization_code",
-                    "client_id" to config.clientId,
-                    "client_secret" to config.clientSecret,
-                    "code" to code,
-                    "redirect_uri" to callbackUrl,
-                )
+                val body = LinkedMultiValueMap<String, String>().apply {
+                    add("grant_type", "authorization_code")
+                    add("client_id", config.clientId)
+                    add("client_secret", config.clientSecret)
+                    add("code", code)
+                    add("redirect_uri", callbackUrl)
+                }
                 val response = restClient.post()
                     .uri(config.tokenUrl)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(requestBody)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
                     .retrieve()
                     .body(Map::class.java) ?: throw ExpectedException("${provider.displayName} 토큰 교환 실패", HttpStatus.BAD_GATEWAY)
                 response["access_token"] as? String

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/SharedAccountService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/SharedAccountService.kt
@@ -114,6 +114,7 @@ class SharedAccountService(
     @Transactional
     fun copyCredential(userId: Long, channelId: Long, accountId: Long): String {
         val channel = channelService.findChannelOrThrow(channelId)
+        requireAccountShareChannel(channel)
         teamPermissionService.requireTeamMember(channel.teamId, userId)
         val account = findAccountOrThrow(accountId, channelId)
 

--- a/cowork-channel/src/main/resources/db/migration/V11__replace_channel_position_index_with_id.sql
+++ b/cowork-channel/src/main/resources/db/migration/V11__replace_channel_position_index_with_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tb_channels
+    DROP INDEX idx_tb_channels_team_position,
+    ADD INDEX idx_tb_channels_team_position_id (team_id, position, id);

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -3,6 +3,7 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import { Message, MessageDocument } from '../schema/message.schema';
 
+const MESSAGE_FETCH_LIMIT = 100;
 const FILE_ATTACHMENT_LIMIT = 100;
 
 export type FileAttachmentRow = {
@@ -52,7 +53,7 @@ export class MessageRepository {
         return this.messageModel.aggregate([
             { $match: query },
             { $sort: { _id: -1 } },
-            { $limit: 100 },
+            { $limit: MESSAGE_FETCH_LIMIT },
             {
                 $lookup: {
                     from: this.messageModel.collection.name,


### PR DESCRIPTION
## 개요

코드 리뷰 피드백을 반영하여 채널 정렬 일관성 개선 및 메시지 조회 관련 상수 관리 방식을 개선하였습니다.

## 본문

### [channel] ChannelEntity position 필드 추가 및 정렬 보조키 적용

`ChannelEntity`에 `position` 필드가 누락되어 있어 추가하였습니다.

`ChannelRepository`의 정렬 기준을 `id ASC` 단독에서 `position ASC, id ASC` 복합 정렬로 변경하였습니다. `position`은 비고유 필드이므로 동일한 position 값을 가진 채널 간 순서가 실행마다 달라질 수 있어, `id`를 보조 정렬 키로 추가하여 결과의 일관성을 보장하였습니다.

V7 마이그레이션에서 추가된 `(team_id, position)` 인덱스를 `(team_id, position, id)` 복합 인덱스로 교체하는 V11 마이그레이션을 추가하였습니다. 정렬 쿼리에 `id`가 포함됨에 따라 인덱스에도 동일하게 반영하여 인덱스 커버리지를 유지하였습니다.

### [chat] 메시지 조회 limit 상수 추출

`findMessages`에서 `$limit` 단계에 하드코딩된 `100`을 `MESSAGE_FETCH_LIMIT` 상수로 추출하였습니다. 기존 `FILE_ATTACHMENT_LIMIT`과 동일한 방식으로 관리되어 가독성과 유지보수성이 향상되었습니다.
