### PR TITLE
[chat] 멘션 관련 Swagger 문서 갱신

### DIFF
--- a/cowork-chat/src/chat/dto/message-response.dto.ts
+++ b/cowork-chat/src/chat/dto/message-response.dto.ts
@@ -14,11 +14,11 @@ class AttachmentResponseDto {
 }
 
 class MentionedMessageDto {
-    @ApiProperty() _id!: string;
-    @ApiProperty() authorId!: number;
-    @ApiProperty() content!: string;
-    @ApiProperty({ enum: ['TEXT', 'FILE', 'SYSTEM'] }) type!: string;
-    @ApiProperty() createdAt!: string;
+    @ApiProperty({ description: '부모 메시지 MongoDB ObjectId' }) _id!: string;
+    @ApiProperty({ description: '부모 메시지 작성자 ID' }) authorId!: number;
+    @ApiProperty({ description: '부모 메시지 내용' }) content!: string;
+    @ApiProperty({ enum: ['TEXT', 'FILE', 'SYSTEM'], description: '부모 메시지 타입' }) type!: string;
+    @ApiProperty({ description: '부모 메시지 생성 시각 (ISO 8601)' }) createdAt!: string;
 }
 
 export class MessageResponseDto {
@@ -30,15 +30,15 @@ export class MessageResponseDto {
     @ApiProperty() content!: string;
     @ApiProperty({ enum: ['TEXT', 'FILE', 'SYSTEM'] }) type!: string;
     @ApiProperty({ type: [AttachmentResponseDto] }) attachments!: AttachmentResponseDto[];
-    @ApiPropertyOptional({ nullable: true }) parentMessageId!: string | null;
+    @ApiPropertyOptional({ nullable: true, description: '스레드 답글의 부모 메시지 ObjectId (최상위 메시지이면 null)' }) parentMessageId!: string | null;
     @ApiProperty() isEdited!: boolean;
     @ApiProperty() isPinned!: boolean;
     @ApiPropertyOptional({ nullable: true }) clientMessageId!: string | null;
-    @ApiProperty({ type: [Number] }) mentions!: number[];
+    @ApiProperty({ type: [Number], description: '메시지 내용에서 파싱된 멘션 사용자 ID 목록 (`<@userId>` 형식으로 작성된 멘션)' }) mentions!: number[];
     @ApiProperty() createdAt!: string;
     @ApiProperty() updatedAt!: string;
     @ApiProperty({ type: [ReactionResponseDto] }) reactions!: ReactionResponseDto[];
-    @ApiPropertyOptional({ type: MentionedMessageDto, nullable: true }) mentionedMessage?: MentionedMessageDto | null;
+    @ApiPropertyOptional({ type: MentionedMessageDto, nullable: true, description: '스레드 답글의 부모 메시지 정보 (최상위 메시지이거나 스레드가 아니면 null)' }) mentionedMessage?: MentionedMessageDto | null;
 }
 
 export class MessageListResponseDto {

--- a/cowork-chat/src/chat/dto/message-response.dto.ts
+++ b/cowork-chat/src/chat/dto/message-response.dto.ts
@@ -13,7 +13,7 @@ class AttachmentResponseDto {
     @ApiProperty() mimeType!: string;
 }
 
-class MentionedMessageDto {
+export class MentionedMessageDto {
     @ApiProperty({ description: '부모 메시지 MongoDB ObjectId' }) _id!: string;
     @ApiProperty({ description: '부모 메시지 작성자 ID' }) authorId!: number;
     @ApiProperty({ description: '부모 메시지 내용' }) content!: string;
@@ -30,7 +30,7 @@ export class MessageResponseDto {
     @ApiProperty() content!: string;
     @ApiProperty({ enum: ['TEXT', 'FILE', 'SYSTEM'] }) type!: string;
     @ApiProperty({ type: [AttachmentResponseDto] }) attachments!: AttachmentResponseDto[];
-    @ApiPropertyOptional({ nullable: true, description: '스레드 답글의 부모 메시지 ObjectId (최상위 메시지이면 null)' }) parentMessageId!: string | null;
+    @ApiProperty({ nullable: true, description: '스레드 답글의 부모 메시지 ObjectId (최상위 메시지이면 null)' }) parentMessageId!: string | null;
     @ApiProperty() isEdited!: boolean;
     @ApiProperty() isPinned!: boolean;
     @ApiPropertyOptional({ nullable: true }) clientMessageId!: string | null;

--- a/cowork-chat/src/chat/dto/send-message.dto.ts
+++ b/cowork-chat/src/chat/dto/send-message.dto.ts
@@ -22,7 +22,7 @@ export class SendMessageDto {
     @ApiPropertyOptional({ description: '프로젝트 ID (팀 채널이면 null)', nullable: true })
     @IsNumber() @IsOptional() projectId?: number | null;
 
-    @ApiProperty({ description: '메시지 내용 (최대 25000자)', maxLength: 25000, minLength: 1 })
+    @ApiProperty({ description: '메시지 내용 (최대 25000자). 멘션은 `<@userId>` 형식으로 포함 가능 (예: `<@123>`)', maxLength: 25000, minLength: 1 })
     @IsString() @MaxLength(25000) content!: string;
 
     @ApiPropertyOptional({ enum: ['TEXT', 'FILE'], default: 'TEXT' })


### PR DESCRIPTION
## 개요

chat 모듈의 멘션 관련 DTO에 누락된 Swagger `description`을 추가하였습니다. `MentionedMessageDto` 필드 5개, `MessageResponseDto`의 `mentions`·`parentMessageId`·`mentionedMessage` 필드, `SendMessageDto.content`에 멘션 입력 형식 설명을 보완하였습니다.

## 본문

### message-response.dto.ts

- `MentionedMessageDto` 내 `_id`, `authorId`, `content`, `type`, `createdAt` 필드에 `description` 추가
- `MessageResponseDto.parentMessageId`: "스레드 답글의 부모 메시지 ObjectId (최상위 메시지이면 null)" 설명 추가
- `MessageResponseDto.mentions`: `` `<@userId>` `` 형식으로 파싱된 멘션 사용자 ID 목록임을 명시
- `MessageResponseDto.mentionedMessage`: "스레드가 아니면 null" 조건 설명 추가

### send-message.dto.ts

- `SendMessageDto.content`: 멘션 입력 형식(`` `<@userId>` ``, 예: `` `<@123>` ``)을 description에 추가
