### PR TITLE
[chat] bootstrap 실패 시 `process.exit` 누락 버그 수정

### DIFF
--- a/cowork-chat/src/main.ts
+++ b/cowork-chat/src/main.ts
@@ -90,5 +90,6 @@ async function bootstrap() {
 }
 
 bootstrap().catch((err) => {
-    new Logger('Bootstrap').error('Application failed to start', err);
+    console.error('Application failed to start', err);
+    process.exit(1);
 });

--- a/docs/LOCAL_RUN_GUIDE.md
+++ b/docs/LOCAL_RUN_GUIDE.md
@@ -197,13 +197,13 @@ Kafka는 외부 접근용(`9094`)과 컨테이너 내부용(`9092`) 리스너가
 
 `local`/`dev`/`prod` 프로파일 모두에서 Config Server가 Vault와 native 설정을 합쳐 내려준다. Spring Boot 이외 애플리케이션도 같은 기준으로 이 값을 읽는다.
 
-| 서비스 유형                                  | 시크릿 경로                      |
-|-----------------------------------------|-----------------------------|
-| Spring Boot | Vault → Config Server → 서비스 |
+| 서비스 유형                                        | 시크릿 경로                      |
+|-----------------------------------------------|-----------------------------|
+| Spring Boot                                   | Vault → Config Server → 서비스 |
 | Go (`authorization`, `notification`, `voice`) | Vault → Config Server → 서비스 |
-| Elixir (`user`) | Vault → Config Server → 서비스 |
-| Kotlin (`preference`) | Vault → Config Server → 서비스 |
-| NestJS (`chat`) | Vault → Config Server → 서비스 |
+| Elixir (`user`)                               | Vault → Config Server → 서비스 |
+| Kotlin (`preference`)                         | Vault → Config Server → 서비스 |
+| NestJS (`chat`)                               | Vault → Config Server → 서비스 |
 
 `vault-init` 컨테이너가 Vault 기동 직후 `secret/application` 경로에 아래 시크릿을 자동으로 기록한다.
 
@@ -217,29 +217,29 @@ Kafka는 외부 접근용(`9094`)과 컨테이너 내부용(`9092`) 리스너가
 
 추가로 서비스별 Vault 경로도 같이 시드된다.
 
-| Vault 경로 | 주요 키 |
-|---|---|
-| `secret/cowork-authorization` | `DB_DSN`, `DATAGSM_CLIENT_ID`, `JWT_SECRET` |
-| `secret/cowork-notification` | `db.dsn` |
-| `secret/cowork-voice` | `MONGODB_URI`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` |
-| `secret/cowork-chat` | `MONGODB_URI`, `ELASTICSEARCH_URL` |
+| Vault 경로                      | 주요 키                                                   |
+|-------------------------------|--------------------------------------------------------|
+| `secret/cowork-authorization` | `DB_DSN`, `DATAGSM_CLIENT_ID`, `JWT_SECRET`            |
+| `secret/cowork-notification`  | `db.dsn`                                               |
+| `secret/cowork-voice`         | `MONGODB_URI`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` |
+| `secret/cowork-chat`          | `MONGODB_URI`, `ELASTICSEARCH_URL`                     |
 
 `.env`에서 `SPRING_PROFILES_ACTIVE=dev`로 변경하면 config server가 Vault composite 모드로 전환된다. `VAULT_HOST`는 `cowork-vault`로 자동 설정된다.
 
 ## 10. 자주 쓰는 확인 포인트
 
-| 서비스                  | URL                                                          |
-|----------------------|--------------------------------------------------------------|
-| Eureka Dashboard     | `http://localhost:8761`                                      |
-| Gateway Swagger      | `http://localhost:8080/swagger-ui.html`                      |
-| Kafka UI             | `http://localhost:8090`                                      |
-| Prometheus           | `http://localhost:9090`                                      |
-| Grafana              | `http://localhost:3001`                                      |
-| MinIO Console        | `http://localhost:9002`                                      |
-| Vault                | `http://localhost:8200`                                      |
-| Elasticsearch 클러스터 상태 | `http://localhost:9200/_cluster/health`                      |
-| chat_messages 인덱스 확인 | `http://localhost:9200/chat_messages/_count`                 |
-| 인덱스 목록              | `http://localhost:9200/_cat/indices?v`                       |
+| 서비스                   | URL                                          |
+|-----------------------|----------------------------------------------|
+| Eureka Dashboard      | `http://localhost:8761`                      |
+| Gateway Swagger       | `http://localhost:8080/swagger-ui.html`      |
+| Kafka UI              | `http://localhost:8090`                      |
+| Prometheus            | `http://localhost:9090`                      |
+| Grafana               | `http://localhost:3001`                      |
+| MinIO Console         | `http://localhost:9002`                      |
+| Vault                 | `http://localhost:8200`                      |
+| Elasticsearch 클러스터 상태 | `http://localhost:9200/_cluster/health`      |
+| chat_messages 인덱스 확인  | `http://localhost:9200/chat_messages/_count` |
+| 인덱스 목록                | `http://localhost:9200/_cat/indices?v`       |
 
 ## 11. 알려진 주의사항
 

