### PR TITLE
[chat] context 객체 파라미터 통합과 BaseHttpClient 추출

### DIFF
--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/OAuthAccountService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/OAuthAccountService.kt
@@ -174,17 +174,17 @@ class OAuthAccountService(
             }
 
             AccountProvider.JIRA -> {
-                val requestBody = mapOf(
-                    "grant_type" to "authorization_code",
-                    "client_id" to config.clientId,
-                    "client_secret" to config.clientSecret,
-                    "code" to code,
-                    "redirect_uri" to callbackUrl,
-                )
+                val body = LinkedMultiValueMap<String, String>().apply {
+                    add("grant_type", "authorization_code")
+                    add("client_id", config.clientId)
+                    add("client_secret", config.clientSecret)
+                    add("code", code)
+                    add("redirect_uri", callbackUrl)
+                }
                 val response = restClient.post()
                     .uri(config.tokenUrl)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(requestBody)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
                     .retrieve()
                     .body(Map::class.java) ?: throw ExpectedException("Jira 토큰 교환 실패", HttpStatus.BAD_GATEWAY)
                 response["access_token"] as? String

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -28,12 +28,8 @@ import {
     SendMessageResponseDto,
 } from './dto/message-response.dto';
 import { CreateGithubIssueDto, CreateGithubIssueResponseDto } from './dto/create-github-issue.dto';
-import {
-    SlashCommandDto,
-    SlashCommandResponseDto,
-} from './dto/slash-command.dto';
-import { FileListQueryDto } from './dto/file-list.dto';
-import { FileListResponseDto } from './dto/file-list.dto';
+import { SlashCommandDto, SlashCommandResponseDto } from './dto/slash-command.dto';
+import { FileListQueryDto, FileListResponseDto } from './dto/file-list.dto';
 import { UserId, UserRole } from '../common/decorator/user.decorator';
 
 @ApiTags('Chat')
@@ -53,7 +49,7 @@ export class ChatController {
         @Body() dto: CreateFileUploadUrlRequestDto,
         @UserId() userId: number,
     ): Promise<CreateFileUploadUrlResponseDto> {
-        return this.chatService.createFileUploadUrl(channelId, dto, userId);
+        return this.chatService.createFileUploadUrl({ channelId, userId }, dto);
     }
 
     @Post('files/confirm')
@@ -69,7 +65,7 @@ export class ChatController {
         @Body() dto: ConfirmFileUploadRequestDto,
         @UserId() userId: number,
     ): Promise<ConfirmFileUploadResponseDto> {
-        const fileUrl = await this.chatService.confirmFileUpload(channelId, dto.objectKey, userId);
+        const fileUrl = await this.chatService.confirmFileUpload({ channelId, userId }, dto);
         return { fileUrl };
     }
 
@@ -85,7 +81,7 @@ export class ChatController {
         @Query() query: FileListQueryDto,
         @UserId() userId: number,
     ): Promise<FileListResponseDto> {
-        return this.chatService.getFileList(channelId, userId, query.before, query.limit);
+        return this.chatService.getFileList({ channelId, userId }, query);
     }
 
     @Post('messages')
@@ -99,7 +95,7 @@ export class ChatController {
         @UserId() userId: number,
         @UserRole() userRole: string,
     ): Promise<SendMessageResponseDto> {
-        await this.chatService.sendMessage(channelId, dto, userId, userRole);
+        await this.chatService.sendMessage({ channelId, userId, userRole }, dto);
         return { queued: true };
     }
 
@@ -117,7 +113,7 @@ export class ChatController {
         @Body() dto: CreateGithubIssueDto,
         @UserId() userId: number,
     ): Promise<CreateGithubIssueResponseDto> {
-        await this.chatService.publishGithubIssueCreateCommand(channelId, dto, userId);
+        await this.chatService.publishGithubIssueCreateCommand({ channelId, userId }, dto);
         return { queued: true };
     }
 
@@ -135,7 +131,7 @@ export class ChatController {
         @Body() dto: SlashCommandDto,
         @UserId() userId: number,
     ): Promise<SlashCommandResponseDto> {
-        await this.chatService.handleSlashCommand(channelId, dto, userId);
+        await this.chatService.handleSlashCommand({ channelId, userId }, dto);
         return { queued: true };
     }
 
@@ -148,8 +144,7 @@ export class ChatController {
         @Query() query: GetMessagesDto,
         @UserId() userId: number,
     ): Promise<MessageResponseDto[]> {
-        await this.chatService.checkMembership(channelId, userId);
-        return this.chatService.getMessages(channelId, query.before) as any;
+        return this.chatService.getMessages({ channelId, userId }, query.before) as unknown as MessageResponseDto[];
     }
 
     @Patch('messages/:messageId')
@@ -164,7 +159,7 @@ export class ChatController {
         @UserId() userId: number,
         @UserRole() userRole: string,
     ) {
-        return this.chatService.editMessage(channelId, messageId, userId, dto, userRole);
+        return this.chatService.editMessage({ channelId, messageId, userId, userRole }, dto);
     }
 
     @Delete('messages/:messageId')
@@ -178,6 +173,6 @@ export class ChatController {
         @UserId() userId: number,
         @UserRole() userRole: string,
     ) {
-        return this.chatService.deleteMessage(channelId, messageId, userId, userRole);
+        return this.chatService.deleteMessage({ channelId, messageId, userId, userRole });
     }
 }

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -31,6 +31,7 @@ import { CreateGithubIssueDto, CreateGithubIssueResponseDto } from './dto/create
 import { SlashCommandDto, SlashCommandResponseDto } from './dto/slash-command.dto';
 import { FileListQueryDto, FileListResponseDto } from './dto/file-list.dto';
 import { UserId, UserRole } from '../common/decorator/user.decorator';
