### PR TITLE
[chat] 스레드 답글 조회를 위한 `parentMessageId` 쿼리 파라미터 추가

### DIFF
--- a/cowork-chat/src/chat/chat.controller.ts
+++ b/cowork-chat/src/chat/chat.controller.ts
@@ -235,7 +235,7 @@ export class ChatController {
         @Query() query: GetMessagesDto,
         @UserId() userId: number,
     ) {
-        return this.chatService.getMessages({ channelId, userId }, query.before);
+        return this.chatService.getMessages({ channelId, userId }, query.before, query.parentMessageId);
     }
 
     /**

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -298,9 +298,9 @@ export class ChatService {
      * @param before - 이 MongoDB ObjectId 이전의 메시지 조회 (없으면 최신부터)
      * @returns 최대 100개의 메시지 배열
      */
-    async getMessages(ctx: ChannelUserContext, before?: string) {
+    async getMessages(ctx: ChannelUserContext, before?: string, parentMessageId?: string) {
         await this.checkMembership(ctx.channelId, ctx.userId);
-        const rows = await this.messageRepository.findMessages(ctx.channelId, before);
+        const rows = await this.messageRepository.findMessages(ctx.channelId, before, parentMessageId);
         return rows.map(row => this.toMessageResponse(row, ctx.userId));
     }
 

--- a/cowork-chat/src/chat/dto/get-messages.dto.ts
+++ b/cowork-chat/src/chat/dto/get-messages.dto.ts
@@ -4,4 +4,7 @@ import { ApiPropertyOptional } from '@nestjs/swagger';
 export class GetMessagesDto {
     @ApiPropertyOptional({ description: '이 메시지 ID 이전 메시지 조회 (커서 페이지네이션)' })
     @IsMongoId() @IsOptional() before?: string;
+
+    @ApiPropertyOptional({ description: '스레드 답글 조회 - 지정한 부모 메시지의 답글만 반환' })
+    @IsMongoId() @IsOptional() parentMessageId?: string;
 }

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -126,40 +126,49 @@ export class MessageRepository {
      * @param before - 이 ObjectId 문자열보다 이전 메시지를 조회하는 커서. 생략 시 최신부터 조회
      * @returns {@link MessageRow} 배열 (최신순 정렬, 최대 100개)
      */
-    findMessages(channelId: number, before?: string): Promise<MessageRow[]> {
+    findMessages(channelId: number, before?: string, parentMessageId?: string): Promise<MessageRow[]> {
         const query: Record<string, unknown> = { channelId };
         if (before) {
             query['_id'] = { $lt: new Types.ObjectId(before) };
         }
+        if (parentMessageId) {
+            query['parentMessageId'] = new Types.ObjectId(parentMessageId);
+        }
+
+        const lookupStages = parentMessageId
+            ? [{ $addFields: { mentionedMessage: null } }]
+            : [
+                {
+                    $lookup: {
+                        from: this.messageModel.collection.name,
+                        localField: 'parentMessageId',
+                        foreignField: '_id',
+                        as: 'mentionedMessage',
+                        pipeline: [
+                            {
+                                $project: {
+                                    _id: 1,
+                                    authorId: 1,
+                                    content: 1,
+                                    type: 1,
+                                    createdAt: 1,
+                                },
+                            },
+                        ],
+                    },
+                },
+                {
+                    $addFields: {
+                        mentionedMessage: { $arrayElemAt: ['$mentionedMessage', 0] },
+                    },
+                },
+            ];
 
         return this.messageModel.aggregate([
             { $match: query },
             { $sort: { _id: -1 } },
             { $limit: MESSAGE_FETCH_LIMIT },
-            {
-                $lookup: {
-                    from: this.messageModel.collection.name,
-                    localField: 'parentMessageId',
-                    foreignField: '_id',
-                    as: 'mentionedMessage',
-                    pipeline: [
-                        {
-                            $project: {
-                                _id: 1,
-                                authorId: 1,
-                                content: 1,
-                                type: 1,
-                                createdAt: 1,
-                            },
-                        },
-                    ],
-                },
-            },
-            {
-                $addFields: {
-                    mentionedMessage: { $arrayElemAt: ['$mentionedMessage', 0] },
-                },
-            },
+            ...lookupStages,
         ]);
     }
 

--- a/cowork-chat/src/chat/schema/message.schema.ts
+++ b/cowork-chat/src/chat/schema/message.schema.ts
@@ -174,6 +174,9 @@ MessageSchema.index({ authorId: 1 });
 /** 스레드 답글 조회 시 부모 메시지 기준으로 빠르게 필터링하기 위한 인덱스 */
 MessageSchema.index({ parentMessageId: 1 });
 
+/** 채널 내 스레드 답글 목록 조회를 위한 복합 인덱스 (`channelId`, `parentMessageId`, `_id` 내림차순) */
+MessageSchema.index({ channelId: 1, parentMessageId: 1, _id: -1 });
+
 /** 채널별 고정 메시지 목록 조회를 위한 복합 인덱스 */
 MessageSchema.index({ isPinned: 1, channelId: 1 });
 


### PR DESCRIPTION
## 개요

`GET /channels/{channelId}/messages` 엔드포인트에 `parentMessageId` 쿼리 파라미터를 추가하였습니다. 해당 파라미터를 전달하면 지정한 부모 메시지의 스레드 답글만 반환되며, 생략 시 기존 동작이 유지됩니다.

## 본문

### 배경

클라이언트가 스레드 뷰를 열 때 서버 측 필터링이 없어 전체 메시지를 수신한 뒤 클라이언트에서 `parentMessageId`로 필터링하는 임시 방식을 사용하고 있었습니다.

### 변경 사항

**`GetMessagesDto`**
- `parentMessageId` 옵션 파라미터(`@IsMongoId`, `@IsOptional`) 추가

**`MessageRepository.findMessages()`**
- `parentMessageId` 인자를 받아 MongoDB `$match` 쿼리에 조건 추가
- 스레드 조회 시 클라이언트가 부모 메시지를 이미 보유하고 있으므로 `$lookup` 단계를 생략하고 `mentionedMessage: null`로 고정하여 불필요한 조인 비용을 제거

**`message.schema.ts`**
- `{ channelId: 1, parentMessageId: 1, _id: -1 }` 복합 인덱스 추가 — 채널 내 스레드 답글 커서 조회에 최적화

**`ChatService.getMessages()` / `ChatController.getMessages()`**
- `parentMessageId` 인자를 레이어 간 전달하도록 수정