--- a/docs/LOCAL_RUN_GUIDE.md
+++ b/docs/LOCAL_RUN_GUIDE.md
@@ -8,6 +8,7 @@
 - 2026-04-28 (vault-init 추가, gateway JWT_SECRET 주입 수정, authorization USER_SERVICE_URL 수정)
 - 2026-05-02 (`cowork-user` Elixir 전환, Flyway 자동 실행, healthcheck 검증 반영)
 - 2026-05-11 (Elasticsearch 검색 인덱싱 추가, 로컬 배포 고려 사항 보완)
+- 2026-05-26 (ACCOUNT_CREDENTIAL_ENCRYPTION_KEY·ACCOUNT_SHARE_OAUTH_STATE_SECRET 누락 보완, cowork-chat cold-start 경쟁 조건 주의사항 추가)
 
 검증 기준:
 - `docker-compose.yml`
@@ -53,13 +54,15 @@ cp .env.example .env
 
 | 키                       | 기본값                              | 필요한 경우                                |
 |-------------------------|----------------------------------|---------------------------------------|
-| `LIVEKIT_API_KEY`       | `devkey`                         | 로컬 LiveKit / voice 기본값                |
-| `LIVEKIT_API_SECRET`    | `devsecret`                      | 로컬 LiveKit / voice 기본값                |
-| `LIVEKIT_CONFIG_FILE`   | `livekit.yaml`                   | 클라우드·운영 환경에서 `livekit-cloud.yaml`로 변경 |
-| `OAUTH2_GOOGLE_*`       | 비어 있음                            | Google OAuth2 사용 시                    |
-| `OAUTH2_GITHUB_*`       | 비어 있음                            | GitHub OAuth2 사용 시                    |
-| `MINIO_PUBLIC_ENDPOINT` | `http://__LOCAL_IP__:9000`       | 모바일 앱·외부 기기에서 파일 접근 시 실제 IP로 수정       |
-| `ELASTICSEARCH_URL`     | `http://elasticsearch:9200`      | 운영 환경에서 관리형 ES 클러스터 주소로 변경            |
+| `LIVEKIT_API_KEY`                    | `devkey`                    | 로컬 LiveKit / voice 기본값                |
+| `LIVEKIT_API_SECRET`                 | `devsecret`                 | 로컬 LiveKit / voice 기본값                |
+| `LIVEKIT_CONFIG_FILE`                | `livekit.yaml`              | 클라우드·운영 환경에서 `livekit-cloud.yaml`로 변경 |
+| `OAUTH2_GOOGLE_*`                    | 비어 있음                       | Google OAuth2 사용 시                    |
+| `OAUTH2_GITHUB_*`                    | 비어 있음                       | GitHub OAuth2 사용 시                    |
+| `MINIO_PUBLIC_ENDPOINT`              | `http://__LOCAL_IP__:9000`  | 모바일 앱·외부 기기에서 파일 접근 시 실제 IP로 수정       |
+| `ELASTICSEARCH_URL`                  | `http://elasticsearch:9200` | 운영 환경에서 관리형 ES 클러스터 주소로 변경            |
+| `ACCOUNT_CREDENTIAL_ENCRYPTION_KEY`  | 비어 있음                       | **필수** — `openssl rand -base64 32`로 생성, 없으면 vault-init이 빈 값으로 시드 |
+| `ACCOUNT_SHARE_OAUTH_STATE_SECRET`   | 비어 있음                       | **필수** — `openssl rand -base64 32`로 생성, 없으면 vault-init이 빈 값으로 시드 |
 
 Firebase 관련:
 - `docker/secrets/firebase-credentials.json` 파일이 실제로 있어야 `cowork-notification`이 기동된다.
