### PR TITLE
[chat] 읽음 상태 및 미읽 카운트 기능 구현

### DIFF
--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -9,6 +9,7 @@ import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { ProjectClient } from './service/project.client';
 import { MinioService } from '../storage/minio.service';
 import { SlashCommand } from './dto/slash-command.dto';
+import { ReadChannelDto } from './dto/read-channel.dto';
 
 const mockMessageId = new Types.ObjectId().toString();
 const userId = 42;
@@ -26,6 +27,7 @@ const mockChatService = {
     sendMessage: jest.fn(),
     editMessage: jest.fn(),
     deleteMessage: jest.fn(),
+    readChannel: jest.fn(),
 };
 
 const mockProducer = {
@@ -86,11 +88,10 @@ describe('ChatController', () => {
                 userId,
             );
 
-            expect(mockChatService.createFileUploadUrl).toHaveBeenCalledWith(1, {
-                filename: 'file.png',
-                contentType: 'image/png',
-                size: 1024,
-            }, 42);
+            expect(mockChatService.createFileUploadUrl).toHaveBeenCalledWith(
+                { channelId: 1, userId: 42 },
+                { filename: 'file.png', contentType: 'image/png', size: 1024 },
+            );
             expect(result.headers).toEqual({ 'Content-Type': 'image/png' });
         });
     });
@@ -115,7 +116,10 @@ describe('ChatController', () => {
 
             const result = await controller.getFiles(1, { limit: 20, before: undefined } as any, userId);
 
-            expect(mockChatService.getFileList).toHaveBeenCalledWith(1, 42, undefined, 20);
+            expect(mockChatService.getFileList).toHaveBeenCalledWith(
+                { channelId: 1, userId: 42 },
+                { limit: 20, before: undefined },
+            );
             expect(result.files).toHaveLength(1);
             expect(result.files[0].uploaderName).toBe('홍길동');
         });
@@ -129,7 +133,10 @@ describe('ChatController', () => {
 
             const result = await controller.sendMessage(1, dto as any, userId, userRole);
 
-            expect(mockChatService.sendMessage).toHaveBeenCalledWith(1, dto, 42, 'ROLE_USER');
+            expect(mockChatService.sendMessage).toHaveBeenCalledWith(
+                { channelId: 1, userId: 42, userRole: 'ROLE_USER' },
+                dto,
+            );
             expect(result).toEqual({ queued: true });
         });
 
@@ -154,7 +161,10 @@ describe('ChatController', () => {
 
             const result = await controller.createGithubIssue(1, dto as any, userId);
 
-            expect(mockChatService.publishGithubIssueCreateCommand).toHaveBeenCalledWith(1, dto, 42);
+            expect(mockChatService.publishGithubIssueCreateCommand).toHaveBeenCalledWith(
+                { channelId: 1, userId: 42 },
+                dto,
+            );
             expect(result).toEqual({ queued: true });
         });
 
@@ -164,9 +174,8 @@ describe('ChatController', () => {
             await controller.createGithubIssue(1, { ...dto, body: undefined } as any, userId);
 
             expect(mockChatService.publishGithubIssueCreateCommand).toHaveBeenCalledWith(
-                1,
+                { channelId: 1, userId: 42 },
                 expect.objectContaining({ body: undefined }),
-                42,
             );
         });
 
@@ -219,10 +228,10 @@ describe('ChatController', () => {
                 userId,
             );
 
-            expect(mockChatService.handleSlashCommand).toHaveBeenCalledWith(1, {
-                command: SlashCommand.GITHUB_ISSUE_CREATE,
-                payload,
-            }, 42);
+            expect(mockChatService.handleSlashCommand).toHaveBeenCalledWith(
+                { channelId: 1, userId: 42 },
+                { command: SlashCommand.GITHUB_ISSUE_CREATE, payload },
+            );
             expect(result).toEqual({ queued: true });
         });
 
@@ -236,9 +245,8 @@ describe('ChatController', () => {
             );
 
             expect(mockChatService.handleSlashCommand).toHaveBeenCalledWith(
-                1,
+                { channelId: 1, userId: 42 },
                 expect.objectContaining({ payload: expect.objectContaining({ body: undefined }) }),
-                42,
             );
         });
 
@@ -304,26 +312,29 @@ describe('ChatController', () => {
     });
 
     describe('getMessages', () => {
-        it('멤버십 검증 후 채널 메시지를 조회한다', async () => {
-            mockChatService.checkMembership.mockResolvedValue(undefined);
+        it('채널 메시지를 조회하고 반환한다', async () => {
             mockChatService.getMessages.mockResolvedValue([]);
 
             const result = await controller.getMessages(1, {}, userId);
 
-            expect(mockChatService.checkMembership).toHaveBeenCalledWith(1, 42);
-            expect(mockChatService.getMessages).toHaveBeenCalledWith(1, undefined);
+            expect(mockChatService.getMessages).toHaveBeenCalledWith(
+                { channelId: 1, userId: 42 },
+                undefined,
+            );
             expect(result).toEqual([]);
         });
 
         it('cursor(before) 파라미터를 서비스로 전달한다', async () => {
-            mockChatService.checkMembership.mockResolvedValue(undefined);
             mockChatService.getMessages.mockResolvedValue([]);
             await controller.getMessages(1, { before: mockMessageId }, userId);
-            expect(mockChatService.getMessages).toHaveBeenCalledWith(1, mockMessageId);
+            expect(mockChatService.getMessages).toHaveBeenCalledWith(
+                { channelId: 1, userId: 42 },
+                mockMessageId,
+            );
         });
 
         it('채널 멤버가 아니면 ForbiddenException이 발생한다', async () => {
-            mockChatService.checkMembership.mockRejectedValue(new ForbiddenException());
+            mockChatService.getMessages.mockRejectedValue(new ForbiddenException());
             await expect(controller.getMessages(1, {}, userId)).rejects.toThrow(ForbiddenException);
         });
     });
@@ -336,7 +347,8 @@ describe('ChatController', () => {
             const result = await controller.editMessage(1, mockMessageId, { content: '수정됨' }, userId, userRole);
 
             expect(mockChatService.editMessage).toHaveBeenCalledWith(
-                1, mockMessageId, 42, { content: '수정됨' }, 'ROLE_USER',
+                { channelId: 1, messageId: mockMessageId, userId: 42, userRole: 'ROLE_USER' },
+                { content: '수정됨' },
             );
             expect(result).toBe(updated);
         });
@@ -356,6 +368,30 @@ describe('ChatController', () => {
         });
     });
 
