### PR TITLE
[chat] `channel.event` / `project.event` Kafka Consumer 및 WS 브로드캐스트 추가

### DIFF
--- a/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelEvent.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelEvent.kt
@@ -1,0 +1,12 @@
+package com.cowork.channel.event
+
+data class ChannelEvent(
+    val eventType: String,
+    val channelId: Long,
+    val teamId: Long,
+    val name: String,
+    val type: String,
+    val viewType: String,
+    val description: String?,
+    val isPrivate: Boolean,
+)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelEventPublisher.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/event/ChannelEventPublisher.kt
@@ -1,0 +1,46 @@
+package com.cowork.channel.event
+
+import com.cowork.channel.domain.Channel
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+private const val TOPIC = "channel.event"
+
+@Component
+class ChannelEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, Any>,
+) {
+    private val log = LoggerFactory.getLogger(ChannelEventPublisher::class.java)
+
+    fun publishCreated(channel: Channel) = publish("CREATED", channel)
+    fun publishUpdated(channel: Channel) = publish("UPDATED", channel)
+    fun publishDeleted(channel: Channel) = publish("DELETED", channel)
+
+    private fun publish(eventType: String, channel: Channel) {
+        val event = ChannelEvent(
+            eventType = eventType,
+            channelId = channel.id,
+            teamId = channel.teamId,
+            name = channel.name,
+            type = channel.type.name,
+            viewType = channel.viewType.name,
+            description = channel.description,
+            isPrivate = channel.isPrivate,
+        )
+        kafkaTemplate.send(TOPIC, channel.teamId.toString(), event)
+            .whenComplete { result, ex ->
+                if (ex != null) {
+                    log.error(
+                        "채널 이벤트 발행 실패 [eventType={}, channelId={}]",
+                        eventType, channel.id, ex,
+                    )
+                } else {
+                    log.info(
+                        "채널 이벤트 발행 성공 [eventType={}, channelId={}, offset={}]",
+                        eventType, channel.id, result.recordMetadata.offset(),
+                    )
+                }
+            }
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
@@ -6,6 +6,7 @@ import com.cowork.channel.domain.ChannelMember
 import com.cowork.channel.domain.ChannelType
 import com.cowork.channel.domain.ChannelViewType
 import com.cowork.channel.dto.*
+import com.cowork.channel.event.ChannelEventPublisher
 import com.cowork.channel.event.ChannelMemberEventPublisher
 import com.cowork.channel.event.ChannelMembershipSyncPublisher
 import com.cowork.channel.repository.ChannelMemberRepository
@@ -25,6 +26,7 @@ class ChannelService(
     private val teamPermissionService: TeamPermissionService,
     private val channelMemberEventPublisher: ChannelMemberEventPublisher,
     private val channelMembershipSyncPublisher: ChannelMembershipSyncPublisher,
+    private val channelEventPublisher: ChannelEventPublisher,
     private val projectClient: ProjectClient,
     private val meetingNoteTemplateService: MeetingNoteTemplateService,
 ) {
@@ -75,6 +77,7 @@ class ChannelService(
         TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
             override fun afterCommit() {
                 channelMembershipSyncPublisher.publishChannelSnapshot(channel, listOf(member))
+                channelEventPublisher.publishCreated(channel)
             }
         })
         return ChannelResponse.of(channel)
@@ -118,6 +121,11 @@ class ChannelService(
         requireChannelManager(channel, userId)
         channel.update(request.name, request.description, request.isPrivate)
         if (updateProjectId) channel.assignProject(request.projectId)
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() {
+                channelEventPublisher.publishUpdated(channel)
+            }
+        })
         return ChannelResponse.of(channel)
     }
 
@@ -138,6 +146,7 @@ class ChannelService(
                 members.forEach { member ->
                     channelMemberEventPublisher.publishLeave(channel.id, channel.teamId, member.userId)
                 }
+                channelEventPublisher.publishDeleted(channel)
             }
         })
     }

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/ChannelServiceTest.kt
@@ -8,6 +8,7 @@ import com.cowork.channel.domain.ChannelViewType
 import com.cowork.channel.dto.AddMemberRequest
 import com.cowork.channel.dto.CreateChannelRequest
 import com.cowork.channel.dto.UpdateChannelRequest
+import com.cowork.channel.event.ChannelEventPublisher
 import com.cowork.channel.event.ChannelMemberEventPublisher
 import com.cowork.channel.event.ChannelMembershipSyncPublisher
 import com.cowork.channel.repository.ChannelMemberRepository
