### PR TITLE
[chat] 채널 메시지 고정/해제/목록 조회 API 추가

### DIFF
--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -176,4 +176,47 @@ export class ChatController {
     ) {
         return this.chatService.deleteMessage({ channelId, messageId, userId, userRole });
     }
+
+    @Post('pins/:messageId')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: '메시지 고정' })
+    @ApiResponse({ status: 200, type: MessageResponseDto })
+    @ApiResponse({ status: 400, description: '이미 고정된 메시지' })
+    @ApiResponse({ status: 403, description: '채널 멤버 아님 또는 권한 없음' })
+    @ApiResponse({ status: 404, description: '메시지 없음' })
+    async pinMessage(
+        @Param('channelId', ParseIntPipe) channelId: number,
+        @Param('messageId') messageId: string,
+        @UserId() userId: number,
+        @UserRole() userRole: string,
+    ) {
+        return this.chatService.pinMessage({ channelId, messageId, userId, userRole });
+    }
+
+    @Delete('pins/:messageId')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: '메시지 고정 해제' })
+    @ApiResponse({ status: 204 })
+    @ApiResponse({ status: 400, description: '고정되지 않은 메시지' })
+    @ApiResponse({ status: 403, description: '채널 멤버 아님 또는 권한 없음' })
+    @ApiResponse({ status: 404, description: '메시지 없음' })
+    async unpinMessage(
+        @Param('channelId', ParseIntPipe) channelId: number,
+        @Param('messageId') messageId: string,
+        @UserId() userId: number,
+        @UserRole() userRole: string,
+    ) {
+        await this.chatService.unpinMessage({ channelId, messageId, userId, userRole });
+    }
+
+    @Get('pins')
+    @ApiOperation({ summary: '채널 고정 메시지 목록 조회' })
+    @ApiResponse({ status: 200, type: [MessageResponseDto] })
+    @ApiResponse({ status: 403, description: '채널 멤버 아님' })
+    async getPinnedMessages(
+        @Param('channelId', ParseIntPipe) channelId: number,
+        @UserId() userId: number,
+    ): Promise<MessageRow[]> {
+        return this.chatService.getPinnedMessages({ channelId, userId });
+    }
 }

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -249,6 +249,10 @@ export class ChatService {
         message.isPinned = true;
         const updated = await message.save();
 
+        if (updated.projectId) {
+            void this.elasticsearchService.updatePinStatus(ctx.messageId, true);
+        }
+
         this.chatGateway.server
             ?.to(`chat:${ctx.channelId}`)
             .emit('message:pinned', { messageId: ctx.messageId, channelId: ctx.channelId });
@@ -261,7 +265,11 @@ export class ChatService {
         if (!message.isPinned) throw new BadRequestException('고정되지 않은 메시지입니다');
 
         message.isPinned = false;
-        await message.save();
+        const updated = await message.save();
+
+        if (updated.projectId) {
+            void this.elasticsearchService.updatePinStatus(ctx.messageId, false);
+        }
 
         this.chatGateway.server
             ?.to(`chat:${ctx.channelId}`)

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -242,6 +242,37 @@ export class ChatService {
         return { channelId: message.channelId, messageId: ctx.messageId };
     }
 
+    async pinMessage(ctx: MessageUserRoleContext) {
+        const message = await this.findAndVerifyMessage(ctx, '본인 메시지만 고정할 수 있습니다');
+        if (message.isPinned) throw new BadRequestException('이미 고정된 메시지입니다');
+
+        message.isPinned = true;
+        const updated = await message.save();
+
+        this.chatGateway.server
+            ?.to(`chat:${ctx.channelId}`)
+            .emit('message:pinned', { messageId: ctx.messageId, channelId: ctx.channelId });
+
+        return updated;
+    }
+
+    async unpinMessage(ctx: MessageUserRoleContext) {
+        const message = await this.findAndVerifyMessage(ctx, '본인 메시지만 고정 해제할 수 있습니다');
+        if (!message.isPinned) throw new BadRequestException('고정되지 않은 메시지입니다');
+
+        message.isPinned = false;
+        await message.save();
+
+        this.chatGateway.server
+            ?.to(`chat:${ctx.channelId}`)
+            .emit('message:unpinned', { messageId: ctx.messageId, channelId: ctx.channelId });
+    }
+
+    async getPinnedMessages(ctx: ChannelUserContext): Promise<MessageRow[]> {
+        await this.checkMembership(ctx.channelId, ctx.userId);
+        return this.messageRepository.findPinnedMessages(ctx.channelId);
+    }
+
     async saveSystemMessage(
         teamId: number,
         channelId: number,

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -213,6 +213,37 @@ export class MessageRepository {
         ).lean() as Promise<NotificationMessage | null>;
     }
 
+    findPinnedMessages(channelId: number): Promise<MessageRow[]> {
+        return this.messageModel.aggregate([
+            { $match: { channelId, isPinned: true } },
+            { $sort: { _id: -1 } },
+            {
+                $lookup: {
+                    from: this.messageModel.collection.name,
+                    localField: 'parentMessageId',
+                    foreignField: '_id',
+                    as: 'mentionedMessage',
+                    pipeline: [
+                        {
+                            $project: {
+                                _id: 1,
+                                authorId: 1,
+                                content: 1,
+                                type: 1,
+                                createdAt: 1,
+                            },
+                        },
+                    ],
+                },
+            },
+            {
+                $addFields: {
+                    mentionedMessage: { $arrayElemAt: ['$mentionedMessage', 0] },
+                },
+            },
+        ]);
+    }
+
     async findParentAuthorsByIds(parentIds: Types.ObjectId[]): Promise<Map<string, { authorId: number }>> {
         const parents = await this.messageModel
             .find({ _id: { $in: parentIds } })

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -217,6 +217,7 @@ export class MessageRepository {
         return this.messageModel.aggregate([
             { $match: { channelId, isPinned: true } },
             { $sort: { _id: -1 } },
+            { $limit: MESSAGE_FETCH_LIMIT },
             {
                 $lookup: {
                     from: this.messageModel.collection.name,

--- a/cowork-chat/src/search/elasticsearch.service.ts
+++ b/cowork-chat/src/search/elasticsearch.service.ts
@@ -117,6 +117,19 @@ export class ElasticsearchService implements OnModuleInit {
         }
     }
 
+    async updatePinStatus(messageId: string, isPinned: boolean): Promise<void> {
+        try {
+            await this.client.update({
+                index: INDEX,
+                id: messageId,
+                doc: { isPinned },
+            });
+        } catch (err: any) {
+            if (err?.statusCode === 404) return;
+            this.logger.error(`ES 메시지 핀 상태 업데이트 실패 id=${messageId}`, err);
+        }
+    }
+
     async deleteMessage(messageId: string): Promise<void> {
         try {
             await this.client.delete({ index: INDEX, id: messageId });

--- a/docs/todo/02-management/message-pin.md
+++ b/docs/todo/02-management/message-pin.md
@@ -1,12 +1,14 @@
-# 채널 메시지 고정
+# ~~채널 메시지 고정~~
 
-- **서비스**: cowork-chat
-- **우선순위**: 🟠
+- **서비스**: ~~cowork-chat~~
+- **우선순위**: ~~🟠~~
 
-## 필요 API
+## ~~필요 API~~
 
-| 메서드 | 경로 | 설명 |
+| ~~메서드~~ | ~~경로~~ | ~~설명~~ |
 |--------|------|------|
-| `POST` | `/channels/{channelId}/pins/{messageId}` | 메시지 고정 |
-| `DELETE` | `/channels/{channelId}/pins/{messageId}` | 고정 해제 |
-| `GET` | `/channels/{channelId}/pins` | 고정 메시지 목록 |
+| ~~`POST`~~ | ~~`/channels/{channelId}/pins/{messageId}`~~ | ~~메시지 고정~~ |
+| ~~`DELETE`~~ | ~~`/channels/{channelId}/pins/{messageId}`~~ | ~~고정 해제~~ |
+| ~~`GET`~~ | ~~`/channels/{channelId}/pins`~~ | ~~고정 메시지 목록~~ |
+
+> ✅ PR #122에서 구현 완료

--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -16,7 +16,7 @@ if ! command -v gh &>/dev/null; then
   exit 1
 fi
 
-BASE_BRANCH="${4:-$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||' || echo "develop")}"
+BASE_BRANCH="${4:-develop}"
 CURRENT_BRANCH=$(git branch --show-current)
 
 if [[ "$CURRENT_BRANCH" == "$BASE_BRANCH" ]]; then


### PR DESCRIPTION
## 개요

`cowork-chat` 서비스에 채널 메시지 고정/해제 및 고정 목록 조회 API를 추가하였습니다.
아울러 PR 생성 스크립트의 기본 베이스 브랜치를 `develop`으로 고정하였습니다.

## 본문

### 추가된 API

| 메서드 | 경로 | 설명 | 응답 |
|--------|------|------|------|
| `POST` | `/channels/:channelId/pins/:messageId` | 메시지 고정 | 200 |
| `DELETE` | `/channels/:channelId/pins/:messageId` | 고정 해제 | 204 |
| `GET` | `/channels/:channelId/pins` | 채널 고정 메시지 목록 조회 | 200 |

### 권한 정책

메시지 작성자 또는 Admin 역할인 사용자만 고정/해제가 가능합니다. 채널 멤버십 확인은 기존 `findAndVerifyMessage`를 재사용하여 처리하였습니다.

### 중복 요청 처리

이미 고정된 메시지에 고정을 재시도하거나, 고정되지 않은 메시지에 해제를 요청하는 경우 400 에러를 반환합니다.

### 실시간 이벤트

고정/해제 완료 후 해당 채널 소켓 룸(`chat:{channelId}`)으로 `message:pinned` / `message:unpinned` 이벤트를 브로드캐스트합니다. 기존 `editMessage`, `deleteMessage`와 동일한 패턴을 따랐습니다.

### 데이터 계층

`Message` 스키마에는 이미 `isPinned` 필드와 `{ isPinned: 1, channelId: 1 }` 복합 인덱스가 존재하므로 스키마 변경 없이 API 계층만 추가하였습니다. 고정 목록 조회는 `findMessages`와 동일한 aggregate 파이프라인 구조를 사용하였습니다.

### PR 스크립트 수정

`scripts/create-pr.sh`에서 기본 베이스 브랜치를 `git symbolic-ref`로 동적 감지하던 방식을 `develop` 고정으로 변경하였습니다. `develop → main` PR이 필요한 경우 4번째 인자로 `main`을 명시적으로 전달하면 됩니다.
