### PR TITLE
[channel] 크리덴셜 마스킹 로직 개선

### DIFF
--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/SharedAccountResponse.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/SharedAccountResponse.kt
@@ -26,7 +26,7 @@ data class SharedAccountResponse(
     @Schema(description = "로그인 식별자 (이메일 또는 username)", example = "team@company.com")
     val accountIdentifier: String?,
 
-    @Schema(description = "마스킹된 credential (마지막 4자리만 노출)", example = "••••w0rd!")
+    @Schema(description = "마스킹된 credential (길이에 따라 마지막 2~4자리 노출)", example = "••••w0rd!")
     val maskedCredential: String?,
 
     @Schema(description = "OAuth 연동으로 등록된 계정 여부")

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/CredentialEncryptionService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/CredentialEncryptionService.kt
@@ -43,10 +43,10 @@ class CredentialEncryptionService(
         return String(cipher.doFinal(ciphertext), Charsets.UTF_8)
     }
 
-    // "••••1234" 형식
+    // 마스킹 처리 (길이에 따라 마지막 2~4자리 노출, 4자 이하면 전체 마스킹)
     fun mask(plaintext: String): String {
         if (plaintext.length <= 4) return "••••"
         val show = minOf(4, plaintext.length / 2)
-        return "••••" + plaintext.takeLast(show)
+        return "••••${plaintext.takeLast(show)}"
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/CredentialEncryptionService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/CredentialEncryptionService.kt
@@ -43,7 +43,10 @@ class CredentialEncryptionService(
         return String(cipher.doFinal(ciphertext), Charsets.UTF_8)
     }
 
-    // "••••1234" 형식 (마지막 4자리만 노출, 전체가 4자 이하면 전부 마스킹)
-    fun mask(plaintext: String): String =
-        if (plaintext.length <= 4) "••••" else "••••" + plaintext.takeLast(4)
+    // "••••1234" 형식
+    fun mask(plaintext: String): String {
+        if (plaintext.length <= 4) return "••••"
+        val show = minOf(4, plaintext.length / 2)
+        return "••••" + plaintext.takeLast(show)
+    }
 }


### PR DESCRIPTION
## 개요

공용 계정의 크리덴셜 마스킹 로직을 개선하였습니다.

## 본문

기존의 고정된 4자리 노출 방식에서, 보안성을 강화하기 위해 문자열 길이에 따라 노출되는 자리수를 유연하게 결정하도록 변경하였습니다.
- 4자 이하인 경우 전체를 마스킹합니다.
- 4자 초과인 경우 문자열 길이의 절반과 4 중 작은 값만큼만 노출하도록 로직을 수정하였습니다.
