### PR TITLE
[global] 스레드 메시지 parentMessageId 필터 TODO 완료 처리

### DIFF
--- a/docs/20260526_TODO.md
+++ b/docs/20260526_TODO.md
@@ -21,7 +21,7 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 | 8  | ~~채널 메시지 고정 API~~                | ~~cowork-chat~~       | 🟠   | ~~[바로가기](./todo/02-management/message-pin.md)~~             |
 | 9  | ~~프로젝트 수정·삭제·보관 API~~            | ~~cowork-project~~    | 🟠   | ~~[바로가기](./todo/02-management/project-crud.md)~~            |
 | 10 | ~~메시지 Emoji 반응 API + WS 이벤트~~    | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/03-messaging/emoji-reaction.md)~~           |
-| 11 | 스레드 메시지 `parentMessageId` 필터     | cowork-chat           | 🟡   | [바로가기](./todo/03-messaging/thread-filter.md)                |
+| 11 | ~~스레드 메시지 `parentMessageId` 필터~~ | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/03-messaging/thread-filter.md)~~            |
 | 12 | ~~파일·이미지 첨부 API + 메시지 모델 확장~~    | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/03-messaging/file-attachment.md)~~          |
 | 13 | ~~@멘션 멤버 검색 API~~                | ~~cowork-user~~       | 🟡   | ~~[바로가기](./todo/03-messaging/mention.md)~~                  |
 | 14 | ~~읽음 상태 및 미읽 카운트~~               | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/04-notification/read-status.md)~~           |


### PR DESCRIPTION
## 개요

`docs/20260526_TODO.md`에서 11번 항목인 스레드 메시지 `parentMessageId` 필터 기능이 구현 완료되었으므로 완료 처리하였습니다.

## 본문

`cowork-chat` 서비스의 스레드 메시지 `parentMessageId` 필터 API가 구현 완료됨에 따라, `20260526_TODO.md` 체크리스트의 11번 항목을 취소선으로 표시하였습니다.