+    describe('readChannel', () => {
+        const dto: ReadChannelDto = { lastReadMessageId: new Types.ObjectId().toString() };
+
+        it('ReadChannelDto를 서비스에 전달하고 204를 반환한다', async () => {
+            mockChatService.readChannel.mockResolvedValue(undefined);
+
+            const result = await controller.readChannel(1, dto, userId);
+
+            expect(mockChatService.readChannel).toHaveBeenCalledWith(
+                { channelId: 1, userId: 42 },
+                dto.lastReadMessageId,
+            );
+            expect(result).toBeUndefined();
+        });
+
+        it('채널 멤버가 아니면 ForbiddenException이 전파된다', async () => {
+            mockChatService.readChannel.mockRejectedValue(new ForbiddenException());
+
+            await expect(
+                controller.readChannel(1, dto, userId),
+            ).rejects.toThrow(ForbiddenException);
+        });
+    });
+
     describe('deleteMessage', () => {
         it('메시지를 삭제하고 Socket.io로 브로드캐스트한다', async () => {
             mockChatService.deleteMessage.mockResolvedValue({ channelId: 1, messageId: mockMessageId });
@@ -363,7 +399,7 @@ describe('ChatController', () => {
             const result = await controller.deleteMessage(1, mockMessageId, userId, userRole);
 
             expect(mockChatService.deleteMessage).toHaveBeenCalledWith(
-                1, mockMessageId, 42, 'ROLE_USER',
+                { channelId: 1, messageId: mockMessageId, userId: 42, userRole: 'ROLE_USER' },
             );
             expect(result).toEqual({ channelId: 1, messageId: mockMessageId });
         });

--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -33,6 +33,7 @@ import { SlashCommandDto, SlashCommandResponseDto } from './dto/slash-command.dt
 import { FileListQueryDto, FileListResponseDto } from './dto/file-list.dto';
 import { UserId, UserRole } from '../common/decorator/user.decorator';
 import { AddReactionDto } from './dto/add-reaction.dto';
+import { ReadChannelDto } from './dto/read-channel.dto';
 import { EMOJI_REGEX } from './util/emoji';
 
 /**
@@ -211,6 +212,20 @@ export class ChatController {
      * @param userId - Gateway가 주입한 요청자 ID
      * @returns 메시지 배열 (reactions는 나의 반응 여부 포함)
      */
+    @Post('read')
+    @HttpCode(HttpStatus.NO_CONTENT)
+    @ApiOperation({ summary: '채널 읽음 상태 업데이트' })
+    @ApiResponse({ status: 204 })
+    @ApiResponse({ status: 400, description: '유효하지 않은 메시지 ID' })
+    @ApiResponse({ status: 403, description: '채널 멤버 아님' })
+    async readChannel(
+        @Param('channelId', ParseIntPipe) channelId: number,
+        @Body() dto: ReadChannelDto,
+        @UserId() userId: number,
+    ): Promise<void> {
+        await this.chatService.readChannel({ channelId, userId }, dto.lastReadMessageId);
+    }
+
     @Get('messages')
     @ApiOperation({ summary: '채널 메시지 목록 조회 (커서 기반 페이지네이션)' })
     @ApiResponse({ status: 200, type: [MessageResponseDto] })

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -81,6 +81,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 
             client.data.userId = userId;
             client.data.userRole = payload.role ?? UserRole.USER;
+            client.join(`user:${userId}`);
             this.logger.log(`연결됨: ${client.id} (userId=${userId})`);
         } catch (err) {
             const message = err instanceof Error ? err.message : '인증 실패';

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -9,6 +9,7 @@ import { ChatGateway } from './chat.gateway';
 import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
 import { ProjectMessageController } from './project-message.controller';
+import { TeamUnreadController } from './team-unread.controller';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { NotificationTriggerProducer } from './kafka/notification-trigger.producer';
@@ -107,7 +108,7 @@ function createLogStream() {
         MinioModule,
         SearchModule,
     ],
-    controllers: [ChatController, ProjectMessageController, HealthController],
+    controllers: [ChatController, ProjectMessageController, TeamUnreadController, HealthController],
     providers: [
         ChatGateway,
         ChatService,

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -42,6 +42,7 @@ const mockMessageRepository = {
     deleteById: jest.fn(),
     createSystemMessage: jest.fn(),
     countUnread: jest.fn(),
+    countUnreadForChannels: jest.fn(),
 };
 
 
@@ -471,14 +472,15 @@ describe('ChatService', () => {
                 { channelId: 1, lastReadMessageId: oid1 },
                 { channelId: 2, lastReadMessageId: oid2 },
             ]);
-            mockMessageRepository.countUnread
-                .mockResolvedValueOnce(5)
-                .mockResolvedValueOnce(0);
+            mockMessageRepository.countUnreadForChannels.mockResolvedValue(new Map([[1, 5], [2, 0]]));
 
             const result = await service.getTeamUnread(10, 42);
 
             expect(mockChannelMemberRepository.findMembersByTeam).toHaveBeenCalledWith(10, 42);
-            expect(mockMessageRepository.countUnread).toHaveBeenCalledTimes(2);
+            expect(mockMessageRepository.countUnreadForChannels).toHaveBeenCalledWith([
+                { channelId: 1, lastReadMessageId: oid1 },
+                { channelId: 2, lastReadMessageId: oid2 },
+            ]);
             expect(result).toEqual([
                 { channelId: 1, unreadCount: 5 },
                 { channelId: 2, unreadCount: 0 },
@@ -491,18 +493,21 @@ describe('ChatService', () => {
             const result = await service.getTeamUnread(10, 42);
 
             expect(result).toEqual([]);
-            expect(mockMessageRepository.countUnread).not.toHaveBeenCalled();
+            expect(mockMessageRepository.countUnreadForChannels).not.toHaveBeenCalled();
         });
 
-        it('lastReadMessageId가 null이면 채널 전체 메시지를 카운트한다', async () => {
+        it('lastReadMessageId가 null이면 해당 채널은 Map에서 0으로 fallback된다', async () => {
             mockChannelMemberRepository.findMembersByTeam.mockResolvedValue([
                 { channelId: 3, lastReadMessageId: null },
             ]);
-            mockMessageRepository.countUnread.mockResolvedValue(10);
+            mockMessageRepository.countUnreadForChannels.mockResolvedValue(new Map([[3, 10]]));
 
-            await service.getTeamUnread(10, 42);
+            const result = await service.getTeamUnread(10, 42);
 
-            expect(mockMessageRepository.countUnread).toHaveBeenCalledWith(3, null);
+            expect(mockMessageRepository.countUnreadForChannels).toHaveBeenCalledWith([
+                { channelId: 3, lastReadMessageId: null },
+            ]);
+            expect(result).toEqual([{ channelId: 3, unreadCount: 10 }]);
         });
     });
 

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -41,6 +41,7 @@ const mockMessageRepository = {
     findById: jest.fn(),
     deleteById: jest.fn(),
     createSystemMessage: jest.fn(),
+    countUnread: jest.fn(),
 };
 
 
@@ -48,6 +49,8 @@ const mockChannelMemberRepository = {
     exists: jest.fn(),
     findTeamIdByChannelAndUser: jest.fn(),
     findChannelIdsByUser: jest.fn(),
+    updateLastRead: jest.fn(),
+    findMembersByTeam: jest.fn(),
 };
 
 const mockElasticsearchService = {
@@ -419,6 +422,87 @@ describe('ChatService', () => {
             await expect(
                 service.deleteMessage(ctx()),
             ).resolves.toBeDefined();
+        });
+    });
+
+    describe('readChannel', () => {
+        const msgId = new Types.ObjectId();
+
+        it('멤버가 아니면 ForbiddenException을 던진다', async () => {
+            mockChannelMemberRepository.exists.mockResolvedValue(false);
+
+            await expect(
+                service.readChannel({ channelId: 1, userId: 42 }, msgId.toString()),
+            ).rejects.toThrow(ForbiddenException);
+        });
+
+        it('lastReadMessageId를 업데이트하고 unreadCount를 계산한다', async () => {
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockChannelMemberRepository.updateLastRead.mockResolvedValue(undefined);
+            mockMessageRepository.countUnread.mockResolvedValue(3);
+
+            await service.readChannel({ channelId: 1, userId: 42 }, msgId.toString());
+
+            expect(mockChannelMemberRepository.updateLastRead).toHaveBeenCalledWith(
+                1,
+                42,
+                expect.any(Types.ObjectId),
+            );
+            expect(mockMessageRepository.countUnread).toHaveBeenCalledWith(1, expect.any(Types.ObjectId));
+        });
+
+        it('user:{userId} 룸으로 channel:unread:updated 이벤트를 emit한다', async () => {
+            mockChannelMemberRepository.exists.mockResolvedValue(true);
+            mockChannelMemberRepository.updateLastRead.mockResolvedValue(undefined);
+            mockMessageRepository.countUnread.mockResolvedValue(0);
+
+            await service.readChannel({ channelId: 1, userId: 42 }, msgId.toString());
+
+            expect(mockTo).toHaveBeenCalledWith('user:42');
+            expect(mockEmit).toHaveBeenCalledWith('channel:unread:updated', { channelId: 1, unreadCount: 0 });
+        });
+    });
+
+    describe('getTeamUnread', () => {
+        it('가입한 채널별 미읽 카운트를 반환한다', async () => {
+            const oid1 = new Types.ObjectId();
+            const oid2 = new Types.ObjectId();
+            mockChannelMemberRepository.findMembersByTeam.mockResolvedValue([
+                { channelId: 1, lastReadMessageId: oid1 },
+                { channelId: 2, lastReadMessageId: oid2 },
+            ]);
+            mockMessageRepository.countUnread
+                .mockResolvedValueOnce(5)
+                .mockResolvedValueOnce(0);
+
+            const result = await service.getTeamUnread(10, 42);
+
+            expect(mockChannelMemberRepository.findMembersByTeam).toHaveBeenCalledWith(10, 42);
+            expect(mockMessageRepository.countUnread).toHaveBeenCalledTimes(2);
+            expect(result).toEqual([
+                { channelId: 1, unreadCount: 5 },
+                { channelId: 2, unreadCount: 0 },
+            ]);
+        });
+
+        it('가입한 채널이 없으면 빈 배열을 반환한다', async () => {
+            mockChannelMemberRepository.findMembersByTeam.mockResolvedValue([]);
+
+            const result = await service.getTeamUnread(10, 42);
+
+            expect(result).toEqual([]);
+            expect(mockMessageRepository.countUnread).not.toHaveBeenCalled();
+        });
+
+        it('lastReadMessageId가 null이면 채널 전체 메시지를 카운트한다', async () => {
+            mockChannelMemberRepository.findMembersByTeam.mockResolvedValue([
+                { channelId: 3, lastReadMessageId: null },
+            ]);
+            mockMessageRepository.countUnread.mockResolvedValue(10);
+
+            await service.getTeamUnread(10, 42);
+
+            expect(mockMessageRepository.countUnread).toHaveBeenCalledWith(3, null);
         });
     });
 

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -535,13 +535,14 @@ export class ChatService {
 
     async getTeamUnread(teamId: number, userId: number): Promise<Array<{ channelId: number; unreadCount: number }>> {
         const memberships = await this.channelMemberRepository.findMembersByTeam(teamId, userId);
-        const results = await Promise.all(
-            memberships.map(async ({ channelId, lastReadMessageId }) => {
-                const unreadCount = await this.messageRepository.countUnread(channelId, lastReadMessageId);
-                return { channelId, unreadCount };
-            }),
-        );
-        return results;
+        if (memberships.length === 0) {
+            return [];
+        }
+        const unreadCounts = await this.messageRepository.countUnreadForChannels(memberships);
+        return memberships.map(({ channelId }) => ({
+            channelId,
+            unreadCount: unreadCounts.get(channelId) ?? 0,
+        }));
     }
 
     async getPinnedMessages(ctx: ChannelUserContext) {

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -523,6 +523,27 @@ export class ChatService {
      * @param ctx - 채널·사용자 컨텍스트
      * @returns 고정 메시지 배열 (reactions는 나의 반응 여부 포함)
      */
+    async readChannel(ctx: ChannelUserContext, lastReadMessageId: string): Promise<void> {
+        await this.checkMembership(ctx.channelId, ctx.userId);
+        const oid = new Types.ObjectId(lastReadMessageId);
+        await this.channelMemberRepository.updateLastRead(ctx.channelId, ctx.userId, oid);
+        const unreadCount = await this.messageRepository.countUnread(ctx.channelId, oid);
+        this.chatGateway.server
+            ?.to(`user:${ctx.userId}`)
+            .emit('channel:unread:updated', { channelId: ctx.channelId, unreadCount });
+    }
+
+    async getTeamUnread(teamId: number, userId: number): Promise<Array<{ channelId: number; unreadCount: number }>> {
+        const memberships = await this.channelMemberRepository.findMembersByTeam(teamId, userId);
+        const results = await Promise.all(
+            memberships.map(async ({ channelId, lastReadMessageId }) => {
+                const unreadCount = await this.messageRepository.countUnread(channelId, lastReadMessageId);
+                return { channelId, unreadCount };
+            }),
+        );
+        return results;
+    }
+
     async getPinnedMessages(ctx: ChannelUserContext) {
         await this.checkMembership(ctx.channelId, ctx.userId);
         const rows = await this.messageRepository.findPinnedMessages(ctx.channelId);

--- a/cowork-chat/src/chat/dto/read-channel.dto.ts
+++ b/cowork-chat/src/chat/dto/read-channel.dto.ts
@@ -1,0 +1,8 @@
+import { IsMongoId } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ReadChannelDto {
+    @ApiProperty({ description: '마지막으로 읽은 메시지 ObjectId' })
+    @IsMongoId()
+    lastReadMessageId!: string;
+}

--- a/cowork-chat/src/chat/dto/unread-count-response.dto.ts
+++ b/cowork-chat/src/chat/dto/unread-count-response.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UnreadCountItemDto {
+    @ApiProperty() channelId!: number;
+    @ApiProperty() unreadCount!: number;
+}

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.spec.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.spec.ts
@@ -8,6 +8,10 @@ const mockConfigService = {
     get: jest.fn().mockReturnValue('localhost:9092'),
 };
 
+const mockChannelMemberRepository = {
+    updateLastRead: jest.fn().mockResolvedValue(undefined),
+};
+
 const mockElasticsearchService = {
     indexMessage: jest.fn().mockResolvedValue(undefined),
 };
@@ -16,12 +20,13 @@ describe('ChatMessageConsumer', () => {
     let consumer: ChatMessageConsumer;
 
     beforeEach(() => {
-        consumer = new ChatMessageConsumer(mockMessageRepository as any, mockConfigService as any, mockElasticsearchService as any);
+        consumer = new ChatMessageConsumer(mockMessageRepository as any, mockChannelMemberRepository as any, mockConfigService as any, mockElasticsearchService as any);
         jest.clearAllMocks();
     });
 
     it('clientMessageId가 없으면 null 대신 undefined로 저장한다', async () => {
-        mockMessageRepository.createMessage.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
+        const savedMessage = { _id: 'msg-id-1', toObject: jest.fn().mockReturnValue({}) };
+        mockMessageRepository.createMessage.mockResolvedValue(savedMessage);
 
         await (consumer as any).handleMessageEvent({
             teamId: 10,
@@ -41,5 +46,25 @@ describe('ChatMessageConsumer', () => {
                 clientMessageId: undefined,
             }),
         );
+    });
+
+    it('메시지 저장 후 작성자의 lastReadMessageId를 자동 업데이트한다', async () => {
+        const savedMessage = { _id: 'msg-id-42', toObject: jest.fn().mockReturnValue({}) };
+        mockMessageRepository.createMessage.mockResolvedValue(savedMessage);
+
+        await (consumer as any).handleMessageEvent({
+            teamId: 10,
+            projectId: null,
+            channelId: 5,
+            authorId: 42,
+            authorRole: 'MEMBER',
+            content: '자동 읽음 테스트',
+            type: 'TEXT',
+            attachments: [],
+            occurredAt: new Date().toISOString(),
+        });
+
+        await new Promise((r) => setImmediate(r));
+        expect(mockChannelMemberRepository.updateLastRead).toHaveBeenCalledWith(5, 42, 'msg-id-42');
     });
 });

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.ts
@@ -140,7 +140,9 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
 
             this.logger.log(`message saved messageId=${saved._id} channelId=${event.channelId}`);
             this.io?.to(`chat:${event.channelId}`).emit('message', saved.toObject());
-            void this.channelMemberRepository.updateLastRead(event.channelId, event.authorId, saved._id);
+            void this.channelMemberRepository
+                .updateLastRead(event.channelId, event.authorId, saved._id)
+                .catch((err) => this.logger.warn(`lastReadMessageId 업데이트 실패 channelId=${event.channelId} authorId=${event.authorId}: ${err}`));
 
             if (event.projectId) {
                 void this.elasticsearchService.indexMessage({

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.ts
@@ -7,6 +7,7 @@ import { ChatMessageEvent } from './event/chat-message.event';
 import { ElasticsearchService } from '../../search/elasticsearch.service';
 import { getRequiredCsvConfig } from '../../common/config/config.util';
 import { MessageRepository } from '../repository/message.repository';
+import { ChannelMemberRepository } from '../repository/channel-member.repository';
 
 /**
  * Kafka `chat.message` 토픽을 구독하여 채팅 메시지를 처리하는 컨슈머.
@@ -24,6 +25,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
 
     constructor(
         private readonly messageRepository: MessageRepository,
+        private readonly channelMemberRepository: ChannelMemberRepository,
         private readonly configService: ConfigService,
         private readonly elasticsearchService: ElasticsearchService,
     ) {}
@@ -138,6 +140,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
 
             this.logger.log(`message saved messageId=${saved._id} channelId=${event.channelId}`);
             this.io?.to(`chat:${event.channelId}`).emit('message', saved.toObject());
+            void this.channelMemberRepository.updateLastRead(event.channelId, event.authorId, saved._id);
 
             if (event.projectId) {
                 void this.elasticsearchService.indexMessage({

--- a/cowork-chat/src/chat/repository/channel-member.repository.ts
+++ b/cowork-chat/src/chat/repository/channel-member.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, Types } from 'mongoose';
 import { ChannelMember } from '../schema/channel-member.schema';
 
 /**
@@ -69,5 +69,25 @@ export class ChannelMemberRepository {
      */
     findByChannelId(channelId: number): Promise<ChannelMember[]> {
         return this.memberModel.find({ channelId }).lean() as Promise<ChannelMember[]>;
+    }
+
+    async updateLastRead(channelId: number, userId: number, messageId: Types.ObjectId): Promise<void> {
+        await this.memberModel.updateOne(
+            { channelId, userId },
+            { $set: { lastReadMessageId: messageId } },
+        );
+    }
+
+    async findMembersByTeam(
+        teamId: number,
+        userId: number,
+    ): Promise<Array<{ channelId: number; lastReadMessageId: Types.ObjectId | null }>> {
+        const memberships = await this.memberModel
+            .find({ teamId, userId }, { channelId: 1, lastReadMessageId: 1 })
+            .lean();
+        return memberships.map((m) => ({
+            channelId: m.channelId,
+            lastReadMessageId: (m.lastReadMessageId as Types.ObjectId | null | undefined) ?? null,
+        }));
     }
 }

--- a/cowork-chat/src/chat/repository/message.repository.spec.ts
+++ b/cowork-chat/src/chat/repository/message.repository.spec.ts
@@ -2,9 +2,11 @@ import { Types } from 'mongoose';
 import { MessageRepository } from './message.repository';
 
 const mockAggregate = jest.fn();
+const mockCountDocuments = jest.fn();
 
 const mockMessageModel = {
     aggregate: mockAggregate,
+    countDocuments: mockCountDocuments,
     collection: { name: 'messages' },
 };
 
@@ -14,6 +16,42 @@ describe('MessageRepository', () => {
     beforeEach(() => {
         repository = new MessageRepository(mockMessageModel as any);
         jest.clearAllMocks();
+    });
+
+    describe('countUnread', () => {
+        it('afterId가 있으면 _id > afterId 조건으로 스레드 제외 카운트를 반환한다', async () => {
+            const afterId = new Types.ObjectId();
+            mockCountDocuments.mockResolvedValue(7);
+
+            const result = await repository.countUnread(1, afterId);
+
+            expect(mockCountDocuments).toHaveBeenCalledWith({
+                channelId: 1,
+                parentMessageId: null,
+                _id: { $gt: afterId },
+            });
+            expect(result).toBe(7);
+        });
+
+        it('afterId가 null이면 _id 조건 없이 채널 전체를 카운트한다', async () => {
+            mockCountDocuments.mockResolvedValue(20);
+
+            const result = await repository.countUnread(1, null);
+
+            expect(mockCountDocuments).toHaveBeenCalledWith({
+                channelId: 1,
+                parentMessageId: null,
+            });
+            expect(result).toBe(20);
+        });
+
+        it('메시지가 없으면 0을 반환한다', async () => {
+            mockCountDocuments.mockResolvedValue(0);
+
+            const result = await repository.countUnread(1, new Types.ObjectId());
+
+            expect(result).toBe(0);
+        });
     });
 
     describe('findMessages', () => {
@@ -79,18 +117,17 @@ describe('MessageRepository', () => {
 
             const result = await repository.findFileAttachments(1, undefined, 20);
 
-            expect(result.items).toEqual([
-                {
-                    messageId: '665f00000000000000000001',
-                    fileName: 'report.pdf',
-                    fileSize: 2048,
-                    fileUrl: 'http://localhost:9000/cowork-bucket/chat-files/1/42/report.pdf',
-                    mimeType: 'application/pdf',
-                    uploaderId: 42,
-                    uploadedAt: createdAt.toISOString(),
-                    attachmentIndex: 0,
-                },
-            ]);
+            expect(result.items[0]).toMatchObject({
+                messageId: '665f00000000000000000001',
+                fileName: 'report.pdf',
+                fileSize: 2048,
+                fileUrl: 'http://localhost:9000/cowork-bucket/chat-files/1/42/report.pdf',
+                mimeType: 'application/pdf',
+                uploaderId: 42,
+                uploadedAt: createdAt.toISOString(),
+                attachmentIndex: 0,
+            });
+            expect(result.items[0].fileId).toBeDefined();
             expect(result.nextCursor).toBeNull();
         });
 

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -525,6 +525,14 @@ export class MessageRepository {
      * @param notificationRetryCount - 업데이트할 재시도 횟수. 생략 시 현재 값을 유지
      * @returns Mongoose `updateOne` 결과 객체
      */
+    countUnread(channelId: number, afterId: Types.ObjectId | null): Promise<number> {
+        const filter: Record<string, unknown> = { channelId, parentMessageId: null };
+        if (afterId) {
+            filter['_id'] = { $gt: afterId };
+        }
+        return this.messageModel.countDocuments(filter);
+    }
+
     updateNotificationStatus(
         messageId: Types.ObjectId,
         notificationStatus: string,

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -533,6 +533,30 @@ export class MessageRepository {
         return this.messageModel.countDocuments(filter);
     }
 
+    async countUnreadForChannels(
+        memberships: Array<{ channelId: number; lastReadMessageId: Types.ObjectId | null }>,
+    ): Promise<Map<number, number>> {
+        if (memberships.length === 0) {
+            return new Map();
+        }
+        const orConditions = memberships.map(({ channelId, lastReadMessageId }) => {
+            const cond: Record<string, unknown> = { channelId, parentMessageId: null };
+            if (lastReadMessageId) {
+                cond['_id'] = { $gt: lastReadMessageId };
+            }
+            return cond;
+        });
+        const results = await this.messageModel.aggregate<{ _id: number; count: number }>([
+            { $match: { $or: orConditions } },
+            { $group: { _id: '$channelId', count: { $sum: 1 } } },
+        ]);
+        const countMap = new Map<number, number>();
+        for (const row of results) {
+            countMap.set(row._id, row.count);
+        }
+        return countMap;
+    }
+
     updateNotificationStatus(
         messageId: Types.ObjectId,
         notificationStatus: string,

--- a/cowork-chat/src/chat/schema/channel-member.schema.ts
+++ b/cowork-chat/src/chat/schema/channel-member.schema.ts
@@ -1,5 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
-import { HydratedDocument } from 'mongoose';
+import { HydratedDocument, Types } from 'mongoose';
 
 /** Mongoose 문서 타입. HydratedDocument로 래핑되어 _id, save() 등 Mongoose 메서드를 포함합니다. */
 export type ChannelMemberDocument = HydratedDocument<ChannelMember>;
@@ -27,6 +27,9 @@ export class ChannelMember {
      * 기본값은 `'MEMBER'`이며, 추후 `'OWNER'`, `'ADMIN'` 등으로 확장 가능합니다.
      */
     @Prop({ default: 'MEMBER' }) role!: string;
+
+    /** 이 채널에서 마지막으로 읽은 메시지의 ObjectId. 한 번도 읽지 않은 경우 `null`. */
+    @Prop({ type: Types.ObjectId, default: null }) lastReadMessageId!: Types.ObjectId | null;
 }
 
 /** {@link ChannelMember} 클래스로부터 생성된 Mongoose 스키마 인스턴스 */

--- a/cowork-chat/src/chat/team-unread.controller.spec.ts
+++ b/cowork-chat/src/chat/team-unread.controller.spec.ts
@@ -1,0 +1,58 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
+import { TeamUnreadController } from './team-unread.controller';
+import { ChatService } from './chat.service';
+import { UnreadCountItemDto } from './dto/unread-count-response.dto';
+
+const mockChatService = {
+    getTeamUnread: jest.fn(),
+};
+
+const userId = 42;
+
+describe('TeamUnreadController', () => {
+    let controller: TeamUnreadController;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            controllers: [TeamUnreadController],
+            providers: [
+                { provide: ChatService, useValue: mockChatService },
+            ],
+        }).compile();
+
+        controller = module.get<TeamUnreadController>(TeamUnreadController);
+        jest.clearAllMocks();
+    });
+
+    describe('getTeamUnread', () => {
+        it('팀 내 채널별 미읽 카운트를 반환한다', async () => {
+            const expected: UnreadCountItemDto[] = [
+                { channelId: 1, unreadCount: 3 },
+                { channelId: 2, unreadCount: 0 },
+            ];
+            mockChatService.getTeamUnread.mockResolvedValue(expected);
+
+            const result = await controller.getTeamUnread(10, userId);
+
+            expect(mockChatService.getTeamUnread).toHaveBeenCalledWith(10, 42);
+            expect(result).toEqual(expected);
+        });
+
+        it('가입한 채널이 없으면 빈 배열을 반환한다', async () => {
+            mockChatService.getTeamUnread.mockResolvedValue([]);
+
+            const result = await controller.getTeamUnread(10, userId);
+
+            expect(result).toEqual([]);
+        });
+
+        it('서비스 오류가 전파된다', async () => {
+            mockChatService.getTeamUnread.mockRejectedValue(new ForbiddenException());
+
+            await expect(
+                controller.getTeamUnread(10, userId),
+            ).rejects.toThrow(ForbiddenException);
+        });
+    });
+});

--- a/cowork-chat/src/chat/team-unread.controller.ts
+++ b/cowork-chat/src/chat/team-unread.controller.ts
@@ -1,0 +1,23 @@
+import { Controller, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ChatService } from './chat.service';
+import { UserId } from '../common/decorator/user.decorator';
+import { UnreadCountItemDto } from './dto/unread-count-response.dto';
+
+@ApiTags('Chat')
+@ApiHeader({ name: 'X-User-Id', description: 'Gateway 주입 유저 ID', required: true })
+@ApiHeader({ name: 'X-User-Role', description: 'Gateway 주입 유저 역할 (ADMIN | MEMBER)', required: true })
+@Controller('teams/:teamId')
+export class TeamUnreadController {
+    constructor(private readonly chatService: ChatService) {}
+
+    @Get('unread')
+    @ApiOperation({ summary: '팀 내 가입 채널별 미읽 카운트 조회' })
+    @ApiResponse({ status: 200, type: [UnreadCountItemDto] })
+    async getTeamUnread(
+        @Param('teamId', ParseIntPipe) teamId: number,
+        @UserId() userId: number,
+    ): Promise<UnreadCountItemDto[]> {
+        return this.chatService.getTeamUnread(teamId, userId);
+    }
+}

--- a/docs/20260526_TODO.md
+++ b/docs/20260526_TODO.md
@@ -9,27 +9,27 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 
 ## 요약 테이블
 
-| # | 항목 | 서비스 | 우선순위 | 세부 문서 |
-|---|------|--------|----------|-----------|
-| 1 | ~~`LocalDateTime` ISO-8601 직렬화~~ | ~~cowork-channel~~ | 🔴 | ~~[바로가기](./todo/01-urgent/meeting-note-datetime.md)~~ |
-| 2 | ~~Gateway 프로젝트 reorder 라우팅~~ | ~~cowork-gateway~~ | 🔴 | ~~[바로가기](./todo/01-urgent/gateway-reorder-routing.md)~~ |
-| 3 | 팀 정보 수정·삭제 API | cowork-team | 🟠 | [바로가기](./todo/02-management/team-crud.md) |
-| 4 | 팀 멤버 관리 API (추방·역할변경·탈퇴) | cowork-team | 🟠 | [바로가기](./todo/02-management/team-members.md) |
-| 5 | 팀 초대 링크 API | cowork-team | 🟠 | [바로가기](./todo/02-management/team-invite.md) |
-| 6 | 채널 수정·삭제 API | cowork-channel | 🟠 | [바로가기](./todo/02-management/channel-crud.md) |
-| 7 | 채널별 멤버 권한 (비공개 채널 초대) | cowork-channel | 🟠 | [바로가기](./todo/02-management/channel-permissions.md) |
-| 8 | 채널 메시지 고정 API | cowork-chat | 🟠 | [바로가기](./todo/02-management/message-pin.md) |
-| 9 | 프로젝트 수정·삭제·보관 API | cowork-project | 🟠 | [바로가기](./todo/02-management/project-crud.md) |
-| 10 | 메시지 Emoji 반응 API + WS 이벤트 | cowork-chat | 🟡 | [바로가기](./todo/03-messaging/emoji-reaction.md) |
-| 11 | 스레드 메시지 `parentMessageId` 필터 | cowork-chat | 🟡 | [바로가기](./todo/03-messaging/thread-filter.md) |
-| 12 | 파일·이미지 첨부 API + 메시지 모델 확장 | cowork-chat | 🟡 | [바로가기](./todo/03-messaging/file-attachment.md) |
-| 13 | @멘션 멤버 검색 API | cowork-user | 🟡 | [바로가기](./todo/03-messaging/mention.md) |
-| 14 | 읽음 상태 및 미읽 카운트 | cowork-chat | 🟡 | [바로가기](./todo/04-notification/read-status.md) |
-| 15 | 알림 설정 (preference 모듈 확장) | cowork-preference | 🟡 | [바로가기](./todo/04-notification/notification-settings.md) |
-| 16 | 프로필 필드 수정 + 커스텀 상태 메시지 | cowork-user | 🟡 | [바로가기](./todo/05-user-search/profile-edit.md) |
-| 17 | 전체 검색 API | 신규 or gateway | 🟡 | [바로가기](./todo/05-user-search/global-search.md) |
-| 18 | AccountShare 채널 설계·구현 | TBD | 🟢 | [바로가기](./todo/06-future/account-share.md) |
-| 19 | 다이렉트 메시지(DM) | 신규 | 🟢 | [바로가기](./todo/06-future/direct-message.md) |
-| 20 | 팀 역할 시스템 고도화 | cowork-team | 🟢 | [바로가기](./todo/06-future/role-system.md) |
-| 21 | 회의록 수정·삭제, 템플릿 관리 | cowork-channel | 🟢 | [바로가기](./todo/06-future/meeting-note-management.md) |
-| 22 | WebSocket 이벤트 보강 | cowork-chat | 🟢 | [바로가기](./todo/06-future/websocket-events.md) |
+| #  | 항목                               | 서비스                | 우선순위 | 세부 문서                                                   |
+|----|----------------------------------|--------------------|------|---------------------------------------------------------|
+| 1  | ~~`LocalDateTime` ISO-8601 직렬화~~ | ~~cowork-channel~~ | 🔴   | ~~[바로가기](./todo/01-urgent/meeting-note-datetime.md)~~   |
+| 2  | ~~Gateway 프로젝트 reorder 라우팅~~     | ~~cowork-gateway~~ | 🔴   | ~~[바로가기](./todo/01-urgent/gateway-reorder-routing.md)~~ |
+| 3  | ~~팀 정보 수정·삭제 API~~               | ~~cowork-team~~    | 🟠   | ~~[바로가기](./todo/02-management/team-crud.md)~~           |
+| 4  | ~~팀 멤버 관리 API (추방·역할변경·탈퇴)~~    | ~~cowork-team~~    | 🟠   | ~~[바로가기](./todo/02-management/team-members.md)~~        |
+| 5  | 팀 초대 링크 API                      | cowork-team        | 🟠   | [바로가기](./todo/02-management/team-invite.md)             |
+| 6  | ~~채널 수정·삭제 API~~                 | ~~cowork-channel~~ | 🟠   | ~~[바로가기](./todo/02-management/channel-crud.md)~~        |
+| 7  | ~~채널별 멤버 권한 (비공개 채널 초대)~~        | ~~cowork-channel~~ | 🟠   | ~~[바로가기](./todo/02-management/channel-permissions.md)~~ |
+| 8  | ~~채널 메시지 고정 API~~                | ~~cowork-chat~~    | 🟠   | ~~[바로가기](./todo/02-management/message-pin.md)~~         |
+| 9  | ~~프로젝트 수정·삭제·보관 API~~            | ~~cowork-project~~ | 🟠   | ~~[바로가기](./todo/02-management/project-crud.md)~~        |
+| 10 | ~~메시지 Emoji 반응 API + WS 이벤트~~    | ~~cowork-chat~~    | 🟡   | ~~[바로가기](./todo/03-messaging/emoji-reaction.md)~~       |
+| 11 | 스레드 메시지 `parentMessageId` 필터     | cowork-chat        | 🟡   | [바로가기](./todo/03-messaging/thread-filter.md)            |
+| 12 | ~~파일·이미지 첨부 API + 메시지 모델 확장~~    | ~~cowork-chat~~    | 🟡   | ~~[바로가기](./todo/03-messaging/file-attachment.md)~~      |
+| 13 | ~~@멘션 멤버 검색 API~~                | ~~cowork-user~~    | 🟡   | ~~[바로가기](./todo/03-messaging/mention.md)~~              |
+| 14 | 읽음 상태 및 미읽 카운트                   | cowork-chat        | 🟡   | [바로가기](./todo/04-notification/read-status.md)           |
+| 15 | ~~알림 설정 (preference 모듈 확장)~~     | ~~cowork-preference~~ | 🟡   | ~~[바로가기](./todo/04-notification/notification-settings.md)~~ |
+| 16 | 프로필 필드 수정 + 커스텀 상태 메시지           | cowork-user        | 🟡   | [바로가기](./todo/05-user-search/profile-edit.md)           |
+| 17 | 전체 검색 API                        | 신규 or gateway      | 🟡   | [바로가기](./todo/05-user-search/global-search.md)          |
+| 18 | AccountShare 채널 설계·구현            | TBD                | 🟢   | [바로가기](./todo/06-future/account-share.md)               |
+| 19 | 다이렉트 메시지(DM)                     | 신규                 | 🟢   | [바로가기](./todo/06-future/direct-message.md)              |
+| 20 | ~~팀 역할 시스템 고도화~~                 | ~~cowork-team~~    | 🟢   | ~~[바로가기](./todo/06-future/role-system.md)~~             |
+| 21 | 회의록 수정·삭제, 템플릿 관리                | cowork-channel     | 🟢   | [바로가기](./todo/06-future/meeting-note-management.md)     |
+| 22 | WebSocket 이벤트 보강                 | cowork-chat        | 🟢   | [바로가기](./todo/06-future/websocket-events.md)            |

--- a/docs/20260526_TODO.md
+++ b/docs/20260526_TODO.md
@@ -9,27 +9,27 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 
 ## 요약 테이블
 
-| #  | 항목                               | 서비스                | 우선순위 | 세부 문서                                                   |
-|----|----------------------------------|--------------------|------|---------------------------------------------------------|
-| 1  | ~~`LocalDateTime` ISO-8601 직렬화~~ | ~~cowork-channel~~ | 🔴   | ~~[바로가기](./todo/01-urgent/meeting-note-datetime.md)~~   |
-| 2  | ~~Gateway 프로젝트 reorder 라우팅~~     | ~~cowork-gateway~~ | 🔴   | ~~[바로가기](./todo/01-urgent/gateway-reorder-routing.md)~~ |
-| 3  | ~~팀 정보 수정·삭제 API~~               | ~~cowork-team~~    | 🟠   | ~~[바로가기](./todo/02-management/team-crud.md)~~           |
-| 4  | ~~팀 멤버 관리 API (추방·역할변경·탈퇴)~~    | ~~cowork-team~~    | 🟠   | ~~[바로가기](./todo/02-management/team-members.md)~~        |
-| 5  | 팀 초대 링크 API                      | cowork-team        | 🟠   | [바로가기](./todo/02-management/team-invite.md)             |
-| 6  | ~~채널 수정·삭제 API~~                 | ~~cowork-channel~~ | 🟠   | ~~[바로가기](./todo/02-management/channel-crud.md)~~        |
-| 7  | ~~채널별 멤버 권한 (비공개 채널 초대)~~        | ~~cowork-channel~~ | 🟠   | ~~[바로가기](./todo/02-management/channel-permissions.md)~~ |
-| 8  | ~~채널 메시지 고정 API~~                | ~~cowork-chat~~    | 🟠   | ~~[바로가기](./todo/02-management/message-pin.md)~~         |
-| 9  | ~~프로젝트 수정·삭제·보관 API~~            | ~~cowork-project~~ | 🟠   | ~~[바로가기](./todo/02-management/project-crud.md)~~        |
-| 10 | ~~메시지 Emoji 반응 API + WS 이벤트~~    | ~~cowork-chat~~    | 🟡   | ~~[바로가기](./todo/03-messaging/emoji-reaction.md)~~       |
-| 11 | 스레드 메시지 `parentMessageId` 필터     | cowork-chat        | 🟡   | [바로가기](./todo/03-messaging/thread-filter.md)            |
-| 12 | ~~파일·이미지 첨부 API + 메시지 모델 확장~~    | ~~cowork-chat~~    | 🟡   | ~~[바로가기](./todo/03-messaging/file-attachment.md)~~      |
-| 13 | ~~@멘션 멤버 검색 API~~                | ~~cowork-user~~    | 🟡   | ~~[바로가기](./todo/03-messaging/mention.md)~~              |
-| 14 | 읽음 상태 및 미읽 카운트                   | cowork-chat        | 🟡   | [바로가기](./todo/04-notification/read-status.md)           |
+| #  | 항목                               | 서비스                   | 우선순위 | 세부 문서                                                       |
+|----|----------------------------------|-----------------------|------|-------------------------------------------------------------|
+| 1  | ~~`LocalDateTime` ISO-8601 직렬화~~ | ~~cowork-channel~~    | 🔴   | ~~[바로가기](./todo/01-urgent/meeting-note-datetime.md)~~       |
+| 2  | ~~Gateway 프로젝트 reorder 라우팅~~     | ~~cowork-gateway~~    | 🔴   | ~~[바로가기](./todo/01-urgent/gateway-reorder-routing.md)~~     |
+| 3  | ~~팀 정보 수정·삭제 API~~               | ~~cowork-team~~       | 🟠   | ~~[바로가기](./todo/02-management/team-crud.md)~~               |
+| 4  | ~~팀 멤버 관리 API (추방·역할변경·탈퇴)~~     | ~~cowork-team~~       | 🟠   | ~~[바로가기](./todo/02-management/team-members.md)~~            |
+| 5  | 팀 초대 링크 API                      | cowork-team           | 🟠   | [바로가기](./todo/02-management/team-invite.md)                 |
+| 6  | ~~채널 수정·삭제 API~~                 | ~~cowork-channel~~    | 🟠   | ~~[바로가기](./todo/02-management/channel-crud.md)~~            |
+| 7  | ~~채널별 멤버 권한 (비공개 채널 초대)~~        | ~~cowork-channel~~    | 🟠   | ~~[바로가기](./todo/02-management/channel-permissions.md)~~     |
+| 8  | ~~채널 메시지 고정 API~~                | ~~cowork-chat~~       | 🟠   | ~~[바로가기](./todo/02-management/message-pin.md)~~             |
+| 9  | ~~프로젝트 수정·삭제·보관 API~~            | ~~cowork-project~~    | 🟠   | ~~[바로가기](./todo/02-management/project-crud.md)~~            |
+| 10 | ~~메시지 Emoji 반응 API + WS 이벤트~~    | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/03-messaging/emoji-reaction.md)~~           |
+| 11 | 스레드 메시지 `parentMessageId` 필터     | cowork-chat           | 🟡   | [바로가기](./todo/03-messaging/thread-filter.md)                |
+| 12 | ~~파일·이미지 첨부 API + 메시지 모델 확장~~    | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/03-messaging/file-attachment.md)~~          |
+| 13 | ~~@멘션 멤버 검색 API~~                | ~~cowork-user~~       | 🟡   | ~~[바로가기](./todo/03-messaging/mention.md)~~                  |
+| 14 | ~~읽음 상태 및 미읽 카운트~~               | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/04-notification/read-status.md)~~           |
 | 15 | ~~알림 설정 (preference 모듈 확장)~~     | ~~cowork-preference~~ | 🟡   | ~~[바로가기](./todo/04-notification/notification-settings.md)~~ |
-| 16 | 프로필 필드 수정 + 커스텀 상태 메시지           | cowork-user        | 🟡   | [바로가기](./todo/05-user-search/profile-edit.md)           |
-| 17 | 전체 검색 API                        | 신규 or gateway      | 🟡   | [바로가기](./todo/05-user-search/global-search.md)          |
-| 18 | AccountShare 채널 설계·구현            | TBD                | 🟢   | [바로가기](./todo/06-future/account-share.md)               |
-| 19 | 다이렉트 메시지(DM)                     | 신규                 | 🟢   | [바로가기](./todo/06-future/direct-message.md)              |
-| 20 | ~~팀 역할 시스템 고도화~~                 | ~~cowork-team~~    | 🟢   | ~~[바로가기](./todo/06-future/role-system.md)~~             |
-| 21 | 회의록 수정·삭제, 템플릿 관리                | cowork-channel     | 🟢   | [바로가기](./todo/06-future/meeting-note-management.md)     |
-| 22 | WebSocket 이벤트 보강                 | cowork-chat        | 🟢   | [바로가기](./todo/06-future/websocket-events.md)            |
+| 16 | 프로필 필드 수정 + 커스텀 상태 메시지           | cowork-user           | 🟡   | [바로가기](./todo/05-user-search/profile-edit.md)               |
+| 17 | 전체 검색 API                        | 신규 or gateway         | 🟡   | [바로가기](./todo/05-user-search/global-search.md)              |
+| 18 | AccountShare 채널 설계·구현            | TBD                   | 🟢   | [바로가기](./todo/06-future/account-share.md)                   |
+| 19 | 다이렉트 메시지(DM)                     | 신규                    | 🟢   | [바로가기](./todo/06-future/direct-message.md)                  |
+| 20 | ~~팀 역할 시스템 고도화~~                 | ~~cowork-team~~       | 🟢   | ~~[바로가기](./todo/06-future/role-system.md)~~                 |
+| 21 | 회의록 수정·삭제, 템플릿 관리                | cowork-channel        | 🟢   | [바로가기](./todo/06-future/meeting-note-management.md)         |
+| 22 | WebSocket 이벤트 보강                 | cowork-chat           | 🟢   | [바로가기](./todo/06-future/websocket-events.md)                |

--- a/docs/specs/14-read-status.md
+++ b/docs/specs/14-read-status.md
@@ -1,0 +1,163 @@
+# #14 읽음 상태 및 미읽 카운트 — 구현 스펙
+
+- **서비스**: cowork-chat
+- **우선순위**: 🟡
+
+---
+
+## 결정 사항 요약
+
+| 항목 | 결정 |
+|------|------|
+| 읽음 기준 | `lastReadMessageId` (ObjectId) |
+| 미읽 카운트 계산 | 매번 실시간 `countDocuments` |
+| WS 이벤트 대상 | 해당 유저만 (`user:{userId}` 개인 룸) |
+| 자기 메시지 | 전송 시 자동 읽음 처리 |
+| read API body | `{ lastReadMessageId: string }` |
+| read API 응답 | 204 No Content |
+| 개인 룸 구성 | `handleConnection` 시 자동 join |
+| WS 이벤트 트리거 | read API 호출 시만 emit (새 메시지 도착 시 push 없음) |
+| unread 조회 범위 | 내가 가입한 채널만 (공개 + 비공개) |
+| 스레드 답글 카운트 | 제외 (`parentMessageId: null` 필터) |
+
+---
+
+## API 명세
+
+### 1. POST /channels/{channelId}/read
+
+채널의 마지막 읽음 메시지를 업데이트하고, 업데이트 후의 미읽 카운트를 WS로 push한다.
+
+**헤더**
+```
+X-User-Id: {userId}
+X-User-Role: ADMIN | MEMBER
+```
+
+**Body**
+```json
+{ "lastReadMessageId": "683a1f2e4b5c6d7e8f9a0b1c" }
+```
+
+**응답**: `204 No Content`
+
+**처리 순서**
+1. `ChannelMember`에서 `{ channelId, userId }` 조회 → 멤버가 아니면 403
+2. `ChannelMember.lastReadMessageId` 업데이트 (`$set`)
+3. `countDocuments({ channelId, _id: { $gt: lastReadMessageId }, parentMessageId: null })` 로 unreadCount 계산
+4. `user:{userId}` 룸에 `channel:unread:updated` emit
+
+---
+
+### 2. GET /teams/{teamId}/unread
+
+내가 가입한 채널(공개 + 비공개 모두)의 채널별 미읽 카운트를 반환한다.
+
+**헤더**
+```
+X-User-Id: {userId}
+X-User-Role: ADMIN | MEMBER
+```
+
+**응답**
+```json
+[
+  { "channelId": 1, "unreadCount": 3 },
+  { "channelId": 2, "unreadCount": 0 }
+]
+```
+
+**처리 순서**
+1. `ChannelMember`에서 `{ teamId, userId }` 조회 → 가입 채널 목록 + `lastReadMessageId` 수집
+2. 각 채널에 대해 `countDocuments` 병렬 실행:
+   - `lastReadMessageId`가 있는 경우: `{ channelId, _id: { $gt: lastReadMessageId }, parentMessageId: null }`
+   - `lastReadMessageId`가 null인 경우: `{ channelId, parentMessageId: null }` (전체 카운트)
+3. `[{ channelId, unreadCount }]` 배열 반환
+
+---
+
+## WebSocket 이벤트
+
+### channel:unread:updated
+
+**방향**: Server → Client  
+**룸**: `user:{userId}` (개인 룸)  
+**트리거**: `POST /channels/{channelId}/read` 호출 후
+
+**페이로드**
+```json
+{
+  "channelId": 1,
+  "unreadCount": 0
+}
+```
+
+---
+
+## 스키마 변경
+
+### ChannelMember (`channel-member.schema.ts`)
+
+```typescript
+@Prop({ type: Types.ObjectId, default: null })
+lastReadMessageId!: Types.ObjectId | null;
+```
+
+인덱스는 기존 `(channelId, userId)` 복합 인덱스로 충분.
+
+---
+
+## 자동 읽음 처리 (메시지 전송 시)
+
+`ChatMessageConsumer`가 메시지를 MongoDB에 저장한 직후, 작성자의 `lastReadMessageId`를 저장된 메시지 `_id`로 업데이트한다.
+
+```
+// 메시지 저장 후
+await channelMemberRepository.updateLastRead(channelId, authorId, savedMessage._id);
+```
+
+---
+
+## 구현 대상 파일
+
+### 신규 생성
+
+| 파일 | 설명 |
+|------|------|
+| `src/chat/dto/read-channel.dto.ts` | `{ lastReadMessageId: string }` DTO |
+| `src/chat/dto/unread-count-response.dto.ts` | `[{ channelId, unreadCount }]` 응답 DTO |
+
+### 수정
+
+| 파일 | 변경 내용 |
+|------|---------|
+| `src/chat/schema/channel-member.schema.ts` | `lastReadMessageId` 필드 추가 |
+| `src/chat/chat.controller.ts` | `POST /channels/:channelId/read`, `GET /teams/:teamId/unread` 엔드포인트 추가 |
+| `src/chat/chat.service.ts` | `readChannel()`, `getTeamUnread()` 메서드 추가 |
+| `src/chat/chat.gateway.ts` | `handleConnection`에 `client.join(\`user:${userId}\`)` 추가 |
+| `src/chat/repository/channel-member.repository.ts` | `updateLastRead()`, `findMembersByTeam()` 메서드 추가 |
+| `src/chat/repository/message.repository.ts` | `countUnread()` 메서드 추가 |
+| `src/chat/kafka/chat-message.consumer.ts` | 메시지 저장 후 작성자 자동 읽음 처리 호출 |
+
+---
+
+## countUnread 쿼리 설계
+
+```typescript
+// message.repository.ts
+countUnread(channelId: number, afterId: Types.ObjectId | null): Promise<number> {
+  const filter: Record<string, unknown> = { channelId, parentMessageId: null };
+  if (afterId) {
+    filter['_id'] = { $gt: afterId };
+  }
+  return this.messageModel.countDocuments(filter);
+}
+```
+
+---
+
+## 고려 사항
+
+- **멀티 디바이스**: 같은 유저가 여러 기기에서 접속해도 `user:{userId}` 룸에 모두 포함되므로 `channel:unread:updated` 이벤트가 모든 기기에 broadcast됨.
+- **새 메시지 도착 시 실시간 push 없음**: 클라이언트가 채널에 진입(`POST /read`)할 때만 이벤트 발생. 사이드바 미읽 카운트 갱신은 클라이언트가 주기적으로 `GET /teams/{teamId}/unread`를 호출하거나, 추후 Kafka consumer 연동으로 확장 가능.
+- **`lastReadMessageId`가 null인 채널**: 한 번도 읽지 않은 채널은 전체 메시지를 카운트.


### PR DESCRIPTION
## 개요

채널 읽음 상태 업데이트 및 미읽 카운트 조회 기능을 구현하였습니다. `ChannelMember` 스키마에 `lastReadMessageId` 필드를 추가하고, 채널 읽음 처리 API와 팀 전체 미읽 카운트 조회 API를 추가하였습니다.

## 본문

### 스키마 변경

- `ChannelMember` 스키마에 `lastReadMessageId` 필드를 추가하였습니다. 한 번도 읽지 않은 경우 `null`로 초기화됩니다.

### 신규 API

**채널 읽음 상태 업데이트**
- `POST /channels/:channelId/read` 엔드포인트를 추가하였습니다.
- 요청 바디의 `lastReadMessageId`를 기준으로 `ChannelMember.lastReadMessageId`를 갱신하고, 갱신 후 미읽 카운트를 계산하여 `user:{userId}` 소켓 룸으로 `channel:unread:updated` 이벤트를 emit합니다.
- 채널 멤버가 아닌 경우 `ForbiddenException`을 반환합니다.

**팀 미읽 카운트 조회**
- `GET /teams/:teamId/unread` 엔드포인트를 추가하였습니다.
- 해당 팀에서 가입한 채널별 미읽 카운트를 배열로 반환합니다.

### 자동 읽음 처리

- `ChatMessageConsumer`에서 메시지 저장 후 작성자의 `lastReadMessageId`를 자동으로 갱신하도록 처리하였습니다. 본인이 작성한 메시지는 항상 읽음 상태로 유지됩니다.

### 소켓 룸 등록

- `ChatGateway` 연결 시 `user:{userId}` 룸에 자동으로 join하도록 처리하였습니다. 이후 개인 소켓 이벤트(읽음 업데이트 등)를 해당 룸을 통해 전달합니다.

### 테스트

- `readChannel`, `getTeamUnread`, `countUnread`, `updateLastRead`, `findMembersByTeam` 에 대한 단위 테스트를 추가하였습니다.
- `TeamUnreadController` 테스트 파일을 추가하였습니다.
