### PR TITLE
[chat] `ChatGateway` JWT 인증 전환 및 `getMessages` 인자 변경 반영

### DIFF
--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -320,6 +320,7 @@ describe('ChatController', () => {
             expect(mockChatService.getMessages).toHaveBeenCalledWith(
                 { channelId: 1, userId: 42 },
                 undefined,
+                undefined,
             );
             expect(result).toEqual([]);
         });
@@ -330,6 +331,7 @@ describe('ChatController', () => {
             expect(mockChatService.getMessages).toHaveBeenCalledWith(
                 { channelId: 1, userId: 42 },
                 mockMessageId,
+                undefined,
             );
         });
 

--- a/cowork-chat/src/chat/chat.gateway.spec.ts
+++ b/cowork-chat/src/chat/chat.gateway.spec.ts
@@ -77,17 +77,27 @@ describe('ChatGateway', () => {
     });
 
     describe('handleConnection', () => {
-        it('유효한 JWT 토큰으로 연결 시 client.data에 userId가 저장된다', async () => {
+        it('유효한 JWT 토큰으로 연결 시 client.data에 userId가 저장되고 전용 룸에 join한다', async () => {
             const client = mockSocket('valid-token');
             await gateway.handleConnection(client as any);
             expect(client.data.userId).toBe(42);
             expect(client.data.userRole).toBe('ROLE_USER');
+            expect(client.join).toHaveBeenCalledWith('user:42');
             expect(client.disconnect).not.toHaveBeenCalled();
         });
 
-        it('토큰 없이 연결하면 disconnect된다', async () => {
+        it('토큰 없이 연결하면 exception 이벤트를 emit하고 disconnect된다', async () => {
             const client = mockSocket(undefined);
             await gateway.handleConnection(client as any);
+            expect(client.emit).toHaveBeenCalledWith('exception', { message: '인증 실패: 토큰이 전달되지 않았습니다' });
+            expect(client.disconnect).toHaveBeenCalled();
+        });
+
+        it('유효하지 않은 토큰으로 연결하면 exception 이벤트를 emit하고 disconnect된다', async () => {
+            mockJwtService.verifyAsync.mockRejectedValue(new Error('Invalid token'));
+            const client = mockSocket('invalid-token');
+            await gateway.handleConnection(client as any);
+            expect(client.emit).toHaveBeenCalledWith('exception', { message: '인증 실패: Invalid token' });
             expect(client.disconnect).toHaveBeenCalled();
         });
     });

--- a/cowork-chat/src/chat/chat.gateway.spec.ts
+++ b/cowork-chat/src/chat/chat.gateway.spec.ts
@@ -1,17 +1,25 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
 import { ChatGateway } from './chat.gateway';
 import { ChatService } from './chat.service';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
+import { ChannelEventConsumer } from './kafka/channel-event.consumer';
+import { ProjectEventConsumer } from './kafka/project-event.consumer';
+import { MembershipConsumer } from '../membership/membership.consumer';
 
 const mockConfigService = {
     get: jest.fn().mockReturnValue(''),
 };
 
-const mockSocket = (headers: Record<string, string> = { 'x-user-id': '42', 'x-user-role': 'ROLE_USER' }) => ({
+const mockJwtService = {
+    verifyAsync: jest.fn(),
+};
+
+const mockSocket = (authToken?: string) => ({
     id: 'socket-1',
-    handshake: { headers },
+    handshake: { auth: { token: authToken } },
     data: {} as Record<string, unknown>,
     join: jest.fn(),
     leave: jest.fn(),
@@ -21,6 +29,7 @@ const mockSocket = (headers: Record<string, string> = { 'x-user-id': '42', 'x-us
 
 const mockChatService = {
     isMember: jest.fn(),
+    isTeamMember: jest.fn(),
 };
 
 const mockConsumer = {
@@ -31,35 +40,53 @@ const mockGithubIssueResultConsumer = {
     setSocketServer: jest.fn(),
 };
 
+const mockChannelEventConsumer = {
+    setSocketServer: jest.fn(),
+};
+
+const mockProjectEventConsumer = {
+    setSocketServer: jest.fn(),
+};
+
+const mockMembershipConsumer = {
+    setSocketServer: jest.fn(),
+};
+
 describe('ChatGateway', () => {
     let gateway: ChatGateway;
 
     beforeEach(async () => {
+        jest.clearAllMocks();
+        mockJwtService.verifyAsync.mockResolvedValue({ sub: '42', role: 'ROLE_USER' });
+
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 ChatGateway,
                 { provide: ChatService, useValue: mockChatService },
                 { provide: ChatMessageConsumer, useValue: mockConsumer },
                 { provide: GithubIssueResultConsumer, useValue: mockGithubIssueResultConsumer },
+                { provide: ChannelEventConsumer, useValue: mockChannelEventConsumer },
+                { provide: ProjectEventConsumer, useValue: mockProjectEventConsumer },
+                { provide: MembershipConsumer, useValue: mockMembershipConsumer },
                 { provide: ConfigService, useValue: mockConfigService },
+                { provide: JwtService, useValue: mockJwtService },
             ],
         }).compile();
 
         gateway = module.get<ChatGateway>(ChatGateway);
-        jest.clearAllMocks();
     });
 
     describe('handleConnection', () => {
-        it('유효한 x-user-id 헤더로 연결 시 client.data에 userId가 저장된다', async () => {
-            const client = mockSocket();
+        it('유효한 JWT 토큰으로 연결 시 client.data에 userId가 저장된다', async () => {
+            const client = mockSocket('valid-token');
             await gateway.handleConnection(client as any);
             expect(client.data.userId).toBe(42);
             expect(client.data.userRole).toBe('ROLE_USER');
             expect(client.disconnect).not.toHaveBeenCalled();
         });
 
-        it('x-user-id 헤더 없이 연결하면 disconnect된다', async () => {
-            const client = mockSocket({});
+        it('토큰 없이 연결하면 disconnect된다', async () => {
+            const client = mockSocket(undefined);
             await gateway.handleConnection(client as any);
             expect(client.disconnect).toHaveBeenCalled();
         });
@@ -68,7 +95,7 @@ describe('ChatGateway', () => {
     describe('handleJoin', () => {
         it('채널 멤버이면 room에 참가한다', async () => {
             mockChatService.isMember.mockResolvedValue(true);
-            const client = mockSocket();
+            const client = mockSocket('valid-token');
             client.data.userId = 42;
 
             await gateway.handleJoin(client as any, { channelId: 1 });
@@ -79,7 +106,7 @@ describe('ChatGateway', () => {
 
         it('채널 멤버가 아니면 error 이벤트를 emit하고 join하지 않는다', async () => {
             mockChatService.isMember.mockResolvedValue(false);
-            const client = mockSocket();
+            const client = mockSocket('valid-token');
             client.data.userId = 42;
 
             await gateway.handleJoin(client as any, { channelId: 1 });
@@ -91,7 +118,7 @@ describe('ChatGateway', () => {
 
     describe('handleLeave', () => {
         it('채널 room에서 퇴장한다', () => {
-            const client = mockSocket();
+            const client = mockSocket('valid-token');
             gateway.handleLeave(client as any, { channelId: 1 });
             expect(client.leave).toHaveBeenCalledWith('chat:1');
         });

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -147,7 +147,7 @@ describe('ChatService', () => {
 
             await service.getMessages({ channelId: 1, userId: 42 });
 
-            expect(mockMessageRepository.findMessages).toHaveBeenCalledWith(1, undefined);
+            expect(mockMessageRepository.findMessages).toHaveBeenCalledWith(1, undefined, undefined);
         });
 
         it('before cursor를 레포지토리에 전달한다', async () => {
@@ -156,7 +156,7 @@ describe('ChatService', () => {
 
             await service.getMessages({ channelId: 1, userId: 42 }, mockMessageId);
 
-            expect(mockMessageRepository.findMessages).toHaveBeenCalledWith(1, mockMessageId);
+            expect(mockMessageRepository.findMessages).toHaveBeenCalledWith(1, mockMessageId, undefined);
         });
 
         it('레포지토리 조회 결과를 그대로 반환한다', async () => {

--- a/cowork-chat/src/chat/kafka/github-issue.producer.spec.ts
+++ b/cowork-chat/src/chat/kafka/github-issue.producer.spec.ts
@@ -21,6 +21,7 @@ describe('GithubIssueProducer', () => {
 
     beforeEach(async () => {
         jest.clearAllMocks();
+        mockConnect.mockResolvedValue(undefined);
         const configService = {
             get: jest.fn().mockReturnValue('localhost:9092'),
         } as unknown as ConfigService;

--- a/cowork-chat/src/chat/project-message.controller.spec.ts
+++ b/cowork-chat/src/chat/project-message.controller.spec.ts
@@ -46,7 +46,7 @@ describe('ProjectMessageController', () => {
 
             const result = await controller.searchMessages(5, query, userId);
 
-            expect(mockChatService.searchProjectMessages).toHaveBeenCalledWith(5, query, 42);
+            expect(mockChatService.searchProjectMessages).toHaveBeenCalledWith(5, query, { userId: 42 });
             expect(result).toEqual(expected);
         });
 

--- a/cowork-chat/src/search/elasticsearch.service.spec.ts
+++ b/cowork-chat/src/search/elasticsearch.service.spec.ts
@@ -75,7 +75,7 @@ describe('ElasticsearchService', () => {
             });
         });
 
-        it('ES 오류가 발생하면 예외를 전파한다', async () => {
+        it('ES 오류가 발생하면 예외를 삼키고 정상 종료한다', async () => {
             mockClient.index.mockRejectedValue(new Error('ES connection error'));
 
             await expect(service.indexMessage({
@@ -89,7 +89,7 @@ describe('ElasticsearchService', () => {
                 hasAttachments: false,
                 isPinned: false,
                 createdAt: '2026-05-11T10:00:00.000Z',
-            })).rejects.toThrow('ES connection error');
+            })).resolves.toBeUndefined();
         });
     });
 
@@ -146,6 +146,7 @@ describe('ElasticsearchService', () => {
                 ...overrides,
             },
             highlight: { content: ['<em>안녕</em>하세요'] },
+            sort: ['2026-05-11T10:00:00.000Z', messageId],
         });
 
         const baseParams = {
@@ -180,22 +181,25 @@ describe('ElasticsearchService', () => {
             expect(nextCursor).toBeNull();
         });
 
-        it('결과가 limit과 같으면 마지막 messageId를 nextCursor로 반환한다', async () => {
+        it('결과가 limit과 같으면 마지막 sort 값을 base64 인코딩한 nextCursor를 반환한다', async () => {
             const hits = Array.from({ length: 50 }, (_, i) => makeHit(`msg-${i}`));
             mockClient.search.mockResolvedValue({ hits: { hits } });
 
             const { nextCursor } = await service.searchMessages({ ...baseParams, limit: 50 });
 
-            expect(nextCursor).toBe('msg-49');
+            const lastSort = ['2026-05-11T10:00:00.000Z', 'msg-49'];
+            expect(nextCursor).toBe(Buffer.from(JSON.stringify(lastSort)).toString('base64'));
         });
 
         it('before가 있으면 search_after에 포함된다', async () => {
             mockClient.search.mockResolvedValue({ hits: { hits: [] } });
+            const sortValues = ['cursor-id'];
+            const before = Buffer.from(JSON.stringify(sortValues)).toString('base64');
 
-            await service.searchMessages({ ...baseParams, before: 'cursor-id' });
+            await service.searchMessages({ ...baseParams, before });
 
             const body = mockClient.search.mock.calls[0][0].body;
-            expect(body.search_after).toEqual(['cursor-id']);
+            expect(body.search_after).toEqual(sortValues);
         });
 
         it('before가 없으면 search_after가 포함되지 않는다', async () => {


### PR DESCRIPTION
## 개요

`cowork-chat` 모듈의 서비스 코드 변경 이후 동기화되지 않은 테스트 6개 파일, 17개 케이스를 수정하였습니다. 모든 테스트가 정상 통과되었습니다.

## 본문

### `chat.gateway.spec.ts`

`ChatGateway` 생성자에 추가된 `ChannelEventConsumer`, `ProjectEventConsumer`, `MembershipConsumer`, `JwtService` 의존성에 대한 mock이 누락되어 모듈 생성 자체가 실패하였습니다.

- 누락된 mock 프로바이더 5종 추가
- `handleConnection` 인증 방식이 HTTP 헤더 기반 → JWT `auth.token` 기반으로 변경됨에 따라 `mockSocket` 구조를 `handshake.auth.token` 형태로 수정
- `mockJwtService.verifyAsync` 기본 반환값 설정 추가
- `mockChatService`에 `isTeamMember` mock 메서드 추가

### `chat.service.spec.ts` / `chat.controller.spec.ts`

`getMessages` 및 `findMessages` 메서드에 `parentMessageId` 세 번째 인자가 추가됨에 따라 `toHaveBeenCalledWith` 검증 호출에 `undefined` 인자를 추가하였습니다.

### `project-message.controller.spec.ts`

`searchProjectMessages` 세 번째 인자 타입이 `number` → `UserContext` 객체로 변경됨에 따라 기대값을 `42` → `{ userId: 42 }` 로 수정하였습니다.

### `github-issue.producer.spec.ts`

`mockConnect`가 `undefined`을 반환하여 `ensureConnected` 내부의 `.then()` 호출에서 `TypeError`가 발생하였습니다. `mockConnect.mockResolvedValue(undefined)`를 추가하여 해결하였습니다.

### `elasticsearch.service.spec.ts`

세 가지 동작 변경을 반영하였습니다.

- `indexMessage`가 ES 오류를 내부에서 삼키도록 변경됨에 따라 `rejects.toThrow` → `resolves.toBeUndefined`로 수정
- `nextCursor`가 `messageId` 직접 반환 → `lastHit.sort` 배열 기반 base64 JSON 인코딩으로 변경됨에 따라 `makeHit`에 `sort` 필드를 추가하고 기대값을 인코딩된 형태로 수정
- `before` 커서가 base64 인코딩된 JSON 배열임을 반영하여 테스트 입력값을 `Buffer.from(JSON.stringify(...)).toString('base64')` 형태로 수정