+import { MessageRow } from './repository/message.repository';
 
 @ApiTags('Chat')
 @ApiHeader({ name: 'X-User-Id', description: 'Gateway 주입 유저 ID', required: true })
@@ -143,8 +144,8 @@ export class ChatController {
         @Param('channelId', ParseIntPipe) channelId: number,
         @Query() query: GetMessagesDto,
         @UserId() userId: number,
-    ): Promise<MessageResponseDto[]> {
-        return this.chatService.getMessages({ channelId, userId }, query.before) as unknown as MessageResponseDto[];
+    ): Promise<MessageRow[]> {
+        return this.chatService.getMessages({ channelId, userId }, query.before);
     }
 
     @Patch('messages/:messageId')

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -138,33 +138,42 @@ describe('ChatService', () => {
 
     describe('getMessages', () => {
         it('메시지 조회를 레포지토리에 위임한다', async () => {
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findMessages.mockResolvedValue([]);
 
-            await service.getMessages(1);
+            await service.getMessages({ channelId: 1, userId: 42 });
 
             expect(mockMessageRepository.findMessages).toHaveBeenCalledWith(1, undefined);
         });
 
         it('before cursor를 레포지토리에 전달한다', async () => {
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findMessages.mockResolvedValue([]);
 
-            await service.getMessages(1, mockMessageId);
+            await service.getMessages({ channelId: 1, userId: 42 }, mockMessageId);
 
             expect(mockMessageRepository.findMessages).toHaveBeenCalledWith(1, mockMessageId);
         });
 
         it('레포지토리 조회 결과를 그대로 반환한다', async () => {
             const parentId = new Types.ObjectId();
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findMessages.mockResolvedValue([
                 { _id: new Types.ObjectId(), content: '답글', parentMessageId: parentId, mentionedMessage: { _id: parentId, content: '원본', authorId: 1 } },
                 { _id: new Types.ObjectId(), content: '일반 메시지', parentMessageId: null, mentionedMessage: null },
             ]);
 
-            const result = await service.getMessages(1);
+            const result = await service.getMessages({ channelId: 1, userId: 42 });
 
             expect(result[0].mentionedMessage).toBeDefined();
             expect(result[0].mentionedMessage?.content).toBe('원본');
             expect(result[1].mentionedMessage).toBeNull();
+        });
+
+        it('채널 멤버가 아니면 ForbiddenException을 던진다', async () => {
+            mockChannelMemberRepository.exists.mockResolvedValue(false);
+
+            await expect(service.getMessages({ channelId: 1, userId: 99 })).rejects.toThrow(ForbiddenException);
         });
     });
 
@@ -190,7 +199,7 @@ describe('ChatService', () => {
             });
             mockUserClient.getDisplayName.mockResolvedValue('홍길동');
 
-            const result = await service.getFileList(1, 42);
+            const result = await service.getFileList({ channelId: 1, userId: 42 }, {});
 
             expect(mockChannelClient.getChannel).toHaveBeenCalledWith(1, 42);
             expect(mockMessageRepository.findFileAttachments).toHaveBeenCalledWith(1, undefined, 20);
@@ -214,7 +223,7 @@ describe('ChatService', () => {
             mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockChannelClient.getChannel.mockResolvedValue({ id: 1, viewType: 'TEXT' });
 
-            await expect(service.getFileList(1, 42)).rejects.toThrow('FILE_SHARE 채널에서만 파일 목록을 조회할 수 있습니다');
+            await expect(service.getFileList({ channelId: 1, userId: 42 }, {})).rejects.toThrow('FILE_SHARE 채널에서만 파일 목록을 조회할 수 있습니다');
             expect(mockMessageRepository.findFileAttachments).not.toHaveBeenCalled();
         });
 
@@ -224,19 +233,21 @@ describe('ChatService', () => {
             mockChannelClient.getChannel.mockResolvedValue({ id: 1, viewType: 'FILE_SHARE' });
             mockMessageRepository.findFileAttachments.mockResolvedValue({ items: [], nextCursor: null });
 
-            await service.getFileList(1, 42, before, 20);
+            await service.getFileList({ channelId: 1, userId: 42 }, { before, limit: 20 });
 
             expect(mockMessageRepository.findFileAttachments).toHaveBeenCalledWith(1, before, 20);
         });
     });
 
     describe('editMessage', () => {
+        const ctx = (overrides = {}) => ({ channelId: 1, messageId: mockMessageId, userId: 42, userRole: 'MEMBER', ...overrides });
+
         it('본인 메시지를 수정하면 editHistory에 이전 내용이 저장된다', async () => {
             const msg = makeMockMessage();
             mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findById.mockResolvedValue(msg);
 
-            await service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER');
+            await service.editMessage(ctx(), { content: '수정됨' });
 
             expect(msg.editHistory).toHaveLength(1);
             expect(msg.editHistory[0].content).toBe('안녕하세요');
@@ -249,7 +260,7 @@ describe('ChatService', () => {
             mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findById.mockResolvedValue(null);
             await expect(
-                service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
+                service.editMessage(ctx(), { content: '수정됨' }),
             ).rejects.toThrow(NotFoundException);
         });
 
@@ -257,7 +268,7 @@ describe('ChatService', () => {
             mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
             await expect(
-                service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
+                service.editMessage(ctx(), { content: '수정됨' }),
             ).rejects.toThrow(ForbiddenException);
         });
 
@@ -266,7 +277,7 @@ describe('ChatService', () => {
             mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findById.mockResolvedValue(msg);
 
-            await service.editMessage(1, mockMessageId, 42, { content: '관리자 수정' }, 'ROLE_ADMIN');
+            await service.editMessage(ctx({ userRole: 'ROLE_ADMIN' }), { content: '관리자 수정' });
 
             expect(msg.save).toHaveBeenCalled();
         });
@@ -285,7 +296,7 @@ describe('ChatService', () => {
             mockMessageRepository.findById.mockResolvedValue(msg);
             mockElasticsearchService.updateMessage.mockResolvedValue(undefined);
 
-            await service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER');
+            await service.editMessage(ctx(), { content: '수정됨' });
 
             await new Promise((r) => setImmediate(r));
             expect(mockElasticsearchService.updateMessage).toHaveBeenCalledWith(mockMessageId, '수정됨');
@@ -296,7 +307,7 @@ describe('ChatService', () => {
             mockMessageRepository.findById.mockResolvedValue(makeMockMessage({ channelId: 2 }));
 
             await expect(
-                service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
+                service.editMessage(ctx(), { content: '수정됨' }),
             ).rejects.toThrow(ForbiddenException);
         });
 
@@ -305,7 +316,7 @@ describe('ChatService', () => {
             mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findById.mockResolvedValue(msg);
 
-            const result = await service.editMessage(1, mockMessageId, 42, { content: '안녕하세요' }, 'MEMBER');
+            const result = await service.editMessage(ctx(), { content: '안녕하세요' });
 
             expect(msg.save).not.toHaveBeenCalled();
             expect(mockElasticsearchService.updateMessage).not.toHaveBeenCalled();
@@ -325,7 +336,7 @@ describe('ChatService', () => {
             mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findById.mockResolvedValue(msg);
 
-            await service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER');
+            await service.editMessage(ctx(), { content: '수정됨' });
 
             expect(mockTo).toHaveBeenCalledWith('chat:1');
             expect(mockEmit).toHaveBeenCalledWith('message:edited', {
@@ -342,18 +353,20 @@ describe('ChatService', () => {
             mockElasticsearchService.updateMessage.mockRejectedValue(new Error('ES down'));
 
             await expect(
-                service.editMessage(1, mockMessageId, 42, { content: '수정됨' }, 'MEMBER'),
+                service.editMessage(ctx(), { content: '수정됨' }),
             ).resolves.toBeDefined();
         });
     });
 
     describe('deleteMessage', () => {
+        const ctx = (overrides = {}) => ({ channelId: 1, messageId: mockMessageId, userId: 42, userRole: 'MEMBER', ...overrides });
+
         it('본인 메시지를 삭제한다', async () => {
             mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findById.mockResolvedValue(makeMockMessage());
             mockMessageRepository.deleteById.mockResolvedValue({ deletedCount: 1 });
 
-            const result = await service.deleteMessage(1, mockMessageId, 42, 'MEMBER');
+            const result = await service.deleteMessage(ctx());
 
             expect(mockMessageRepository.deleteById).toHaveBeenCalledWith(mockMessageId);
             expect(result.messageId).toBe(mockMessageId);
@@ -363,7 +376,7 @@ describe('ChatService', () => {
             mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findById.mockResolvedValue(null);
             await expect(
-                service.deleteMessage(1, mockMessageId, 42, 'MEMBER'),
+                service.deleteMessage(ctx()),
             ).rejects.toThrow(NotFoundException);
         });
 
@@ -371,7 +384,7 @@ describe('ChatService', () => {
             mockChannelMemberRepository.exists.mockResolvedValue(true);
             mockMessageRepository.findById.mockResolvedValue(makeMockMessage({ authorId: 100 }));
             await expect(
-                service.deleteMessage(1, mockMessageId, 42, 'MEMBER'),
+                service.deleteMessage(ctx()),
             ).rejects.toThrow(ForbiddenException);
         });
 
@@ -381,7 +394,7 @@ describe('ChatService', () => {
             mockMessageRepository.deleteById.mockResolvedValue({ deletedCount: 1 });
 
             await expect(
-                service.deleteMessage(1, mockMessageId, 42, 'ROLE_ADMIN'),
+                service.deleteMessage(ctx({ userRole: 'ROLE_ADMIN' })),
             ).resolves.toBeDefined();
         });
 
@@ -391,7 +404,7 @@ describe('ChatService', () => {
             mockMessageRepository.deleteById.mockResolvedValue({ deletedCount: 1 });
             mockElasticsearchService.deleteMessage.mockResolvedValue(undefined);
 
-            await service.deleteMessage(1, mockMessageId, 42, 'MEMBER');
+            await service.deleteMessage(ctx());
 
             await new Promise((r) => setImmediate(r));
             expect(mockElasticsearchService.deleteMessage).toHaveBeenCalledWith(mockMessageId);
@@ -404,7 +417,7 @@ describe('ChatService', () => {
             mockElasticsearchService.deleteMessage.mockRejectedValue(new Error('ES down'));
 
             await expect(
-                service.deleteMessage(1, mockMessageId, 42, 'MEMBER'),
+                service.deleteMessage(ctx()),
             ).resolves.toBeDefined();
         });
     });

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -19,14 +19,24 @@ import { ChannelClient } from './service/channel.client';
 import { UserClient } from './service/user.client';
 import { ChatGateway } from './chat.gateway';
 import { SendMessageDto } from './dto/send-message.dto';
-import { CreateFileUploadUrlRequestDto, CreateFileUploadUrlResponseDto } from './dto/create-file-upload-url.dto';
+import {
+    ConfirmFileUploadRequestDto,
+    CreateFileUploadUrlRequestDto,
+    CreateFileUploadUrlResponseDto,
+} from './dto/create-file-upload-url.dto';
 import { CreateGithubIssueDto } from './dto/create-github-issue.dto';
 import { SlashCommand, SlashCommandDto } from './dto/slash-command.dto';
 import { SearchMessagesDto } from './dto/search-messages.dto';
 import { SearchMessagesResponseDto } from './dto/search-message-response.dto';
-import { FileListResponseDto } from './dto/file-list.dto';
+import { FileListQueryDto, FileListResponseDto } from './dto/file-list.dto';
 import { MessageRepository } from './repository/message.repository';
 import { ChannelMemberRepository } from './repository/channel-member.repository';
+import {
+    ChannelUserContext,
+    ChannelUserRoleContext,
+    MessageUserRoleContext,
+    UserContext,
+} from './dto/context';
 
 const SYSTEM_AUTHOR_ID = 0;
 const SYSTEM_AUTHOR_NAME = 'System';
@@ -66,14 +76,13 @@ export class ChatService {
     }
 
     async createFileUploadUrl(
-        channelId: number,
+        ctx: ChannelUserContext,
         dto: CreateFileUploadUrlRequestDto,
-        userId: number,
     ): Promise<CreateFileUploadUrlResponseDto> {
-        await this.checkMembership(channelId, userId);
+        await this.checkMembership(ctx.channelId, ctx.userId);
         const upload = await this.minioService.createPresignedUpload({
-            channelId,
-            userId,
+            channelId: ctx.channelId,
+            userId: ctx.userId,
             filename: dto.filename,
             contentType: dto.contentType,
             size: dto.size,
@@ -87,25 +96,21 @@ export class ChatService {
         };
     }
 
-    async confirmFileUpload(channelId: number, objectKey: string, userId: number): Promise<string> {
-        await this.checkMembership(channelId, userId);
-        return this.minioService.confirmUpload(channelId, userId, objectKey);
+    async confirmFileUpload(ctx: ChannelUserContext, dto: ConfirmFileUploadRequestDto): Promise<string> {
+        await this.checkMembership(ctx.channelId, ctx.userId);
+        return this.minioService.confirmUpload(ctx.channelId, ctx.userId, dto.objectKey);
     }
 
-    async getFileList(
-        channelId: number,
-        userId: number,
-        before?: string,
-        limit = 20,
-    ): Promise<FileListResponseDto> {
-        await this.checkMembership(channelId, userId);
+    async getFileList(ctx: ChannelUserContext, query: FileListQueryDto): Promise<FileListResponseDto> {
+        await this.checkMembership(ctx.channelId, ctx.userId);
 
-        const channel = await this.channelClient.getChannel(channelId, userId);
+        const channel = await this.channelClient.getChannel(ctx.channelId, ctx.userId);
         if (channel.viewType !== FILE_SHARE_VIEW_TYPE) {
             throw new BadRequestException('FILE_SHARE 채널에서만 파일 목록을 조회할 수 있습니다');
         }
 
-        const { items, nextCursor } = await this.messageRepository.findFileAttachments(channelId, before, limit);
+        const limit = query.limit ?? 20;
+        const { items, nextCursor } = await this.messageRepository.findFileAttachments(ctx.channelId, query.before, limit);
         const uploaderNames = await this.loadUploaderNames(items);
 
         return {
@@ -123,33 +128,20 @@ export class ChatService {
         };
     }
 
-    async sendMessage(
-        channelId: number,
-        dto: SendMessageDto,
-        userId: number,
-        userRole: string,
-    ): Promise<void> {
-        await this.checkMembership(channelId, userId);
-        await this.chatMessageProducer.sendMessage(channelId, dto, userId, userRole);
+    async sendMessage(ctx: ChannelUserRoleContext, dto: SendMessageDto): Promise<void> {
+        await this.checkMembership(ctx.channelId, ctx.userId);
+        await this.chatMessageProducer.sendMessage(ctx.channelId, dto, ctx.userId, ctx.userRole);
     }
 
-    async handleSlashCommand(
-        channelId: number,
-        dto: SlashCommandDto,
-        userId: number,
-    ): Promise<void> {
+    async handleSlashCommand(ctx: ChannelUserContext, dto: SlashCommandDto): Promise<void> {
         if (dto.command !== SlashCommand.GITHUB_ISSUE_CREATE) {
             throw new BadRequestException('지원하지 않는 슬래시 커맨드입니다');
         }
-        await this.publishGithubIssueCreateCommand(channelId, dto.payload, userId);
+        await this.publishGithubIssueCreateCommand(ctx, dto.payload);
     }
 
-    async publishGithubIssueCreateCommand(
-        channelId: number,
-        dto: CreateGithubIssueDto,
-        userId: number,
-    ): Promise<void> {
-        const channelTeamId = await this.checkMembershipAndGetTeamId(channelId, userId);
+    async publishGithubIssueCreateCommand(ctx: ChannelUserContext, dto: CreateGithubIssueDto): Promise<void> {
+        const channelTeamId = await this.checkMembershipAndGetTeamId(ctx.channelId, ctx.userId);
         const repoInfo = await this.projectClient.getGithubRepoInfo(dto.projectId);
         if (!repoInfo) {
             throw new BadRequestException('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
@@ -159,32 +151,33 @@ export class ChatService {
         }
 
         await this.githubIssueProducer.send({
-            channelId,
+            channelId: ctx.channelId,
             teamId: repoInfo.teamId,
             projectId: dto.projectId,
             owner: repoInfo.owner,
             repo: repoInfo.repo,
             title: dto.title,
             body: dto.body,
-            requesterId: userId,
+            requesterId: ctx.userId,
         });
     }
 
-    async getMessages(channelId: number, before?: string) {
-        return this.messageRepository.findMessages(channelId, before);
+    async getMessages(ctx: ChannelUserContext, before?: string) {
+        await this.checkMembership(ctx.channelId, ctx.userId);
+        return this.messageRepository.findMessages(ctx.channelId, before);
     }
 
     async searchProjectMessages(
         projectId: number,
         dto: SearchMessagesDto,
-        userId: number,
+        ctx: UserContext,
     ): Promise<SearchMessagesResponseDto> {
-        const isMember = await this.projectClient.isMember(projectId, userId);
+        const isMember = await this.projectClient.isMember(projectId, ctx.userId);
         if (!isMember) {
             throw new ForbiddenException('프로젝트 접근 권한이 없습니다');
         }
 
-        const accessibleChannelIds = await this.channelMemberRepository.findChannelIdsByUser(userId);
+        const accessibleChannelIds = await this.channelMemberRepository.findChannelIdsByUser(ctx.userId);
 
         let filteredChannelIds = accessibleChannelIds;
         if (dto.channelId !== undefined) {
@@ -208,16 +201,8 @@ export class ChatService {
         return { messages: hits, nextCursor };
     }
 
-    async editMessage(channelId: number, messageId: string, userId: number, dto: EditMessageDto, userRole: string) {
-        await this.checkMembership(channelId, userId);
-        const message = await this.messageRepository.findById(messageId);
-        if (!message) throw new NotFoundException('메시지를 찾을 수 없습니다');
-        if (message.channelId !== channelId) {
-            throw new ForbiddenException('해당 채널의 메시지가 아닙니다');
-        }
-        if (message.authorId !== userId && !this.isAdmin(userRole)) {
-            throw new ForbiddenException('본인 메시지만 수정할 수 있습니다');
-        }
+    async editMessage(ctx: MessageUserRoleContext, dto: EditMessageDto) {
+        const message = await this.findAndVerifyMessage(ctx, '본인 메시지만 수정할 수 있습니다');
 
         if (message.content === dto.content) {
             return message;
@@ -228,13 +213,13 @@ export class ChatService {
         message.isEdited = true;
         const updated = await message.save();
         if (updated.projectId) {
-            void this.elasticsearchService.updateMessage(messageId, dto.content);
+            void this.elasticsearchService.updateMessage(ctx.messageId, dto.content);
         }
 
         this.chatGateway.server
-            ?.to(`chat:${channelId}`)
+            ?.to(`chat:${ctx.channelId}`)
             .emit('message:edited', {
-                messageId,
+                messageId: ctx.messageId,
                 content: updated.content,
                 editedAt: (updated as MessageDocument).updatedAt?.toISOString(),
             });
@@ -242,27 +227,19 @@ export class ChatService {
         return updated;
     }
 
-    async deleteMessage(channelId: number, messageId: string, userId: number, userRole: string) {
-        await this.checkMembership(channelId, userId);
-        const message = await this.messageRepository.findById(messageId);
-        if (!message) throw new NotFoundException('메시지를 찾을 수 없습니다');
-        if (message.channelId !== channelId) {
-            throw new ForbiddenException('해당 채널의 메시지가 아닙니다');
-        }
-        if (message.authorId !== userId && !this.isAdmin(userRole)) {
-            throw new ForbiddenException('본인 메시지만 삭제할 수 있습니다');
-        }
+    async deleteMessage(ctx: MessageUserRoleContext) {
+        const message = await this.findAndVerifyMessage(ctx, '본인 메시지만 삭제할 수 있습니다');
 
-        await this.messageRepository.deleteById(messageId);
+        await this.messageRepository.deleteById(ctx.messageId);
         if (message.projectId) {
-            void this.elasticsearchService.deleteMessage(messageId);
+            void this.elasticsearchService.deleteMessage(ctx.messageId);
         }
 
         this.chatGateway.server
-            ?.to(`chat:${channelId}`)
-            .emit('message:deleted', { messageId });
+            ?.to(`chat:${ctx.channelId}`)
+            .emit('message:deleted', { messageId: ctx.messageId });
 
-        return { channelId: message.channelId, messageId };
+        return { channelId: message.channelId, messageId: ctx.messageId };
     }
 
     async saveSystemMessage(
@@ -276,6 +253,18 @@ export class ChatService {
 
     private isAdmin(role: string): boolean {
         return role === UserRole.ADMIN;
+    }
+
+    private async findAndVerifyMessage(
+        ctx: MessageUserRoleContext,
+        forbiddenMessage: string,
+    ): Promise<MessageDocument> {
+        await this.checkMembership(ctx.channelId, ctx.userId);
+        const message = await this.messageRepository.findById(ctx.messageId);
+        if (!message) throw new NotFoundException('메시지를 찾을 수 없습니다');
+        if (message.channelId !== ctx.channelId) throw new ForbiddenException('해당 채널의 메시지가 아닙니다');
+        if (message.authorId !== ctx.userId && !this.isAdmin(ctx.userRole)) throw new ForbiddenException(forbiddenMessage);
+        return message;
     }
 
     private async loadUploaderNames(items: Array<{ uploaderId: number }>): Promise<Map<number, string>> {

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -29,7 +29,7 @@ import { SlashCommand, SlashCommandDto } from './dto/slash-command.dto';
 import { SearchMessagesDto } from './dto/search-messages.dto';
 import { SearchMessagesResponseDto } from './dto/search-message-response.dto';
 import { FileListQueryDto, FileListResponseDto } from './dto/file-list.dto';
-import { MessageRepository } from './repository/message.repository';
+import { MessageRepository, MessageRow } from './repository/message.repository';
 import { ChannelMemberRepository } from './repository/channel-member.repository';
 import {
     ChannelUserContext,
@@ -162,7 +162,7 @@ export class ChatService {
         });
     }
 
-    async getMessages(ctx: ChannelUserContext, before?: string) {
+    async getMessages(ctx: ChannelUserContext, before?: string): Promise<MessageRow[]> {
         await this.checkMembership(ctx.channelId, ctx.userId);
         return this.messageRepository.findMessages(ctx.channelId, before);
     }

--- a/cowork-chat/src/chat/dto/context.ts
+++ b/cowork-chat/src/chat/dto/context.ts
@@ -1,0 +1,4 @@
+export type UserContext = { userId: number };
+export type ChannelUserContext = { channelId: number; userId: number };
+export type ChannelUserRoleContext = { channelId: number; userId: number; userRole: string };
+export type MessageUserRoleContext = { channelId: number; messageId: string; userId: number; userRole: string };

--- a/cowork-chat/src/chat/project-message.controller.ts
+++ b/cowork-chat/src/chat/project-message.controller.ts
@@ -42,6 +42,6 @@ export class ProjectMessageController {
         @Query() dto: SearchMessagesDto,
         @UserId() userId: number,
     ): Promise<SearchMessagesResponseDto> {
-        return this.chatService.searchProjectMessages(projectId, dto, userId);
+        return this.chatService.searchProjectMessages(projectId, dto, { userId });
     }
 }

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -38,13 +38,40 @@ export type CreateMessageInput = {
 
 export type NotificationMessage = Message & { _id: Types.ObjectId; createdAt: Date };
 
+export type MentionedMessageRow = {
+    _id: Types.ObjectId;
+    authorId: number;
+    content: string;
+    type: string;
+    createdAt: Date;
+};
+
+export type MessageRow = {
+    _id: Types.ObjectId;
+    teamId: number;
+    projectId: number | null;
+    channelId: number;
+    authorId: number;
+    content: string;
+    type: string;
+    attachments: Array<{ name: string; url: string; size: number; mimeType: string }>;
+    parentMessageId: Types.ObjectId | null;
+    isEdited: boolean;
+    isPinned: boolean;
+    clientMessageId?: string | null;
+    mentions: number[];
+    createdAt: Date;
+    updatedAt: Date;
+    mentionedMessage: MentionedMessageRow | null;
+};
+
 @Injectable()
 export class MessageRepository {
     constructor(
         @InjectModel(Message.name) private readonly messageModel: Model<Message>,
     ) {}
 
-    findMessages(channelId: number, before?: string) {
+    findMessages(channelId: number, before?: string): Promise<MessageRow[]> {
         const query: Record<string, unknown> = { channelId };
         if (before) {
             query['_id'] = { $lt: new Types.ObjectId(before) };

--- a/cowork-chat/src/chat/service/base-http-client.ts
+++ b/cowork-chat/src/chat/service/base-http-client.ts
@@ -1,0 +1,24 @@
+import { Logger } from '@nestjs/common';
+
+export abstract class BaseHttpClient {
+    protected abstract readonly logger: Logger;
+    protected abstract readonly serviceName: string;
+
+    protected async readErrorMessage(res: Response): Promise<string | null> {
+        try {
+            return await res.text();
+        } catch (err) {
+            this.logger.warn(`${this.serviceName} 오류 응답 본문 읽기 실패: ${String(err)}`);
+            return null;
+        }
+    }
+
+    protected async readJsonBody<T>(res: Response): Promise<T> {
+        try {
+            return await res.json() as T;
+        } catch (err) {
+            this.logger.warn(`${this.serviceName} JSON 응답 파싱 실패: ${String(err)}`);
+            throw new Error(`${this.serviceName} 응답 본문 파싱에 실패했습니다`);
+        }
+    }
+}

--- a/cowork-chat/src/chat/service/channel.client.ts
+++ b/cowork-chat/src/chat/service/channel.client.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getRequiredConfig } from '../../common/config/config.util';
+import { BaseHttpClient } from './base-http-client';
 
 export interface ChannelInfo {
     id: number;
@@ -8,11 +9,13 @@ export interface ChannelInfo {
 }
 
 @Injectable()
-export class ChannelClient {
-    private readonly logger = new Logger(ChannelClient.name);
+export class ChannelClient extends BaseHttpClient {
+    protected readonly logger = new Logger(ChannelClient.name);
+    protected readonly serviceName = 'channel-service';
     private readonly channelServiceUrl: string;
 
     constructor(private readonly configService: ConfigService) {
+        super();
         this.channelServiceUrl = getRequiredConfig(this.configService, 'CHANNEL_SERVICE_URL').replace(/\/$/, '');
     }
 
@@ -27,7 +30,7 @@ export class ChannelClient {
             throw new Error(`channel-service 오류: ${res.status}${message ? ` - ${message}` : ''}`);
         }
 
-        const body = await this.readJsonBody(res);
+        const body = await this.readJsonBody<{ id?: number; viewType?: string }>(res);
         if (typeof body.id !== 'number' || typeof body.viewType !== 'string') {
             throw new Error('channel-service 응답 형식이 올바르지 않습니다');
         }
@@ -36,23 +39,5 @@ export class ChannelClient {
             id: body.id,
             viewType: body.viewType,
         };
-    }
-
-    private async readErrorMessage(res: Response): Promise<string | null> {
-        try {
-            return await res.text();
-        } catch (err) {
-            this.logger.warn(`channel-service 오류 응답 본문 읽기 실패: ${String(err)}`);
-            return null;
-        }
-    }
-
-    private async readJsonBody(res: Response): Promise<{ id?: number; viewType?: string }> {
-        try {
-            return await res.json() as { id?: number; viewType?: string };
-        } catch (err) {
-            this.logger.warn(`channel-service JSON 응답 파싱 실패: ${String(err)}`);
-            throw new Error('channel-service 응답 본문 파싱에 실패했습니다');
-        }
     }
 }

--- a/cowork-chat/src/chat/service/user.client.ts
+++ b/cowork-chat/src/chat/service/user.client.ts
@@ -1,13 +1,16 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getRequiredConfig } from '../../common/config/config.util';
+import { BaseHttpClient } from './base-http-client';
 
 @Injectable()
-export class UserClient {
-    private readonly logger = new Logger(UserClient.name);
+export class UserClient extends BaseHttpClient {
+    protected readonly logger = new Logger(UserClient.name);
+    protected readonly serviceName = 'user-service';
     private readonly userServiceUrl: string;
 
     constructor(private readonly configService: ConfigService) {
+        super();
         this.userServiceUrl = getRequiredConfig(this.configService, 'USER_SERVICE_URL').replace(/\/$/, '');
     }
 
@@ -21,7 +24,7 @@ export class UserClient {
             throw new Error(`user-service 오류: ${res.status}${message ? ` - ${message}` : ''}`);
         }
 
-        const body = await this.readJsonBody(res);
+        const body = await this.readJsonBody<{ name?: string; nickname?: string | null }>(res);
         if (typeof body.name !== 'string' || body.name.length === 0) {
             throw new Error('user-service 응답 형식이 올바르지 않습니다');
         }
@@ -31,23 +34,5 @@ export class UserClient {
         }
 
         return body.name;
-    }
-
-    private async readErrorMessage(res: Response): Promise<string | null> {
-        try {
-            return await res.text();
-        } catch (err) {
-            this.logger.warn(`user-service 오류 응답 본문 읽기 실패: ${String(err)}`);
-            return null;
-        }
-    }
-
-    private async readJsonBody(res: Response): Promise<{ name?: string; nickname?: string | null }> {
-        try {
-            return await res.json() as { name?: string; nickname?: string | null };
-        } catch (err) {
-            this.logger.warn(`user-service JSON 응답 파싱 실패: ${String(err)}`);
-            throw new Error('user-service 응답 본문 파싱에 실패했습니다');
-        }
     }
 }


### PR DESCRIPTION
## 개요

`cowork-chat` 모듈의 서비스 메서드 파라미터를 context 객체로 통합하고, HTTP 클라이언트 공통 로직을 `BaseHttpClient` 추상 클래스로 추출하였습니다. 코드 리뷰 반영으로 Jira OAuth 요청 형식 수정 및 타입 안정성 개선도 포함하였습니다.

## 본문

### 1. BaseHttpClient 추출

`ChannelClient`와 `UserClient`에 각각 중복으로 존재하던 `readErrorMessage`, `readJsonBody` 메서드를 `BaseHttpClient` 추상 클래스로 추출하였습니다. 두 클라이언트 모두 이 클래스를 상속받도록 변경하여 중복 코드를 제거하였습니다. `readJsonBody`는 제네릭 타입을 활용하도록 개선하였습니다.

### 2. Context 객체 파라미터 통합

`ChatService`의 여러 메서드에 흩어져 있던 `channelId`, `userId`, `userRole`, `messageId` 파라미터를 아래 4가지 context 타입으로 통합하였습니다.

- `UserContext`: `{ userId }`
- `ChannelUserContext`: `{ channelId, userId }`
- `ChannelUserRoleContext`: `{ channelId, userId, userRole }`
- `MessageUserRoleContext`: `{ channelId, messageId, userId, userRole }`

### 3. findAndVerifyMessage 추출

`editMessage`와 `deleteMessage`에 동일하게 존재하던 멤버십 확인 → 메시지 조회 → 채널 일치 검증 → 권한 검증 흐름을 `findAndVerifyMessage` private 메서드로 추출하였습니다.

### 4. getMessages 멤버십 검증 추가

기존에는 컨트롤러에서 `checkMembership`을 별도로 호출한 뒤 `getMessages`를 호출하는 방식이었습니다. 멤버십 검증 책임을 서비스 레이어로 이동하여 호출 측에서 순서를 신경 쓰지 않아도 되도록 개선하였습니다.

### 5. Jira OAuth 토큰 교환 형식 수정

Jira 토큰 교환 엔드포인트 요청을 RFC 6749 표준에 따라 `application/json` 대신 `application/x-www-form-urlencoded` 형식으로 변경하였습니다. Google, Facebook과 동일한 방식으로 통일하였습니다.

### 6. MessageRow 타입 추가 및 이중 캐스팅 제거

`findMessages` aggregate 결과를 표현하는 `MessageRow`, `MentionedMessageRow` 타입을 `message.repository.ts`에 추가하고 명시적 반환 타입을 선언하였습니다. 이를 통해 컨트롤러의 `as unknown as MessageResponseDto[]` 이중 캐스팅을 제거하고 타입 안정성을 확보하였습니다.
