### PR TITLE
[global] Harness 훅 설정 확장 및 `write-pr` 스크립트 개선

### DIFF
--- a/.agents/skills/write-pr/scripts/create-pr.sh
+++ b/.agents/skills/write-pr/scripts/create-pr.sh
@@ -20,6 +20,11 @@ if [ -z "$BASE" ]; then
   esac
 fi
 
+if [ "$CURRENT" = "$BASE" ]; then
+  echo "ERROR: Current branch '$CURRENT' is the same as the base branch '$BASE'." >&2
+  exit 1
+fi
+
 ARGS=(gh pr create --title "$TITLE" --body-file "$BODY_FILE" --base "$BASE")
 
 if [ -n "$LABELS" ]; then

--- a/.agents/skills/write-pr/scripts/create-pr.sh
+++ b/.agents/skills/write-pr/scripts/create-pr.sh
@@ -11,11 +11,14 @@ if [ ! -f "$BODY_FILE" ]; then
 fi
 
 CURRENT=$(git branch --show-current)
-case "$CURRENT" in
-  feature/*)  BASE="develop" ;;
-  develop)    BASE="master" ;;
-  *)          BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo "develop") ;;
-esac
+BASE="${PR_BASE_BRANCH:-}"
+if [ -z "$BASE" ]; then
+  case "$CURRENT" in
+    feature/*)  BASE="develop" ;;
+    develop)    BASE="master" ;;
+    *)          BASE=$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo "develop") ;;
+  esac
+fi
 
 ARGS=(gh pr create --title "$TITLE" --body-file "$BODY_FILE" --base "$BASE")
 

--- a/.harness/sync.yml
+++ b/.harness/sync.yml
@@ -10,6 +10,14 @@ overrides:
   claude/hooks/ktlint: true
   claude/hooks/command-guard: true
   claude/hooks/logging: true
+  claude/hooks/secret-guard: true
+
+  codex/hooks/dispatcher: true
+  codex/hooks-json: true
+  codex/hooks/command-guard: true
+  codex/hooks/logging: true
+  codex/hooks/ktlint: true
+  codex/hooks/secret-guard: true
 
 branch_prefix: harness-sync/
 base_branch: develop

--- a/docs/20260526_TODO.md
+++ b/docs/20260526_TODO.md
@@ -9,27 +9,27 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 
 ## 요약 테이블
 
-| # | 항목 | 서비스 | 우선순위 | 세부 문서 |
-|---|------|--------|----------|-----------|
-| 1 | ~~`LocalDateTime` ISO-8601 직렬화~~ | ~~cowork-channel~~ | 🔴 | ~~[바로가기](./todo/01-urgent/meeting-note-datetime.md)~~ |
-| 2 | ~~Gateway 프로젝트 reorder 라우팅~~ | ~~cowork-gateway~~ | 🔴 | ~~[바로가기](./todo/01-urgent/gateway-reorder-routing.md)~~ |
-| 3 | 팀 정보 수정·삭제 API | cowork-team | 🟠 | [바로가기](./todo/02-management/team-crud.md) |
-| 4 | 팀 멤버 관리 API (추방·역할변경·탈퇴) | cowork-team | 🟠 | [바로가기](./todo/02-management/team-members.md) |
-| 5 | 팀 초대 링크 API | cowork-team | 🟠 | [바로가기](./todo/02-management/team-invite.md) |
-| 6 | 채널 수정·삭제 API | cowork-channel | 🟠 | [바로가기](./todo/02-management/channel-crud.md) |
-| 7 | 채널별 멤버 권한 (비공개 채널 초대) | cowork-channel | 🟠 | [바로가기](./todo/02-management/channel-permissions.md) |
-| 8 | 채널 메시지 고정 API | cowork-chat | 🟠 | [바로가기](./todo/02-management/message-pin.md) |
-| 9 | 프로젝트 수정·삭제·보관 API | cowork-project | 🟠 | [바로가기](./todo/02-management/project-crud.md) |
-| 10 | 메시지 Emoji 반응 API + WS 이벤트 | cowork-chat | 🟡 | [바로가기](./todo/03-messaging/emoji-reaction.md) |
-| 11 | 스레드 메시지 `parentMessageId` 필터 | cowork-chat | 🟡 | [바로가기](./todo/03-messaging/thread-filter.md) |
-| 12 | 파일·이미지 첨부 API + 메시지 모델 확장 | cowork-chat | 🟡 | [바로가기](./todo/03-messaging/file-attachment.md) |
-| 13 | @멘션 멤버 검색 API | cowork-user | 🟡 | [바로가기](./todo/03-messaging/mention.md) |
-| 14 | 읽음 상태 및 미읽 카운트 | cowork-chat | 🟡 | [바로가기](./todo/04-notification/read-status.md) |
-| 15 | 알림 설정 (preference 모듈 확장) | cowork-preference | 🟡 | [바로가기](./todo/04-notification/notification-settings.md) |
-| 16 | 프로필 필드 수정 + 커스텀 상태 메시지 | cowork-user | 🟡 | [바로가기](./todo/05-user-search/profile-edit.md) |
-| 17 | 전체 검색 API | 신규 or gateway | 🟡 | [바로가기](./todo/05-user-search/global-search.md) |
-| 18 | AccountShare 채널 설계·구현 | TBD | 🟢 | [바로가기](./todo/06-future/account-share.md) |
-| 19 | 다이렉트 메시지(DM) | 신규 | 🟢 | [바로가기](./todo/06-future/direct-message.md) |
-| 20 | 팀 역할 시스템 고도화 | cowork-team | 🟢 | [바로가기](./todo/06-future/role-system.md) |
-| 21 | 회의록 수정·삭제, 템플릿 관리 | cowork-channel | 🟢 | [바로가기](./todo/06-future/meeting-note-management.md) |
-| 22 | WebSocket 이벤트 보강 | cowork-chat | 🟢 | [바로가기](./todo/06-future/websocket-events.md) |
+| #  | 항목                               | 서비스                | 우선순위 | 세부 문서                                                   |
+|----|----------------------------------|--------------------|------|---------------------------------------------------------|
+| 1  | ~~`LocalDateTime` ISO-8601 직렬화~~ | ~~cowork-channel~~ | 🔴   | ~~[바로가기](./todo/01-urgent/meeting-note-datetime.md)~~   |
+| 2  | ~~Gateway 프로젝트 reorder 라우팅~~     | ~~cowork-gateway~~ | 🔴   | ~~[바로가기](./todo/01-urgent/gateway-reorder-routing.md)~~ |
+| 3  | 팀 정보 수정·삭제 API                   | cowork-team        | 🟠   | [바로가기](./todo/02-management/team-crud.md)               |
+| 4  | 팀 멤버 관리 API (추방·역할변경·탈퇴)         | cowork-team        | 🟠   | [바로가기](./todo/02-management/team-members.md)            |
+| 5  | 팀 초대 링크 API                      | cowork-team        | 🟠   | [바로가기](./todo/02-management/team-invite.md)             |
+| 6  | 채널 수정·삭제 API                     | cowork-channel     | 🟠   | [바로가기](./todo/02-management/channel-crud.md)            |
+| 7  | 채널별 멤버 권한 (비공개 채널 초대)            | cowork-channel     | 🟠   | [바로가기](./todo/02-management/channel-permissions.md)     |
+| 8  | 채널 메시지 고정 API                    | cowork-chat        | 🟠   | [바로가기](./todo/02-management/message-pin.md)             |
+| 9  | 프로젝트 수정·삭제·보관 API                | cowork-project     | 🟠   | [바로가기](./todo/02-management/project-crud.md)            |
+| 10 | 메시지 Emoji 반응 API + WS 이벤트        | cowork-chat        | 🟡   | [바로가기](./todo/03-messaging/emoji-reaction.md)           |
+| 11 | 스레드 메시지 `parentMessageId` 필터     | cowork-chat        | 🟡   | [바로가기](./todo/03-messaging/thread-filter.md)            |
+| 12 | 파일·이미지 첨부 API + 메시지 모델 확장        | cowork-chat        | 🟡   | [바로가기](./todo/03-messaging/file-attachment.md)          |
+| 13 | @멘션 멤버 검색 API                    | cowork-user        | 🟡   | [바로가기](./todo/03-messaging/mention.md)                  |
+| 14 | 읽음 상태 및 미읽 카운트                   | cowork-chat        | 🟡   | [바로가기](./todo/04-notification/read-status.md)           |
+| 15 | 알림 설정 (preference 모듈 확장)         | cowork-preference  | 🟡   | [바로가기](./todo/04-notification/notification-settings.md) |
+| 16 | 프로필 필드 수정 + 커스텀 상태 메시지           | cowork-user        | 🟡   | [바로가기](./todo/05-user-search/profile-edit.md)           |
+| 17 | 전체 검색 API                        | 신규 or gateway      | 🟡   | [바로가기](./todo/05-user-search/global-search.md)          |
+| 18 | AccountShare 채널 설계·구현            | TBD                | 🟢   | [바로가기](./todo/06-future/account-share.md)               |
+| 19 | 다이렉트 메시지(DM)                     | 신규                 | 🟢   | [바로가기](./todo/06-future/direct-message.md)              |
+| 20 | 팀 역할 시스템 고도화                     | cowork-team        | 🟢   | [바로가기](./todo/06-future/role-system.md)                 |
+| 21 | 회의록 수정·삭제, 템플릿 관리                | cowork-channel     | 🟢   | [바로가기](./todo/06-future/meeting-note-management.md)     |
+| 22 | WebSocket 이벤트 보강                 | cowork-chat        | 🟢   | [바로가기](./todo/06-future/websocket-events.md)            |


### PR DESCRIPTION
## 개요

write-pr 스크립트에 `PR_BASE_BRANCH` 환경 변수 오버라이드를 추가하였습니다. harness sync 설정에 codex 훅 및 secret-guard 항목을 추가하였으며, TODO 문서의 테이블 정렬을 개선하였습니다.

## 본문

**write-pr 스크립트 base 브랜치 오버라이드 추가**
`create-pr.sh`에서 `PR_BASE_BRANCH` 환경 변수가 설정된 경우 기존 브랜치 패턴 매핑보다 우선적으로 사용하도록 수정하였습니다. 이를 통해 브랜치 명명 규칙과 무관하게 원하는 base 브랜치로 PR을 생성할 수 있습니다.

**harness sync 설정 확장**
`.harness/sync.yml`에 Claude 에이전트용 `secret-guard` 훅을 추가하고, Codex 에이전트 대상 훅 일체(`dispatcher`, `hooks-json`, `command-guard`, `logging`, `ktlint`, `secret-guard`)를 동기화 설정에 포함하였습니다.

**TODO 문서 테이블 정렬 개선**
`docs/20260526_TODO.md`의 마크다운 테이블 컬럼 정렬을 가독성이 향상되도록 조정하였습니다.