@@ -284,6 +287,7 @@ Kafka는 외부 접근용(`9094`)과 컨테이너 내부용(`9092`) 리스너가
 - **인덱스 자동 생성**: 앱 기동 시 `OnModuleInit`에서 `chat_messages` 인덱스가 없으면 자동 생성한다. nori 분석기와 `createdAt` + `messageId` 복합 정렬이 기본 설정된다.
 - **커서 형식**: 검색 페이지네이션의 `nextCursor`는 ES `sort` 배열(`[createdAt, messageId]`)을 `base64(JSON.stringify(...))` 인코딩한 불투명 문자열이다. 이전 방식(messageId 단순 문자열)과 **호환되지 않으므로** 기존 커서를 가진 클라이언트는 재조회가 필요하다.
 - ES 기동이 느릴 경우(`start_period: 60s`): `docker compose logs -f elasticsearch`로 상태 확인 후 `cowork-chat` 재시작
+- **cold-start Kafka 경쟁 조건**: `cowork-chat`의 Kafka consumer는 모듈 초기화 시 `subscribe()`를 호출한다. 최초 `docker compose up` 시 다른 서비스가 Kafka 토픽을 아직 생성하지 않은 상태라면 `UNKNOWN_TOPIC_OR_PARTITION` 오류로 NestJS 초기화가 실패하고 HTTP 서버가 열리지 않는다. `process.exit(1)` 처리로 컨테이너가 자동 재시작되며, 1~2회 재시작 후 토픽이 모두 생성되면 정상 기동된다. 수동으로 해결하려면 `docker compose restart cowork-chat`을 실행하면 된다.
 
 `MINIO_PUBLIC_ENDPOINT`:
 - `scripts/run/local/infra.sh`와 `scripts/run/local/*.sh`는 `.env`의 `__LOCAL_IP__`를 현재 LAN IP로 자동 치환한다.


### PR DESCRIPTION
## 개요

`cowork-chat`의 `bootstrap()` 실패 시 `process.exit(1)`이 없어 NestJS 초기화 실패 후에도 node 프로세스가 살아있고 컨테이너가 자동 재시작되지 않는 버그를 수정하였습니다. 아울러 로컬 구동 검증 중 발견한 `.env` 누락 항목 및 cold-start 경쟁 조건 내용을 `LOCAL_RUN_GUIDE.md`에 보완하였습니다.

## 본문

### 버그 수정 — `cowork-chat/src/main.ts`

`bootstrap()` 함수가 실패하면 `.catch()` 핸들러에서 오류를 로깅만 하고 프로세스를 종료하지 않았습니다. 이로 인해 NestJS 모듈 초기화가 실패하더라도 node 프로세스가 계속 실행 상태를 유지하고, Docker의 `restart: unless-stopped` 정책이 동작하지 않아 컨테이너가 자동으로 재시작되지 않았습니다.

- `new Logger('Bootstrap').error(...)` → `console.error(...)` + `process.exit(1)` 로 변경
- 실패 시 컨테이너가 즉시 재시작되어 Docker 재시작 정책이 정상 동작하도록 수정하였습니다.

### 로컬 구동 문서 보완 — `docs/LOCAL_RUN_GUIDE.md`

로컬 환경에서 `./scripts/run/local/infra.sh start`로 전체 스택을 구동하면서 확인한 두 가지 문제를 반영하였습니다.

**1. `.env` 누락 항목**

`ACCOUNT_CREDENTIAL_ENCRYPTION_KEY`, `ACCOUNT_SHARE_OAUTH_STATE_SECRET` 두 키가 `.env.example` 및 `docker-compose.yml`(vault-init 환경변수)에는 정의되어 있으나 문서의 환경변수 안내 표에 누락되어 있었습니다. 해당 키 없이 기동하면 vault-init이 빈 값을 Vault에 시드하므로, `openssl rand -base64 32`로 값을 생성해 `.env`에 추가해야 함을 명시하였습니다.

**2. `cowork-chat` cold-start Kafka 경쟁 조건**

최초 `docker compose up` 시 `cowork-chat`의 Kafka consumer(`MembershipConsumer`, `ChatMessageConsumer`, `GithubIssueResultConsumer`)가 `onModuleInit`에서 `subscribe()`를 호출하는 시점에 관련 Kafka 토픽이 아직 생성되지 않은 경우 `UNKNOWN_TOPIC_OR_PARTITION` 오류로 NestJS 초기화가 실패하고 HTTP 서버가 열리지 않습니다. 이번 `process.exit(1)` 수정으로 컨테이너가 자동 재시작되며, 1~2회 재시작 후 토픽이 모두 생성되면 정상 기동됩니다. 수동 해결 방법(`docker compose restart cowork-chat`)도 함께 안내하였습니다.
