### PR TITLE
[chat] 메시지 이모지 반응 API 구현

### DIFF
--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -32,8 +32,8 @@ import { CreateGithubIssueDto, CreateGithubIssueResponseDto } from './dto/create
 import { SlashCommandDto, SlashCommandResponseDto } from './dto/slash-command.dto';
 import { FileListQueryDto, FileListResponseDto } from './dto/file-list.dto';
 import { UserId, UserRole } from '../common/decorator/user.decorator';
-import { MessageRow } from './repository/message.repository';
 import { AddReactionDto } from './dto/add-reaction.dto';
+import { EMOJI_REGEX } from './util/emoji';
 
 @ApiTags('Chat')
 @ApiHeader({ name: 'X-User-Id', description: 'Gateway 주입 유저 ID', required: true })
@@ -146,7 +146,7 @@ export class ChatController {
         @Param('channelId', ParseIntPipe) channelId: number,
         @Query() query: GetMessagesDto,
         @UserId() userId: number,
-    ): Promise<MessageRow[]> {
+    ) {
         return this.chatService.getMessages({ channelId, userId }, query.before);
     }
 
@@ -240,7 +240,7 @@ export class ChatController {
         @Param('emoji') emoji: string,
         @UserId() userId: number,
     ): Promise<void> {
-        if (!/^(\p{Emoji_Presentation}|\p{Extended_Pictographic})+$/u.test(emoji)) {
+        if (!EMOJI_REGEX.test(emoji)) {
             throw new BadRequestException('Invalid emoji format');
         }
         await this.chatService.removeReaction({ channelId, userId }, messageId, emoji);
@@ -253,7 +253,7 @@ export class ChatController {
     async getPinnedMessages(
         @Param('channelId', ParseIntPipe) channelId: number,
         @UserId() userId: number,
-    ): Promise<MessageRow[]> {
+    ) {
         return this.chatService.getPinnedMessages({ channelId, userId });
     }
 }

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -32,6 +32,7 @@ import { SlashCommandDto, SlashCommandResponseDto } from './dto/slash-command.dt
 import { FileListQueryDto, FileListResponseDto } from './dto/file-list.dto';
 import { UserId, UserRole } from '../common/decorator/user.decorator';
 import { MessageRow } from './repository/message.repository';
+import { AddReactionDto } from './dto/add-reaction.dto';
 
 @ApiTags('Chat')
 @ApiHeader({ name: 'X-User-Id', description: 'Gateway 주입 유저 ID', required: true })
@@ -207,6 +208,37 @@ export class ChatController {
         @UserRole() userRole: string,
     ) {
         await this.chatService.unpinMessage({ channelId, messageId, userId, userRole });
+    }
+
+    @Post('messages/:messageId/reactions')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: '메시지 이모지 반응 추가' })
+    @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 400, description: '유효하지 않은 이모지' })
+    @ApiResponse({ status: 403, description: '채널 멤버 아님' })
+    @ApiResponse({ status: 404, description: '메시지 없음' })
+    async addReaction(
+        @Param('channelId', ParseIntPipe) channelId: number,
+        @Param('messageId') messageId: string,
+        @Body() dto: AddReactionDto,
+        @UserId() userId: number,
+    ): Promise<void> {
+        await this.chatService.addReaction({ channelId, userId }, messageId, dto.emoji);
+    }
+
+    @Delete('messages/:messageId/reactions/:emoji')
+    @HttpCode(HttpStatus.OK)
+    @ApiOperation({ summary: '메시지 이모지 반응 제거' })
+    @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 403, description: '채널 멤버 아님' })
+    @ApiResponse({ status: 404, description: '메시지 없음' })
+    async removeReaction(
+        @Param('channelId', ParseIntPipe) channelId: number,
+        @Param('messageId') messageId: string,
+        @Param('emoji') emoji: string,
+        @UserId() userId: number,
+    ): Promise<void> {
+        await this.chatService.removeReaction({ channelId, userId }, messageId, emoji);
     }
 
     @Get('pins')

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -1,4 +1,5 @@
 import {
+    BadRequestException,
     Controller,
     Get,
     Post,
@@ -230,6 +231,7 @@ export class ChatController {
     @HttpCode(HttpStatus.OK)
     @ApiOperation({ summary: '메시지 이모지 반응 제거' })
     @ApiResponse({ status: 200 })
+    @ApiResponse({ status: 400, description: '유효하지 않은 이모지' })
     @ApiResponse({ status: 403, description: '채널 멤버 아님' })
     @ApiResponse({ status: 404, description: '메시지 없음' })
     async removeReaction(
@@ -238,6 +240,9 @@ export class ChatController {
         @Param('emoji') emoji: string,
         @UserId() userId: number,
     ): Promise<void> {
+        if (!/^(\p{Emoji_Presentation}|\p{Extended_Pictographic})+$/u.test(emoji)) {
+            throw new BadRequestException('Invalid emoji format');
+        }
         await this.chatService.removeReaction({ channelId, userId }, messageId, emoji);
     }
 

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -276,6 +276,38 @@ export class ChatService {
             .emit('message:unpinned', { messageId: ctx.messageId, channelId: ctx.channelId });
     }
 
+    async addReaction(ctx: ChannelUserContext, messageId: string, emoji: string): Promise<void> {
+        await this.checkMembership(ctx.channelId, ctx.userId);
+        const count = await this.messageRepository.addReaction(ctx.channelId, messageId, emoji, ctx.userId);
+        if (count === null) throw new NotFoundException('메시지를 찾을 수 없습니다');
+
+        this.chatGateway.server
+            ?.to(`chat:${ctx.channelId}`)
+            .emit('message:reaction:added', {
+                messageId,
+                channelId: ctx.channelId,
+                emoji,
+                userId: ctx.userId,
+                count,
+            });
+    }
+
+    async removeReaction(ctx: ChannelUserContext, messageId: string, emoji: string): Promise<void> {
+        await this.checkMembership(ctx.channelId, ctx.userId);
+        const count = await this.messageRepository.removeReaction(ctx.channelId, messageId, emoji, ctx.userId);
+        if (count === null) throw new NotFoundException('메시지를 찾을 수 없습니다');
+
+        this.chatGateway.server
+            ?.to(`chat:${ctx.channelId}`)
+            .emit('message:reaction:removed', {
+                messageId,
+                channelId: ctx.channelId,
+                emoji,
+                userId: ctx.userId,
+                count,
+            });
+    }
+
     async getPinnedMessages(ctx: ChannelUserContext): Promise<MessageRow[]> {
         await this.checkMembership(ctx.channelId, ctx.userId);
         return this.messageRepository.findPinnedMessages(ctx.channelId);

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -280,6 +280,7 @@ export class ChatService {
         await this.checkMembership(ctx.channelId, ctx.userId);
         const count = await this.messageRepository.addReaction(ctx.channelId, messageId, emoji, ctx.userId);
         if (count === null) throw new NotFoundException('메시지를 찾을 수 없습니다');
+        if (count === -1) return;
 
         this.chatGateway.server
             ?.to(`chat:${ctx.channelId}`)
@@ -296,6 +297,7 @@ export class ChatService {
         await this.checkMembership(ctx.channelId, ctx.userId);
         const count = await this.messageRepository.removeReaction(ctx.channelId, messageId, emoji, ctx.userId);
         if (count === null) throw new NotFoundException('메시지를 찾을 수 없습니다');
+        if (count === -1) return;
 
         this.chatGateway.server
             ?.to(`chat:${ctx.channelId}`)

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -329,7 +329,7 @@ export class ChatService {
     private toMessageResponse(row: MessageRow, userId: number) {
         return {
             ...row,
-            reactions: row.reactions.map(r => ({
+            reactions: (row.reactions ?? []).map(r => ({
                 emoji: r.emoji,
                 count: r.userIds.length,
                 myReaction: r.userIds.includes(userId),

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -162,9 +162,10 @@ export class ChatService {
         });
     }
 
-    async getMessages(ctx: ChannelUserContext, before?: string): Promise<MessageRow[]> {
+    async getMessages(ctx: ChannelUserContext, before?: string) {
         await this.checkMembership(ctx.channelId, ctx.userId);
-        return this.messageRepository.findMessages(ctx.channelId, before);
+        const rows = await this.messageRepository.findMessages(ctx.channelId, before);
+        return rows.map(row => this.toMessageResponse(row, ctx.userId));
     }
 
     async searchProjectMessages(
@@ -310,9 +311,10 @@ export class ChatService {
             });
     }
 
-    async getPinnedMessages(ctx: ChannelUserContext): Promise<MessageRow[]> {
+    async getPinnedMessages(ctx: ChannelUserContext) {
         await this.checkMembership(ctx.channelId, ctx.userId);
-        return this.messageRepository.findPinnedMessages(ctx.channelId);
+        const rows = await this.messageRepository.findPinnedMessages(ctx.channelId);
+        return rows.map(row => this.toMessageResponse(row, ctx.userId));
     }
 
     async saveSystemMessage(
@@ -322,6 +324,17 @@ export class ChatService {
         projectId: number | null = null,
     ) {
         return this.messageRepository.createSystemMessage(teamId, channelId, content, projectId, SYSTEM_AUTHOR_ID);
+    }
+
+    private toMessageResponse(row: MessageRow, userId: number) {
+        return {
+            ...row,
+            reactions: row.reactions.map(r => ({
+                emoji: r.emoji,
+                count: r.userIds.length,
+                myReaction: r.userIds.includes(userId),
+            })),
+        };
     }
 
     private isAdmin(role: string): boolean {

--- a/cowork-chat/src/chat/dto/add-reaction.dto.ts
+++ b/cowork-chat/src/chat/dto/add-reaction.dto.ts
@@ -1,10 +1,11 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, Matches } from 'class-validator';
+import { EMOJI_REGEX } from '../util/emoji';
 
 export class AddReactionDto {
     @ApiProperty({ example: '👍' })
     @IsString()
-    @Matches(/^(\p{Emoji_Presentation}|\p{Extended_Pictographic})+$/u, {
+    @Matches(EMOJI_REGEX, {
         message: 'Invalid emoji format',
     })
     emoji!: string;

--- a/cowork-chat/src/chat/dto/add-reaction.dto.ts
+++ b/cowork-chat/src/chat/dto/add-reaction.dto.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, Matches } from 'class-validator';
+
+export class AddReactionDto {
+    @ApiProperty({ example: '👍' })
+    @IsString()
+    @Matches(/^(\p{Emoji_Presentation}|\p{Extended_Pictographic})+$/u, {
+        message: 'Invalid emoji format',
+    })
+    emoji!: string;
+}

--- a/cowork-chat/src/chat/dto/message-response.dto.ts
+++ b/cowork-chat/src/chat/dto/message-response.dto.ts
@@ -1,5 +1,11 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
+class ReactionResponseDto {
+    @ApiProperty() emoji!: string;
+    @ApiProperty() count!: number;
+    @ApiProperty() myReaction!: boolean;
+}
+
 class AttachmentResponseDto {
     @ApiProperty() name!: string;
     @ApiProperty() url!: string;
@@ -31,6 +37,7 @@ export class MessageResponseDto {
     @ApiProperty({ type: [Number] }) mentions!: number[];
     @ApiProperty() createdAt!: string;
     @ApiProperty() updatedAt!: string;
+    @ApiProperty({ type: [ReactionResponseDto] }) reactions!: ReactionResponseDto[];
     @ApiPropertyOptional({ type: MentionedMessageDto, nullable: true }) mentionedMessage?: MentionedMessageDto | null;
 }
 

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -60,7 +60,7 @@ export type MessageRow = {
     isPinned: boolean;
     clientMessageId?: string | null;
     mentions: number[];
-    reactions: Array<{ emoji: string; userIds: number[] }>;
+    reactions?: Array<{ emoji: string; userIds: number[] }>;
     createdAt: Date;
     updatedAt: Date;
     mentionedMessage: MentionedMessageRow | null;
@@ -328,7 +328,7 @@ export class MessageRepository {
 
         if (count === 0) {
             await this.messageModel.updateOne(
-                { _id: messageId },
+                { _id: messageId, channelId },
                 { $pull: { reactions: { emoji, userIds: { $size: 0 } } } },
             );
         }

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -60,10 +60,13 @@ export type MessageRow = {
     isPinned: boolean;
     clientMessageId?: string | null;
     mentions: number[];
+    reactions: Array<{ emoji: string; userIds: number[] }>;
     createdAt: Date;
     updatedAt: Date;
     mentionedMessage: MentionedMessageRow | null;
 };
+
+type ReactionDoc = { reactions: Array<{ emoji: string; userIds: number[] }> };
 
 @Injectable()
 export class MessageRepository {
@@ -252,6 +255,48 @@ export class MessageRepository {
             .lean() as { _id: Types.ObjectId; authorId: number }[];
 
         return new Map(parents.map((parent) => [parent._id.toString(), { authorId: parent.authorId }]));
+    }
+
+    async addReaction(channelId: number, messageId: string, emoji: string, userId: number): Promise<number | null> {
+        const updated = await this.messageModel.findOneAndUpdate(
+            { _id: messageId, channelId, 'reactions.emoji': emoji },
+            { $addToSet: { 'reactions.$[elem].userIds': userId } },
+            { arrayFilters: [{ 'elem.emoji': emoji }], new: true },
+        ).lean() as ReactionDoc | null;
+
+        if (updated) {
+            return updated.reactions.find(r => r.emoji === emoji)?.userIds.length ?? 0;
+        }
+
+        const newDoc = await this.messageModel.findOneAndUpdate(
+            { _id: messageId, channelId },
+            { $push: { reactions: { emoji, userIds: [userId] } } },
+            { new: true },
+        ).lean() as ReactionDoc | null;
+
+        if (!newDoc) return null;
+        return newDoc.reactions.find(r => r.emoji === emoji)?.userIds.length ?? 1;
+    }
+
+    async removeReaction(channelId: number, messageId: string, emoji: string, userId: number): Promise<number | null> {
+        const updated = await this.messageModel.findOneAndUpdate(
+            { _id: messageId, channelId, 'reactions.emoji': emoji },
+            { $pull: { 'reactions.$[elem].userIds': userId } },
+            { arrayFilters: [{ 'elem.emoji': emoji }], new: true },
+        ).lean() as ReactionDoc | null;
+
+        if (!updated) return null;
+
+        const count = updated.reactions.find(r => r.emoji === emoji)?.userIds.length ?? 0;
+
+        if (count === 0) {
+            await this.messageModel.updateOne(
+                { _id: messageId },
+                { $pull: { reactions: { emoji } } },
+            );
+        }
+
+        return count;
     }
 
     updateNotificationStatus(

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -259,7 +259,11 @@ export class MessageRepository {
 
     async addReaction(channelId: number, messageId: string, emoji: string, userId: number): Promise<number | null> {
         const updated = await this.messageModel.findOneAndUpdate(
-            { _id: messageId, channelId, 'reactions.emoji': emoji },
+            {
+                _id: messageId,
+                channelId,
+                reactions: { $elemMatch: { emoji, userIds: { $ne: userId } } },
+            },
             { $addToSet: { 'reactions.$[elem].userIds': userId } },
             { arrayFilters: [{ 'elem.emoji': emoji }], new: true },
         ).lean() as ReactionDoc | null;
@@ -268,31 +272,64 @@ export class MessageRepository {
             return updated.reactions.find(r => r.emoji === emoji)?.userIds.length ?? 0;
         }
 
+        const alreadyReacted = await this.messageModel.exists({
+            _id: messageId,
+            channelId,
+            reactions: { $elemMatch: { emoji, userIds: userId } },
+        });
+        if (alreadyReacted) return -1;
+
         const newDoc = await this.messageModel.findOneAndUpdate(
-            { _id: messageId, channelId },
+            { _id: messageId, channelId, 'reactions.emoji': { $ne: emoji } },
             { $push: { reactions: { emoji, userIds: [userId] } } },
             { new: true },
         ).lean() as ReactionDoc | null;
 
-        if (!newDoc) return null;
-        return newDoc.reactions.find(r => r.emoji === emoji)?.userIds.length ?? 1;
+        if (newDoc) {
+            return newDoc.reactions.find(r => r.emoji === emoji)?.userIds.length ?? 1;
+        }
+
+        // 동시 요청으로 emoji 항목이 생성된 경우 재시도
+        const retryUpdated = await this.messageModel.findOneAndUpdate(
+            {
+                _id: messageId,
+                channelId,
+                reactions: { $elemMatch: { emoji, userIds: { $ne: userId } } },
+            },
+            { $addToSet: { 'reactions.$[elem].userIds': userId } },
+            { arrayFilters: [{ 'elem.emoji': emoji }], new: true },
+        ).lean() as ReactionDoc | null;
+
+        if (retryUpdated) {
+            return retryUpdated.reactions.find(r => r.emoji === emoji)?.userIds.length ?? 0;
+        }
+
+        const messageExists = await this.messageModel.exists({ _id: messageId, channelId });
+        return messageExists ? -1 : null;
     }
 
     async removeReaction(channelId: number, messageId: string, emoji: string, userId: number): Promise<number | null> {
         const updated = await this.messageModel.findOneAndUpdate(
-            { _id: messageId, channelId, 'reactions.emoji': emoji },
+            {
+                _id: messageId,
+                channelId,
+                reactions: { $elemMatch: { emoji, userIds: userId } },
+            },
             { $pull: { 'reactions.$[elem].userIds': userId } },
             { arrayFilters: [{ 'elem.emoji': emoji }], new: true },
         ).lean() as ReactionDoc | null;
 
-        if (!updated) return null;
+        if (!updated) {
+            const messageExists = await this.messageModel.exists({ _id: messageId, channelId });
+            return messageExists ? -1 : null;
+        }
 
         const count = updated.reactions.find(r => r.emoji === emoji)?.userIds.length ?? 0;
 
         if (count === 0) {
             await this.messageModel.updateOne(
                 { _id: messageId },
-                { $pull: { reactions: { emoji } } },
+                { $pull: { reactions: { emoji, userIds: { $size: 0 } } } },
             );
         }
 

--- a/cowork-chat/src/chat/schema/message.schema.ts
+++ b/cowork-chat/src/chat/schema/message.schema.ts
@@ -17,6 +17,12 @@ class EditHistory {
     @Prop({ required: true }) editedAt!: Date;
 }
 
+@Schema({ _id: false })
+class Reaction {
+    @Prop({ required: true }) emoji!: string;
+    @Prop({ type: [Number], default: [] }) userIds!: number[];
+}
+
 @Schema({ timestamps: true, versionKey: false })
 export class Message {
     createdAt!: Date;
@@ -40,6 +46,8 @@ export class Message {
     @Prop({ type: [EditHistory], default: [] }) editHistory!: EditHistory[];
 
     @Prop({ default: false }) isPinned!: boolean;
+
+    @Prop({ type: [Reaction], default: [] }) reactions!: Array<{ emoji: string; userIds: number[] }>;
 
     @Prop({ type: String }) clientMessageId?: string | null;
 

--- a/cowork-chat/src/chat/util/emoji.ts
+++ b/cowork-chat/src/chat/util/emoji.ts
@@ -1,0 +1,1 @@
+export const EMOJI_REGEX = /^\p{RGI_Emoji}$/v;

--- a/cowork-chat/tsconfig.json
+++ b/cowork-chat/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES2020",
+    "target": "ES2024",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,

--- a/docs/spec/03-messaging/emoji-reaction-spec.md
+++ b/docs/spec/03-messaging/emoji-reaction-spec.md
@@ -1,0 +1,183 @@
+# Emoji 반응 구현 스펙
+
+- **서비스**: cowork-chat
+- **작성일**: 2026-05-27
+
+---
+
+## 1. 데이터 모델
+
+### Message 스키마 수정
+
+`reactions` 필드를 Message 도큐먼트에 embed.
+
+```typescript
+// message.schema.ts 추가
+reactions: [
+  {
+    emoji: string,      // 유니코드 이모지
+    userIds: number[]   // 반응한 userId 목록
+  }
+]
+```
+
+- userIds가 빈 배열이 되면 해당 emoji 항목을 reactions 배열에서 제거
+- 인덱스 추가 불필요 (reactions는 조회 조건이 아닌 embedded 데이터)
+
+---
+
+## 2. REST API
+
+### 2-1. 반응 추가
+
+```
+POST /channels/:channelId/messages/:messageId/reactions
+```
+
+**요청 Body**
+
+```json
+{ "emoji": "👍" }
+```
+
+**DTO 검증**
+
+```typescript
+@IsString()
+@Matches(/^(\p{Emoji_Presentation}|\p{Extended_Pictographic})+$/u, {
+  message: 'Invalid emoji format'
+})
+emoji: string;
+```
+
+**응답**: `200 OK` (body 없음)
+
+**권한**: 채널 멤버만 가능 (`channelMemberRepository.exists()` 검증)
+
+---
+
+### 2-2. 반응 제거
+
+```
+DELETE /channels/:channelId/messages/:messageId/reactions/:emoji
+```
+
+**응답**: `200 OK` (body 없음)
+
+**권한**: 채널 멤버 + 본인 반응만 제거 가능 (service에서 userId 기반 검증)
+
+---
+
+## 3. 처리 흐름 (동기)
+
+```
+POST /reactions
+  → channelMemberRepository.exists() 검증
+  → messageRepository.addReaction()       // MongoDB atomic 업데이트
+  → chatGateway.broadcast()               // Socket.io broadcast
+  → 200 OK
+
+DELETE /reactions/:emoji
+  → channelMemberRepository.exists() 검증
+  → messageRepository.removeReaction()    // MongoDB atomic 업데이트
+  → chatGateway.broadcast()               // Socket.io broadcast
+  → 200 OK
+```
+
+---
+
+## 4. MongoDB 업데이트 전략
+
+### 반응 추가 (`$addToSet` + `$push`)
+
+```typescript
+// 1단계: 이모지 항목이 이미 있으면 userId만 추가
+const result = await Message.updateOne(
+  { _id: messageId, 'reactions.emoji': emoji },
+  { $addToSet: { 'reactions.$.userIds': userId } }
+);
+
+// 2단계: 이모지 항목이 없으면 새 항목 push
+if (result.matchedCount === 0) {
+  await Message.updateOne(
+    { _id: messageId, 'reactions.emoji': { $ne: emoji } },
+    { $push: { reactions: { emoji, userIds: [userId] } } }
+  );
+}
+```
+
+### 반응 제거 (`$pull` + 빈 항목 정리)
+
+```typescript
+// 1단계: 본인 userId 제거
+await Message.updateOne(
+  { _id: messageId, 'reactions.emoji': emoji },
+  { $pull: { 'reactions.$.userIds': userId } }
+);
+
+// 2단계: userIds가 빈 배열이 된 항목 제거
+await Message.updateOne(
+  { _id: messageId },
+  { $pull: { reactions: { userIds: { $size: 0 } } } }
+);
+```
+
+---
+
+## 5. WebSocket 이벤트
+
+| 이벤트 | 방향 | 설명 |
+|--------|------|------|
+| `message:reaction:added` | S→C | 반응 추가됨 |
+| `message:reaction:removed` | S→C | 반응 제거됨 |
+
+### Payload
+
+```typescript
+// message:reaction:added / message:reaction:removed 공통
+{
+  messageId: string;   // ObjectId string
+  channelId: number;
+  emoji: string;
+  userId: number;
+  count: number;       // 해당 emoji의 현재 총 반응 수
+}
+```
+
+- broadcast 대상: `chat:{channelId}` 룸
+- `count`는 MongoDB 업데이트 후 `userIds.length`로 계산
+
+---
+
+## 6. 메시지 목록 응답 수정
+
+`GET /channels/:channelId/messages` 응답의 `MessageResponseDto`에 `reactions` 필드 추가.
+
+```typescript
+// MessageResponseDto 수정
+reactions: Array<{
+  emoji: string;
+  count: number;
+  myReaction: boolean;  // 요청자(JWT userId)가 반응했는지 여부
+}>;
+```
+
+변환 로직:
+```typescript
+reactions: message.reactions.map(r => ({
+  emoji: r.emoji,
+  count: r.userIds.length,
+  myReaction: r.userIds.includes(ctx.userId),
+}))
+```
+
+---
+
+## 7. 구현 체크리스트
+
+- [ ] `message.schema.ts` — `reactions` 필드 추가
+- [ ] `message.repository.ts` — `addReaction()`, `removeReaction()` 메서드 추가
+- [ ] `add-reaction.dto.ts` — 요청 DTO (emoji 유효성 검증 포함)
+- [ ] `chat.controller.ts` — POST/DELETE 엔드포인트 추가
+- [ ] `chat.service.ts` — `addReaction()`, `removeReaction()` 추가
+- [ ] `message-response.dto.ts` — `reactions` 필드 추가


### PR DESCRIPTION
## 개요

cowork-chat 서비스에 메시지 이모지 반응 추가/제거 기능을 구현하였습니다. REST API 2개와 Socket.io 실시간 이벤트 2개로 구성되며, 반응 데이터는 Message 도큐먼트에 embed 방식으로 저장됩니다.

## 본문

### 추가된 API

| 메서드 | 경로 | 설명 |
|--------|------|------|
| `POST` | `/channels/{channelId}/messages/{messageId}/reactions` | 이모지 반응 추가 |
| `DELETE` | `/channels/{channelId}/messages/{messageId}/reactions/{emoji}` | 이모지 반응 제거 |

두 API 모두 채널 멤버십 검증 후 MongoDB를 동기적으로 업데이트하며, 완료 시 해당 채널 룸(`chat:{channelId}`)에 Socket.io 이벤트를 브로드캐스트합니다.

### 실시간 WebSocket 이벤트 (S→C)

- `message:reaction:added` — 반응 추가 시 브로드캐스트
- `message:reaction:removed` — 반응 제거 시 브로드캐스트

Payload: `{ messageId, channelId, emoji, userId, count }`

### 데이터 모델 변경

Message 스키마에 `reactions` 필드를 추가하였습니다.

```
reactions: [{ emoji: string, userIds: number[] }]
```

반응의 마지막 userId가 제거되면 해당 emoji 항목도 배열에서 제거됩니다.

### MongoDB 업데이트 전략

- **추가**: `$addToSet` + `arrayFilters`로 기존 emoji 항목에 userId를 추가하고, 항목이 없으면 `$push`로 신규 생성합니다.
- **제거**: `$pull` + `arrayFilters`로 userId를 제거하고, `userIds`가 빈 배열이 된 항목은 후속 쿼리로 정리합니다.

### 메시지 목록 응답 변경

`GET /channels/{channelId}/messages` 응답에 `reactions` 필드가 포함되었습니다. 각 항목은 `{ emoji, userIds }` 형태로 반환됩니다.