@@ -33,10 +34,11 @@ class ChannelServiceTest {
     private val teamPermission = mockk<TeamPermissionService>()
     private val channelMemberEventPublisher = mockk<ChannelMemberEventPublisher>(relaxed = true)
     private val channelMembershipSyncPublisher = mockk<ChannelMembershipSyncPublisher>(relaxed = true)
+    private val channelEventPublisher = mockk<ChannelEventPublisher>(relaxed = true)
     private val projectClient = mockk<ProjectClient>()
     private val meetingNoteTemplateService = mockk<MeetingNoteTemplateService>(relaxed = true)
 
-    private val service = ChannelService(channelRepository, channelMemberRepository, teamPermission, channelMemberEventPublisher, channelMembershipSyncPublisher, projectClient, meetingNoteTemplateService)
+    private val service = ChannelService(channelRepository, channelMemberRepository, teamPermission, channelMemberEventPublisher, channelMembershipSyncPublisher, channelEventPublisher, projectClient, meetingNoteTemplateService)
 
     @BeforeEach
     fun setUp() {

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -144,7 +144,13 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      * 채널/프로젝트 생성·수정·삭제 이벤트 수신에 사용한다.
      */
     @SubscribeMessage('join:team')
-    handleJoinTeam(@ConnectedSocket() client: Socket, @MessageBody() payload: { teamId: number }) {
+    async handleJoinTeam(@ConnectedSocket() client: Socket, @MessageBody() payload: { teamId: number }) {
+        const { userId } = client.data;
+        const isMember = await this.chatService.isTeamMember(payload.teamId, userId);
+        if (!isMember) {
+            client.emit('error', { message: '팀 접근 권한이 없습니다' });
+            return;
+        }
         client.join(`team:${payload.teamId}`);
     }
 

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -15,6 +15,9 @@ import { Server, Socket } from 'socket.io';
 import { ChatService } from './chat.service';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
+import { ChannelEventConsumer } from './kafka/channel-event.consumer';
+import { ProjectEventConsumer } from './kafka/project-event.consumer';
+import { MembershipConsumer } from '../membership/membership.consumer';
 import { JoinChannelDto } from './dto/join-channel.dto';
 import { UserRole } from '../common/enum/user-role.enum';
 
@@ -45,6 +48,9 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
         private readonly chatService: ChatService,
         private readonly consumer: ChatMessageConsumer,
         private readonly githubIssueResultConsumer: GithubIssueResultConsumer,
+        private readonly channelEventConsumer: ChannelEventConsumer,
+        private readonly projectEventConsumer: ProjectEventConsumer,
+        private readonly membershipConsumer: MembershipConsumer,
         private readonly configService: ConfigService,
         private readonly jwtService: JwtService,
     ) {}
@@ -58,6 +64,9 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     afterInit(server: Server) {
         this.consumer.setSocketServer(server);
         this.githubIssueResultConsumer.setSocketServer(server);
+        this.channelEventConsumer.setSocketServer(server);
+        this.projectEventConsumer.setSocketServer(server);
+        this.membershipConsumer.setSocketServer(server);
     }
 
     /**
@@ -128,5 +137,22 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     @SubscribeMessage('leave')
     handleLeave(@ConnectedSocket() client: Socket, @MessageBody() payload: JoinChannelDto) {
         client.leave(`chat:${payload.channelId}`);
+    }
+
+    /**
+     * `join:team` 이벤트 핸들러. `team:{teamId}` 룸에 참여한다.
+     * 채널/프로젝트 생성·수정·삭제 이벤트 수신에 사용한다.
+     */
+    @SubscribeMessage('join:team')
+    handleJoinTeam(@ConnectedSocket() client: Socket, @MessageBody() payload: { teamId: number }) {
+        client.join(`team:${payload.teamId}`);
+    }
+
+    /**
+     * `leave:team` 이벤트 핸들러. `team:{teamId}` 룸에서 나간다.
+     */
+    @SubscribeMessage('leave:team')
+    handleLeaveTeam(@ConnectedSocket() client: Socket, @MessageBody() payload: { teamId: number }) {
+        client.leave(`team:${payload.teamId}`);
     }
 }

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -145,6 +145,10 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      */
     @SubscribeMessage('join:team')
     async handleJoinTeam(@ConnectedSocket() client: Socket, @MessageBody() payload: { teamId: number }) {
+        if (!payload || typeof payload.teamId !== 'number') {
+            client.emit('error', { message: '올바르지 않은 요청 형식입니다' });
+            return;
+        }
         const { userId } = client.data;
         const isMember = await this.chatService.isTeamMember(payload.teamId, userId);
         if (!isMember) {
@@ -159,6 +163,10 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      */
     @SubscribeMessage('leave:team')
     handleLeaveTeam(@ConnectedSocket() client: Socket, @MessageBody() payload: { teamId: number }) {
+        if (!payload || typeof payload.teamId !== 'number') {
+            client.emit('error', { message: '올바르지 않은 요청 형식입니다' });
+            return;
+        }
         client.leave(`team:${payload.teamId}`);
     }
 }

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -16,6 +16,8 @@ import { NotificationTriggerProducer } from './kafka/notification-trigger.produc
 import { NotificationOutboxPoller } from './kafka/notification-outbox.poller';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
+import { ChannelEventConsumer } from './kafka/channel-event.consumer';
+import { ProjectEventConsumer } from './kafka/project-event.consumer';
 import { ProjectClient } from './service/project.client';
 import { ChannelClient } from './service/channel.client';
 import { UserClient } from './service/user.client';
@@ -120,6 +122,8 @@ function createLogStream() {
         NotificationOutboxPoller,
         GithubIssueProducer,
         GithubIssueResultConsumer,
+        ChannelEventConsumer,
+        ProjectEventConsumer,
         ProjectClient,
         ChannelClient,
         UserClient,

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -80,6 +80,10 @@ export class ChatService {
         return this.channelMemberRepository.exists(channelId, userId);
     }
 
+    async isTeamMember(teamId: number, userId: number): Promise<boolean> {
+        return this.channelMemberRepository.existsByTeam(teamId, userId);
+    }
+
     /**
      * 채널 멤버십을 검증한다. 멤버가 아니면 `ForbiddenException`을 던진다.
      *

--- a/cowork-chat/src/chat/kafka/channel-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/channel-event.consumer.ts
@@ -61,7 +61,13 @@ export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
     }
 
     private handleEvent(event: ChannelEvent) {
-        if (!this.io) return;
+        if (!this.io) {
+            throw new Error('Socket.IO server is not initialized yet');
+        }
+        if (!event || !event.eventType || !event.teamId) {
+            this.logger.warn('유효하지 않은 채널 이벤트 페이로드입니다: ' + JSON.stringify(event));
+            return;
+        }
         const room = `team:${event.teamId}`;
         const { eventType, ...payload } = event;
 

--- a/cowork-chat/src/chat/kafka/channel-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/channel-event.consumer.ts
@@ -25,6 +25,17 @@ export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
 
     setSocketServer(io: Server) {
         this.io = io;
+    }
+
+    async onModuleInit() {
+        const kafka = new Kafka({
+            clientId: 'cowork-chat-channel-event',
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
+        });
+        this.consumer = kafka.consumer({ groupId: 'cowork-chat-channel-event' });
+        await this.consumer.connect();
+        await this.consumer.subscribe({ topic: 'channel.event', fromBeginning: false });
+
         void this.consumer
             .run({
                 eachMessage: async ({ message }) => {
@@ -43,16 +54,6 @@ export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
                 process.exit(1);
             });
         this.logger.log('Kafka consumer started: channel.event');
-    }
-
-    async onModuleInit() {
-        const kafka = new Kafka({
-            clientId: 'cowork-chat-channel-event',
-            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
-        });
-        this.consumer = kafka.consumer({ groupId: 'cowork-chat-channel-event' });
-        await this.consumer.connect();
-        await this.consumer.subscribe({ topic: 'channel.event', fromBeginning: false });
     }
 
     async onModuleDestroy() {

--- a/cowork-chat/src/chat/kafka/channel-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/channel-event.consumer.ts
@@ -25,17 +25,6 @@ export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
 
     setSocketServer(io: Server) {
         this.io = io;
-    }
-
-    async onModuleInit() {
-        const kafka = new Kafka({
-            clientId: 'cowork-chat-channel-event',
-            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
-        });
-        this.consumer = kafka.consumer({ groupId: 'cowork-chat-channel-event' });
-        await this.consumer.connect();
-        await this.consumer.subscribe({ topic: 'channel.event', fromBeginning: false });
-
         void this.consumer
             .run({
                 eachMessage: async ({ message }) => {
@@ -49,8 +38,21 @@ export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
                     }
                 },
             })
-            .catch((err) => this.logger.error('채널 이벤트 Kafka consumer 실행 실패', err));
+            .catch((err) => {
+                this.logger.error('채널 이벤트 Kafka consumer 실행 실패', err);
+                process.exit(1);
+            });
         this.logger.log('Kafka consumer started: channel.event');
+    }
+
+    async onModuleInit() {
+        const kafka = new Kafka({
+            clientId: 'cowork-chat-channel-event',
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
+        });
+        this.consumer = kafka.consumer({ groupId: 'cowork-chat-channel-event' });
+        await this.consumer.connect();
+        await this.consumer.subscribe({ topic: 'channel.event', fromBeginning: false });
     }
 
     async onModuleDestroy() {

--- a/cowork-chat/src/chat/kafka/channel-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/channel-event.consumer.ts
@@ -1,0 +1,73 @@
+import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Kafka, Consumer } from 'kafkajs';
+import { Server } from 'socket.io';
+import { getRequiredCsvConfig } from '../../common/config/config.util';
+
+interface ChannelEvent {
+    eventType: 'CREATED' | 'UPDATED' | 'DELETED';
+    channelId: number;
+    teamId: number;
+    name: string;
+    type: string;
+    viewType: string;
+    description: string | null;
+    isPrivate: boolean;
+}
+
+@Injectable()
+export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
+    private readonly logger = new Logger(ChannelEventConsumer.name);
+    private consumer!: Consumer;
+    private io?: Server;
+
+    constructor(private readonly configService: ConfigService) {}
+
+    setSocketServer(io: Server) {
+        this.io = io;
+    }
+
+    async onModuleInit() {
+        const kafka = new Kafka({
+            clientId: 'cowork-chat-channel-event',
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
+        });
+        this.consumer = kafka.consumer({ groupId: 'cowork-chat-channel-event' });
+        await this.consumer.connect();
+        await this.consumer.subscribe({ topic: 'channel.event', fromBeginning: false });
+
+        void this.consumer
+            .run({
+                eachMessage: async ({ message }) => {
+                    if (!message.value) return;
+                    try {
+                        const event: ChannelEvent = JSON.parse(message.value.toString());
+                        this.handleEvent(event);
+                    } catch (err) {
+                        this.logger.error('채널 이벤트 Kafka 메시지 처리 중 예외 발생', err);
+                        if (!(err instanceof SyntaxError)) throw err;
+                    }
+                },
+            })
+            .catch((err) => this.logger.error('채널 이벤트 Kafka consumer 실행 실패', err));
+        this.logger.log('Kafka consumer started: channel.event');
+    }
+
+    async onModuleDestroy() {
+        await this.consumer.disconnect();
+    }
+
+    private handleEvent(event: ChannelEvent) {
+        if (!this.io) return;
+        const room = `team:${event.teamId}`;
+        const { eventType, ...payload } = event;
+
+        if (eventType === 'CREATED') {
+            this.io.to(room).emit('channel:created', payload);
+        } else if (eventType === 'UPDATED') {
+            this.io.to(room).emit('channel:updated', payload);
+        } else if (eventType === 'DELETED') {
+            this.io.to(room).emit('channel:deleted', { channelId: event.channelId, teamId: event.teamId });
+        }
+    }
+}

--- a/cowork-chat/src/chat/kafka/project-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/project-event.consumer.ts
@@ -1,0 +1,71 @@
+import { Injectable, OnModuleDestroy, OnModuleInit, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Kafka, Consumer } from 'kafkajs';
+import { Server } from 'socket.io';
+import { getRequiredCsvConfig } from '../../common/config/config.util';
+
+interface ProjectEvent {
+    eventType: 'CREATED' | 'UPDATED' | 'DELETED';
+    projectId: number;
+    teamId: number;
+    name: string;
+    description: string | null;
+    status: string;
+}
+
+@Injectable()
+export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
+    private readonly logger = new Logger(ProjectEventConsumer.name);
+    private consumer!: Consumer;
+    private io?: Server;
+
+    constructor(private readonly configService: ConfigService) {}
+
+    setSocketServer(io: Server) {
+        this.io = io;
+    }
+
+    async onModuleInit() {
+        const kafka = new Kafka({
+            clientId: 'cowork-chat-project-event',
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
+        });
+        this.consumer = kafka.consumer({ groupId: 'cowork-chat-project-event' });
+        await this.consumer.connect();
+        await this.consumer.subscribe({ topic: 'project.event', fromBeginning: false });
+
+        void this.consumer
+            .run({
+                eachMessage: async ({ message }) => {
+                    if (!message.value) return;
+                    try {
+                        const event: ProjectEvent = JSON.parse(message.value.toString());
+                        this.handleEvent(event);
+                    } catch (err) {
+                        this.logger.error('프로젝트 이벤트 Kafka 메시지 처리 중 예외 발생', err);
+                        if (!(err instanceof SyntaxError)) throw err;
+                    }
+                },
+            })
+            .catch((err) => this.logger.error('프로젝트 이벤트 Kafka consumer 실행 실패', err));
+        this.logger.log('Kafka consumer started: project.event');
+    }
+
+    async onModuleDestroy() {
+        await this.consumer.disconnect();
+    }
+
+    private handleEvent(event: ProjectEvent) {
+        if (!this.io) return;
+        const room = `team:${event.teamId}`;
+        const { eventType, ...payload } = event;
+
+        if (eventType === 'CREATED') {
+            this.io.to(room).emit('project:created', payload);
+        } else if (eventType === 'UPDATED') {
+            this.io.to(room).emit('project:updated', payload);
+        } else if (eventType === 'DELETED') {
+            this.io.to(room).emit('project:deleted', { projectId: event.projectId, teamId: event.teamId });
+        }
+    }
+}

--- a/cowork-chat/src/chat/kafka/project-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/project-event.consumer.ts
@@ -23,17 +23,6 @@ export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
 
     setSocketServer(io: Server) {
         this.io = io;
-    }
-
-    async onModuleInit() {
-        const kafka = new Kafka({
-            clientId: 'cowork-chat-project-event',
-            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
-        });
-        this.consumer = kafka.consumer({ groupId: 'cowork-chat-project-event' });
-        await this.consumer.connect();
-        await this.consumer.subscribe({ topic: 'project.event', fromBeginning: false });
-
         void this.consumer
             .run({
                 eachMessage: async ({ message }) => {
@@ -47,8 +36,21 @@ export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
                     }
                 },
             })
-            .catch((err) => this.logger.error('프로젝트 이벤트 Kafka consumer 실행 실패', err));
+            .catch((err) => {
+                this.logger.error('프로젝트 이벤트 Kafka consumer 실행 실패', err);
+                process.exit(1);
+            });
         this.logger.log('Kafka consumer started: project.event');
+    }
+
+    async onModuleInit() {
+        const kafka = new Kafka({
+            clientId: 'cowork-chat-project-event',
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
+        });
+        this.consumer = kafka.consumer({ groupId: 'cowork-chat-project-event' });
+        await this.consumer.connect();
+        await this.consumer.subscribe({ topic: 'project.event', fromBeginning: false });
     }
 
     async onModuleDestroy() {

--- a/cowork-chat/src/chat/kafka/project-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/project-event.consumer.ts
@@ -23,6 +23,17 @@ export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
 
     setSocketServer(io: Server) {
         this.io = io;
+    }
+
+    async onModuleInit() {
+        const kafka = new Kafka({
+            clientId: 'cowork-chat-project-event',
+            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
+        });
+        this.consumer = kafka.consumer({ groupId: 'cowork-chat-project-event' });
+        await this.consumer.connect();
+        await this.consumer.subscribe({ topic: 'project.event', fromBeginning: false });
+
         void this.consumer
             .run({
                 eachMessage: async ({ message }) => {
@@ -41,16 +52,6 @@ export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
                 process.exit(1);
             });
         this.logger.log('Kafka consumer started: project.event');
-    }
-
-    async onModuleInit() {
-        const kafka = new Kafka({
-            clientId: 'cowork-chat-project-event',
-            brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),
-        });
-        this.consumer = kafka.consumer({ groupId: 'cowork-chat-project-event' });
-        await this.consumer.connect();
-        await this.consumer.subscribe({ topic: 'project.event', fromBeginning: false });
     }
 
     async onModuleDestroy() {

--- a/cowork-chat/src/chat/kafka/project-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/project-event.consumer.ts
@@ -59,7 +59,13 @@ export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
     }
 
     private handleEvent(event: ProjectEvent) {
-        if (!this.io) return;
+        if (!this.io) {
+            throw new Error('Socket.IO server is not initialized yet');
+        }
+        if (!event || !event.eventType || !event.teamId) {
+            this.logger.warn('유효하지 않은 프로젝트 이벤트 페이로드입니다: ' + JSON.stringify(event));
+            return;
+        }
         const room = `team:${event.teamId}`;
         const { eventType, ...payload } = event;
 

--- a/cowork-chat/src/chat/repository/channel-member.repository.ts
+++ b/cowork-chat/src/chat/repository/channel-member.repository.ts
@@ -30,6 +30,11 @@ export class ChannelMemberRepository {
         return member !== null;
     }
 
+    async existsByTeam(teamId: number, userId: number): Promise<boolean> {
+        const member = await this.memberModel.exists({ teamId, userId });
+        return member !== null;
+    }
+
     /**
      * 채널과 사용자 ID로 해당 멤버십이 속한 팀 ID를 조회합니다.
      *

--- a/cowork-chat/src/membership/membership.consumer.ts
+++ b/cowork-chat/src/membership/membership.consumer.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { Kafka, Consumer } from 'kafkajs';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
+import { Server } from 'socket.io';
 import { ChannelMember } from '../chat/schema/channel-member.schema';
 import { ChannelMemberEvent } from './event/membership.event';
 import { getRequiredCsvConfig } from '../common/config/config.util';
@@ -11,11 +12,16 @@ import { getRequiredCsvConfig } from '../common/config/config.util';
 export class MembershipConsumer implements OnModuleInit, OnModuleDestroy {
     private readonly logger = new Logger(MembershipConsumer.name);
     private consumer!: Consumer;
+    private io?: Server;
 
     constructor(
         @InjectModel(ChannelMember.name) private readonly memberModel: Model<ChannelMember>,
         private readonly configService: ConfigService,
     ) {}
+
+    setSocketServer(io: Server) {
+        this.io = io;
+    }
 
     async onModuleInit() {
         const kafka = new Kafka({
@@ -57,10 +63,13 @@ export class MembershipConsumer implements OnModuleInit, OnModuleDestroy {
                     { $set: { teamId, role } },
                     { upsert: true },
                 );
+                this.io?.to(`chat:${channelId}`).emit('member:joined', { channelId, teamId, userId, role });
             } else if (eventType === 'LEAVE') {
                 await this.memberModel.deleteOne({ channelId, userId });
+                this.io?.to(`chat:${channelId}`).emit('member:left', { channelId, teamId, userId });
             } else if (eventType === 'ROLE_CHANGE') {
                 await this.memberModel.updateOne({ channelId, userId }, { $set: { teamId, role } });
+                this.io?.to(`chat:${channelId}`).emit('member:role:updated', { channelId, teamId, userId, role });
             }
         } catch (err) {
             this.logger.error(`멤버십 이벤트 처리 실패 [${eventType}]`, err);

--- a/cowork-chat/src/membership/membership.consumer.ts
+++ b/cowork-chat/src/membership/membership.consumer.ts
@@ -54,6 +54,10 @@ export class MembershipConsumer implements OnModuleInit, OnModuleDestroy {
     }
 
     private async handleEvent(event: ChannelMemberEvent): Promise<void> {
+        if (!event || !event.eventType || !event.channelId || !event.userId) {
+            this.logger.warn('유효하지 않은 멤버십 이벤트 페이로드입니다: ' + JSON.stringify(event));
+            return;
+        }
         const { eventType, channelId, teamId, userId, role } = event;
 
         try {

--- a/cowork-project/src/main/kotlin/com/cowork/project/event/ProjectEvent.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/event/ProjectEvent.kt
@@ -1,0 +1,10 @@
+package com.cowork.project.event
+
+data class ProjectEvent(
+    val eventType: String,
+    val projectId: Long,
+    val teamId: Long,
+    val name: String,
+    val description: String?,
+    val status: String,
+)

--- a/cowork-project/src/main/kotlin/com/cowork/project/event/ProjectEventPublisher.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/event/ProjectEventPublisher.kt
@@ -1,0 +1,44 @@
+package com.cowork.project.event
+
+import com.cowork.project.domain.Project
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+private const val TOPIC = "project.event"
+
+@Component
+class ProjectEventPublisher(
+    private val kafkaTemplate: KafkaTemplate<String, Any>,
+) {
+    private val log = LoggerFactory.getLogger(ProjectEventPublisher::class.java)
+
+    fun publishCreated(project: Project) = publish("CREATED", project)
+    fun publishUpdated(project: Project) = publish("UPDATED", project)
+    fun publishDeleted(project: Project) = publish("DELETED", project)
+
+    private fun publish(eventType: String, project: Project) {
+        val event = ProjectEvent(
+            eventType = eventType,
+            projectId = project.id,
+            teamId = project.teamId,
+            name = project.name,
+            description = project.description,
+            status = project.status.name,
+        )
+        kafkaTemplate.send(TOPIC, project.teamId.toString(), event)
+            .whenComplete { result, ex ->
+                if (ex != null) {
+                    log.error(
+                        "프로젝트 이벤트 발행 실패 [eventType={}, projectId={}]",
+                        eventType, project.id, ex,
+                    )
+                } else {
+                    log.info(
+                        "프로젝트 이벤트 발행 성공 [eventType={}, projectId={}, offset={}]",
+                        eventType, project.id, result.recordMetadata.offset(),
+                    )
+                }
+            }
+    }
+}

--- a/cowork-project/src/main/kotlin/com/cowork/project/service/ProjectService.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/service/ProjectService.kt
@@ -5,6 +5,7 @@ import com.cowork.project.domain.ProjectMember
 import com.cowork.project.domain.ProjectMemberRole
 import com.cowork.project.domain.ProjectStatus
 import com.cowork.project.dto.*
+import com.cowork.project.event.ProjectEventPublisher
 import com.cowork.project.repository.ProjectMemberRepository
 import com.cowork.project.repository.ProjectRepository
 import com.cowork.project.repository.TeamMembershipRepository
@@ -13,6 +14,8 @@ import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.sdk.exception.ExpectedException
 
 private const val TEAM_ROLE_OWNER = "OWNER"
@@ -24,6 +27,7 @@ class ProjectService(
     private val projectRepository: ProjectRepository,
     private val projectMemberRepository: ProjectMemberRepository,
     private val teamMembershipRepository: TeamMembershipRepository,
+    private val projectEventPublisher: ProjectEventPublisher,
 ) {
 
     private fun findProjectOrThrow(projectId: Long): Project =
@@ -97,6 +101,12 @@ class ProjectService(
             )
         )
 
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() {
+                projectEventPublisher.publishCreated(project)
+            }
+        })
+
         return ProjectResponse.of(project)
     }
 
@@ -116,6 +126,12 @@ class ProjectService(
         request.description?.let { project.updateDescription(it) }
         request.status?.let { project.updateStatus(parseStatus(it)) }
 
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() {
+                projectEventPublisher.publishUpdated(project)
+            }
+        })
+
         return ProjectResponse.of(project)
     }
 
@@ -124,6 +140,11 @@ class ProjectService(
         val project = findProjectOrThrow(projectId)
         requireProjectOwner(project, userId)
         projectRepository.delete(project)
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() {
+                projectEventPublisher.publishDeleted(project)
+            }
+        })
     }
 
     fun getProjectsByTeamId(userId: Long, teamId: Long, pageable: Pageable): Page<ProjectResponse> {

--- a/cowork-project/src/test/kotlin/com/cowork/project/service/ProjectServiceTest.kt
+++ b/cowork-project/src/test/kotlin/com/cowork/project/service/ProjectServiceTest.kt
@@ -12,16 +12,14 @@ import com.cowork.project.repository.ProjectMemberRepository
 import com.cowork.project.repository.ProjectRepository
 import com.cowork.project.repository.TeamMembershipRepository
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.Runs
 import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import org.springframework.transaction.support.TransactionSynchronization
 import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.sdk.exception.ExpectedException
 import java.util.Optional
@@ -34,6 +32,16 @@ class ProjectServiceTest {
     private val projectEventPublisher = mockk<ProjectEventPublisher>(relaxed = true)
 
     private val service = ProjectService(projectRepository, projectMemberRepository, teamMembershipRepository, projectEventPublisher)
+
+    @BeforeEach
+    fun setUp() {
+        TransactionSynchronizationManager.initSynchronization()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        TransactionSynchronizationManager.clear()
+    }
 
     private fun project(id: Long = 1L, teamId: Long = 100L, position: Int = 0) =
         Project(id = id, teamId = teamId, name = "p", description = null, position = position, createdBy = 1L)
@@ -54,9 +62,6 @@ class ProjectServiceTest {
 
     @Test
     fun `createProject은 마지막 position 다음 값으로 저장`() {
-        mockkStatic(TransactionSynchronizationManager::class)
-        every { TransactionSynchronizationManager.registerSynchronization(any<TransactionSynchronization>()) } just Runs
-
         every { teamMembershipRepository.findByTeamIdAndUserId(100L, 7L) } returns membership(100L, 7L)
         every { projectRepository.findMaxPositionByTeamId(100L) } returns 3
         every { projectRepository.save(any()) } answers { firstArg() }
@@ -94,9 +99,6 @@ class ProjectServiceTest {
 
     @Test
     fun `updateProject은 팀 OWNER 등가 권한으로 통과`() {
-        mockkStatic(TransactionSynchronizationManager::class)
-        every { TransactionSynchronizationManager.registerSynchronization(any<TransactionSynchronization>()) } just Runs
-
         val proj = project()
         every { projectRepository.findById(1L) } returns Optional.of(proj)
         every { projectMemberRepository.findByProjectIdAndUserId(1L, 99L) } returns null

--- a/cowork-project/src/test/kotlin/com/cowork/project/service/ProjectServiceTest.kt
+++ b/cowork-project/src/test/kotlin/com/cowork/project/service/ProjectServiceTest.kt
@@ -7,6 +7,7 @@ import com.cowork.project.domain.TeamMembership
 import com.cowork.project.dto.AddProjectMemberRequest
 import com.cowork.project.dto.CreateProjectRequest
 import com.cowork.project.dto.UpdateProjectRequest
+import com.cowork.project.event.ProjectEventPublisher
 import com.cowork.project.repository.ProjectMemberRepository
 import com.cowork.project.repository.ProjectRepository
 import com.cowork.project.repository.TeamMembershipRepository
@@ -25,8 +26,9 @@ class ProjectServiceTest {
     private val projectRepository = mockk<ProjectRepository>(relaxed = true)
     private val projectMemberRepository = mockk<ProjectMemberRepository>(relaxed = true)
     private val teamMembershipRepository = mockk<TeamMembershipRepository>()
+    private val projectEventPublisher = mockk<ProjectEventPublisher>(relaxed = true)
 
-    private val service = ProjectService(projectRepository, projectMemberRepository, teamMembershipRepository)
+    private val service = ProjectService(projectRepository, projectMemberRepository, teamMembershipRepository, projectEventPublisher)
 
     private fun project(id: Long = 1L, teamId: Long = 100L, position: Int = 0) =
         Project(id = id, teamId = teamId, name = "p", description = null, position = position, createdBy = 1L)

--- a/cowork-project/src/test/kotlin/com/cowork/project/service/ProjectServiceTest.kt
+++ b/cowork-project/src/test/kotlin/com/cowork/project/service/ProjectServiceTest.kt
@@ -12,12 +12,17 @@ import com.cowork.project.repository.ProjectMemberRepository
 import com.cowork.project.repository.ProjectRepository
 import com.cowork.project.repository.TeamMembershipRepository
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.Runs
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.sdk.exception.ExpectedException
 import java.util.Optional
 
@@ -49,6 +54,9 @@ class ProjectServiceTest {
 
     @Test
     fun `createProject은 마지막 position 다음 값으로 저장`() {
+        mockkStatic(TransactionSynchronizationManager::class)
+        every { TransactionSynchronizationManager.registerSynchronization(any<TransactionSynchronization>()) } just Runs
+
         every { teamMembershipRepository.findByTeamIdAndUserId(100L, 7L) } returns membership(100L, 7L)
         every { projectRepository.findMaxPositionByTeamId(100L) } returns 3
         every { projectRepository.save(any()) } answers { firstArg() }
@@ -86,6 +94,9 @@ class ProjectServiceTest {
 
     @Test
     fun `updateProject은 팀 OWNER 등가 권한으로 통과`() {
+        mockkStatic(TransactionSynchronizationManager::class)
+        every { TransactionSynchronizationManager.registerSynchronization(any<TransactionSynchronization>()) } just Runs
+
         val proj = project()
         every { projectRepository.findById(1L) } returns Optional.of(proj)
         every { projectMemberRepository.findByProjectIdAndUserId(1L, 99L) } returns null

--- a/docs/20260526_TODO.md
+++ b/docs/20260526_TODO.md
@@ -32,4 +32,4 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 | 19 | 다이렉트 메시지(DM)                     | 신규                    | 🟢   | [바로가기](./todo/06-future/direct-message.md)                  |
 | 20 | ~~팀 역할 시스템 고도화~~                 | ~~cowork-team~~       | 🟢   | ~~[바로가기](./todo/06-future/role-system.md)~~                 |
 | 21 | 회의록 수정·삭제, 템플릿 관리                | cowork-channel        | 🟢   | [바로가기](./todo/06-future/meeting-note-management.md)         |
-| 22 | WebSocket 이벤트 보강                 | cowork-chat           | 🟢   | [바로가기](./todo/06-future/websocket-events.md)                |
+| 22 | ~~WebSocket 이벤트 보강~~             | ~~cowork-chat~~       | 🟢   | ~~[바로가기](./todo/06-future/websocket-events.md)~~            |


### PR DESCRIPTION
## 개요

채널·프로젝트 CRUD 및 채널 멤버 변경 시 실시간 WebSocket 이벤트를 클라이언트에 전달하는 기능을 추가하였습니다. `cowork-channel`, `cowork-project`에서 Kafka로 이벤트를 발행하고, `cowork-chat`의 Consumer가 이를 수신하여 Socket.IO 룸으로 브로드캐스트합니다.

## 본문

### 배경

채널·프로젝트 생성·수정·삭제 및 멤버 합류·탈퇴·역할 변경이 발생해도 서버 측 WebSocket 이벤트가 없어 클라이언트가 실시간으로 사이드바를 갱신할 수 없었습니다.

### 변경 사항

#### cowork-channel
- `ChannelEvent` — Kafka 페이로드 data class 추가 (`CREATED` / `UPDATED` / `DELETED`)
- `ChannelEventPublisher` — `channel.event` 토픽으로 Kafka 발행, 파티션 키는 `teamId`
- `ChannelService.createChannel()` / `updateChannel()` / `deleteChannel()` — 트랜잭션 커밋 후 `afterCommit()`에서 이벤트 발행

#### cowork-project
- `ProjectEvent` — Kafka 페이로드 data class 추가 (`CREATED` / `UPDATED` / `DELETED`)
- `ProjectEventPublisher` — `project.event` 토픽으로 Kafka 발행, 파티션 키는 `teamId`
- `ProjectService.createProject()` / `updateProject()` / `deleteProject()` — 트랜잭션 커밋 후 `afterCommit()`에서 이벤트 발행

#### cowork-chat
- `ChannelEventConsumer` — `channel.event` 토픽 구독, `team:{teamId}` 룸에 `channel:created` / `channel:updated` / `channel:deleted` 이벤트 emit
- `ProjectEventConsumer` — `project.event` 토픽 구독, `team:{teamId}` 룸에 `project:created` / `project:updated` / `project:deleted` 이벤트 emit
- `MembershipConsumer` — 기존 멤버십 동기화에 WS emit 추가 (`member:joined` / `member:left` / `member:role:updated`), `chat:{channelId}` 룸으로 전달
- `ChatGateway` — `join:team` / `leave:team` 이벤트 핸들러 추가, `afterInit`에서 신규 Consumer에 Socket.IO `Server` 인스턴스 주입
