### PR TITLE
[team] 초대 코드 기반 팀 가입 API 추가

### DIFF
--- a/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamInviteController.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamInviteController.kt
@@ -1,0 +1,80 @@
+package com.cowork.team.controller
+
+import com.cowork.team.dto.CreateInviteRequest
+import com.cowork.team.dto.InviteResponse
+import com.cowork.team.dto.JoinTeamResponse
+import com.cowork.team.service.TeamInviteService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@Tag(name = "팀 초대", description = "팀 초대 링크 생성·조회·삭제 및 코드로 팀 가입 API")
+@RestController
+@RequestMapping("/teams")
+class TeamInviteController(
+    private val teamInviteService: TeamInviteService,
+) {
+
+    @Operation(summary = "초대 링크 생성", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "생성 성공"),
+        ApiResponse(responseCode = "403", description = "팀 멤버 아님"),
+        ApiResponse(responseCode = "404", description = "팀 없음"),
+    )
+    @PostMapping("/{teamId}/invites")
+    fun createInvite(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable teamId: Long,
+        @RequestBody request: CreateInviteRequest,
+    ): ResponseEntity<InviteResponse> =
+        ResponseEntity.status(HttpStatus.CREATED)
+            .body(teamInviteService.createInvite(userId, teamId, request))
+
+    @Operation(summary = "초대 링크 목록 조회 (만료 포함)", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "403", description = "팀 멤버 아님"),
+    )
+    @GetMapping("/{teamId}/invites")
+    fun getInvites(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable teamId: Long,
+    ): ResponseEntity<List<InviteResponse>> =
+        ResponseEntity.ok(teamInviteService.getInvites(userId, teamId))
+
+    @Operation(summary = "초대 링크 무효화", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "삭제 성공"),
+        ApiResponse(responseCode = "403", description = "권한 없음"),
+        ApiResponse(responseCode = "404", description = "초대 링크 없음"),
+    )
+    @DeleteMapping("/{teamId}/invites/{inviteCode}")
+    fun deleteInvite(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable teamId: Long,
+        @PathVariable inviteCode: String,
+    ): ResponseEntity<Void> {
+        teamInviteService.deleteInvite(userId, teamId, inviteCode)
+        return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "초대 코드로 팀 가입", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "가입 성공"),
+        ApiResponse(responseCode = "404", description = "유효하지 않은 초대 코드"),
+        ApiResponse(responseCode = "409", description = "이미 팀 멤버"),
+        ApiResponse(responseCode = "410", description = "만료된 초대 링크"),
+    )
+    @PostMapping("/join/{inviteCode}")
+    fun joinTeam(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable inviteCode: String,
+    ): ResponseEntity<JoinTeamResponse> =
+        ResponseEntity.ok(teamInviteService.joinTeam(userId, inviteCode))
+}

--- a/cowork-team/src/main/kotlin/com/cowork/team/domain/TeamInvite.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/domain/TeamInvite.kt
@@ -1,0 +1,47 @@
+package com.cowork.team.domain
+
+import jakarta.persistence.*
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+@Table(name = "tb_team_invites")
+class TeamInvite(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id", nullable = false)
+    val team: Team,
+
+    @Column(name = "invite_code", nullable = false, length = 8, unique = true)
+    val inviteCode: String,
+
+    @Column(name = "created_by", nullable = false, updatable = false)
+    val createdBy: Long,
+
+    @Column(name = "duration", nullable = false, length = 10)
+    val duration: String,
+
+    @Column(name = "expires_at")
+    val expiresAt: LocalDateTime? = null,
+) {
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: LocalDateTime? = null
+
+    @Column(name = "deleted_at")
+    var deletedAt: LocalDateTime? = null
+
+    fun softDelete() {
+        deletedAt = LocalDateTime.now()
+    }
+
+    fun isExpired(): Boolean = expiresAt != null && expiresAt.isBefore(LocalDateTime.now())
+
+    fun isDeleted(): Boolean = deletedAt != null
+}

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/CreateInviteRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/CreateInviteRequest.kt
@@ -1,0 +1,22 @@
+package com.cowork.team.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDateTime
+
+enum class InviteDuration(val value: String) {
+    @JsonProperty("1d") ONE_DAY("1d"),
+    @JsonProperty("7d") SEVEN_DAYS("7d"),
+    @JsonProperty("30d") THIRTY_DAYS("30d"),
+    @JsonProperty("never") NEVER("never");
+
+    fun toExpiresAt(from: LocalDateTime): LocalDateTime? = when (this) {
+        ONE_DAY -> from.plusDays(1)
+        SEVEN_DAYS -> from.plusDays(7)
+        THIRTY_DAYS -> from.plusDays(30)
+        NEVER -> null
+    }
+}
+
+data class CreateInviteRequest(
+    val duration: InviteDuration,
+)

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/InviteResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/InviteResponse.kt
@@ -1,0 +1,34 @@
+package com.cowork.team.dto
+
+import com.cowork.team.domain.TeamInvite
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class InviteResponse(
+    @Schema(description = "초대 코드", example = "aB3xK9mZ")
+    val inviteCode: String,
+    @Schema(description = "팀 ID", example = "1")
+    val teamId: Long,
+    @Schema(description = "생성자 사용자 ID", example = "42")
+    val createdBy: Long,
+    @Schema(description = "유효 기간", example = "7d", allowableValues = ["1d", "7d", "30d", "never"])
+    val duration: String,
+    @Schema(description = "만료 일시 (never이면 null)")
+    val expiresAt: LocalDateTime?,
+    @Schema(description = "만료 또는 삭제 여부")
+    val expired: Boolean,
+    @Schema(description = "생성 일시")
+    val createdAt: LocalDateTime,
+) {
+    companion object {
+        fun of(invite: TeamInvite): InviteResponse = InviteResponse(
+            inviteCode = invite.inviteCode,
+            teamId = invite.team.id,
+            createdBy = invite.createdBy,
+            duration = invite.duration,
+            expiresAt = invite.expiresAt,
+            expired = invite.isDeleted() || invite.isExpired(),
+            createdAt = requireNotNull(invite.createdAt),
+        )
+    }
+}

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/JoinTeamResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/JoinTeamResponse.kt
@@ -1,0 +1,15 @@
+package com.cowork.team.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class JoinTeamResponse(
+    @Schema(description = "팀 ID", example = "1")
+    val teamId: Long,
+    @Schema(description = "가입한 사용자 ID", example = "99")
+    val userId: Long,
+    @Schema(description = "부여된 역할", example = "MEMBER")
+    val role: String,
+    @Schema(description = "가입 일시")
+    val joinedAt: LocalDateTime,
+)

--- a/cowork-team/src/main/kotlin/com/cowork/team/event/TeamEventPublisher.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/event/TeamEventPublisher.kt
@@ -28,6 +28,18 @@ class TeamEventPublisher(
         )
     }
 
+    fun publishMemberJoined(teamId: Long, teamName: String, userId: Long) {
+        publishLifecycle(
+            TeamEventPayload(
+                eventType = "MEMBER_JOINED",
+                teamId = teamId,
+                teamName = teamName,
+                actorUserId = userId,
+                targetUserIds = listOf(userId),
+            )
+        )
+    }
+
     fun publishRoleChanged(
         teamId: Long,
         teamName: String,

--- a/cowork-team/src/main/kotlin/com/cowork/team/repository/TeamInviteRepository.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/repository/TeamInviteRepository.kt
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query
 
 interface TeamInviteRepository : JpaRepository<TeamInvite, Long> {
 
+    @Query("SELECT ti FROM TeamInvite ti JOIN FETCH ti.team WHERE ti.team.id = :teamId")
     fun findAllByTeamId(teamId: Long): List<TeamInvite>
 
     fun findByTeamIdAndInviteCode(teamId: Long, inviteCode: String): TeamInvite?

--- a/cowork-team/src/main/kotlin/com/cowork/team/repository/TeamInviteRepository.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/repository/TeamInviteRepository.kt
@@ -1,0 +1,17 @@
+package com.cowork.team.repository
+
+import com.cowork.team.domain.TeamInvite
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+
+interface TeamInviteRepository : JpaRepository<TeamInvite, Long> {
+
+    fun findAllByTeamId(teamId: Long): List<TeamInvite>
+
+    fun findByTeamIdAndInviteCode(teamId: Long, inviteCode: String): TeamInvite?
+
+    @Query("SELECT ti FROM TeamInvite ti JOIN FETCH ti.team WHERE ti.inviteCode = :inviteCode AND ti.deletedAt IS NULL")
+    fun findActiveByInviteCode(inviteCode: String): TeamInvite?
+
+    fun existsByInviteCode(inviteCode: String): Boolean
+}

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamInviteService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamInviteService.kt
@@ -1,0 +1,122 @@
+package com.cowork.team.service
+
+import com.cowork.team.domain.TeamInvite
+import com.cowork.team.domain.TeamMember
+import com.cowork.team.domain.TeamRole
+import com.cowork.team.dto.CreateInviteRequest
+import com.cowork.team.dto.InviteResponse
+import com.cowork.team.dto.JoinTeamResponse
+import com.cowork.team.dto.TeamEventPayload
+import com.cowork.team.event.TeamEventPublisher
+import com.cowork.team.repository.TeamInviteRepository
+import com.cowork.team.repository.TeamMemberRepository
+import com.cowork.team.repository.TeamRepository
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import team.themoment.sdk.exception.ExpectedException
+import java.security.SecureRandom
+import java.time.LocalDateTime
+
+@Service
+@Transactional(readOnly = true)
+class TeamInviteService(
+    private val teamRepository: TeamRepository,
+    private val teamMemberRepository: TeamMemberRepository,
+    private val teamInviteRepository: TeamInviteRepository,
+    private val teamEventPublisher: TeamEventPublisher,
+) {
+    companion object {
+        private const val CODE_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        private const val CODE_LENGTH = 8
+        private val random = SecureRandom()
+    }
+
+    private fun findTeamOrThrow(teamId: Long) =
+        teamRepository.findById(teamId).orElseThrow {
+            ExpectedException("팀을 찾을 수 없습니다. id=$teamId", HttpStatus.NOT_FOUND)
+        }
+
+    private fun requireMember(teamId: Long, userId: Long) =
+        teamMemberRepository.findByTeamIdAndUserId(teamId, userId)
+            ?: throw ExpectedException("팀 멤버가 아닙니다.", HttpStatus.FORBIDDEN)
+
+    private fun generateUniqueCode(): String {
+        repeat(10) {
+            val code = (1..CODE_LENGTH).map { CODE_CHARS[random.nextInt(CODE_CHARS.length)] }.joinToString("")
+            if (!teamInviteRepository.existsByInviteCode(code)) return code
+        }
+        throw ExpectedException("초대 코드 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+    }
+
+    @Transactional
+    fun createInvite(userId: Long, teamId: Long, request: CreateInviteRequest): InviteResponse {
+        requireMember(teamId, userId)
+        val team = findTeamOrThrow(teamId)
+        val expiresAt = request.duration.toExpiresAt(LocalDateTime.now())
+        val invite = TeamInvite(
+            team = team,
+            inviteCode = generateUniqueCode(),
+            createdBy = userId,
+            duration = request.duration.value,
+            expiresAt = expiresAt,
+        )
+        return InviteResponse.of(teamInviteRepository.save(invite))
+    }
+
+    fun getInvites(userId: Long, teamId: Long): List<InviteResponse> {
+        requireMember(teamId, userId)
+        return teamInviteRepository.findAllByTeamId(teamId).map { InviteResponse.of(it) }
+    }
+
+    @Transactional
+    fun deleteInvite(userId: Long, teamId: Long, inviteCode: String) {
+        val actor = requireMember(teamId, userId)
+        val invite = teamInviteRepository.findByTeamIdAndInviteCode(teamId, inviteCode)
+            ?: throw ExpectedException("초대 링크를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+
+        val isOwnerOrAdmin = actor.role == TeamRole.OWNER || actor.role == TeamRole.ADMIN
+        if (invite.createdBy != userId && !isOwnerOrAdmin) {
+            throw ExpectedException("권한이 없습니다.", HttpStatus.FORBIDDEN)
+        }
+
+        invite.softDelete()
+    }
+
+    @Transactional
+    fun joinTeam(userId: Long, inviteCode: String): JoinTeamResponse {
+        val invite = teamInviteRepository.findActiveByInviteCode(inviteCode)
+            ?: throw ExpectedException("유효하지 않은 초대 코드입니다.", HttpStatus.NOT_FOUND)
+
+        if (invite.isExpired()) {
+            throw ExpectedException("만료된 초대 링크입니다.", HttpStatus.GONE)
+        }
+
+        val teamId = invite.team.id
+        if (teamMemberRepository.existsByTeamIdAndUserId(teamId, userId)) {
+            throw ExpectedException("이미 팀 멤버입니다.", HttpStatus.CONFLICT)
+        }
+
+        val member = teamMemberRepository.save(TeamMember(team = invite.team, userId = userId))
+
+        val payload = TeamEventPayload(
+            eventType = "MEMBER_JOINED",
+            teamId = teamId,
+            teamName = invite.team.name,
+            actorUserId = userId,
+            targetUserIds = listOf(userId),
+        )
+        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
+            override fun afterCommit() = teamEventPublisher.publishLifecycle(payload)
+        })
+
+        return JoinTeamResponse(
+            teamId = teamId,
+            userId = userId,
+            role = member.role.name,
+            joinedAt = requireNotNull(member.joinedAt),
+        )
+    }
+}

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamInviteService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamInviteService.kt
@@ -45,7 +45,7 @@ class TeamInviteService(
 
     private fun generateUniqueCode(): String {
         repeat(10) {
-            val code = (1..CODE_LENGTH).map { CODE_CHARS[random.nextInt(CODE_CHARS.length)] }.joinToString("")
+            val code = String(CharArray(CODE_LENGTH) { CODE_CHARS[random.nextInt(CODE_CHARS.length)] })
             if (!teamInviteRepository.existsByInviteCode(code)) return code
         }
         throw ExpectedException("초대 코드 생성에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
@@ -76,6 +76,10 @@ class TeamInviteService(
         val actor = requireMember(teamId, userId)
         val invite = teamInviteRepository.findByTeamIdAndInviteCode(teamId, inviteCode)
             ?: throw ExpectedException("초대 링크를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+
+        if (invite.isDeleted()) {
+            throw ExpectedException("초대 링크를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
+        }
 
         val isOwnerOrAdmin = actor.role == TeamRole.OWNER || actor.role == TeamRole.ADMIN
         if (invite.createdBy != userId && !isOwnerOrAdmin) {

--- a/cowork-team/src/main/resources/db/migration/V4__add_team_invites.sql
+++ b/cowork-team/src/main/resources/db/migration/V4__add_team_invites.sql
@@ -8,6 +8,5 @@ CREATE TABLE tb_team_invites
     expires_at  DATETIME(6) NULL,
     deleted_at  DATETIME(6) NULL,
     created_at  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    INDEX idx_tb_team_invites_team_id (team_id),
-    INDEX idx_tb_team_invites_invite_code (invite_code)
+    INDEX idx_tb_team_invites_team_id (team_id)
 );

--- a/cowork-team/src/main/resources/db/migration/V4__add_team_invites.sql
+++ b/cowork-team/src/main/resources/db/migration/V4__add_team_invites.sql
@@ -1,0 +1,13 @@
+CREATE TABLE tb_team_invites
+(
+    id          BIGINT      AUTO_INCREMENT PRIMARY KEY,
+    team_id     BIGINT      NOT NULL,
+    invite_code VARCHAR(8)  NOT NULL UNIQUE,
+    created_by  BIGINT      NOT NULL,
+    duration    VARCHAR(10) NOT NULL,
+    expires_at  DATETIME(6) NULL,
+    deleted_at  DATETIME(6) NULL,
+    created_at  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    INDEX idx_tb_team_invites_team_id (team_id),
+    INDEX idx_tb_team_invites_invite_code (invite_code)
+);

--- a/cowork-team/src/test/kotlin/com/cowork/team/service/TeamInviteServiceTest.kt
+++ b/cowork-team/src/test/kotlin/com/cowork/team/service/TeamInviteServiceTest.kt
@@ -1,0 +1,250 @@
+package com.cowork.team.service
+
+import com.cowork.team.domain.Team
+import com.cowork.team.domain.TeamInvite
+import com.cowork.team.domain.TeamMember
+import com.cowork.team.domain.TeamRole
+import com.cowork.team.dto.CreateInviteRequest
+import com.cowork.team.dto.InviteDuration
+import com.cowork.team.dto.TeamEventPayload
+import com.cowork.team.event.TeamEventPublisher
+import com.cowork.team.repository.TeamInviteRepository
+import com.cowork.team.repository.TeamMemberRepository
+import com.cowork.team.repository.TeamRepository
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import team.themoment.sdk.exception.ExpectedException
+import java.time.LocalDateTime
+import java.util.Optional
+
+class TeamInviteServiceTest {
+
+    private val teamRepository = mockk<TeamRepository>()
+    private val teamMemberRepository = mockk<TeamMemberRepository>()
+    private val teamInviteRepository = mockk<TeamInviteRepository>()
+    private val teamEventPublisher = mockk<TeamEventPublisher>(relaxed = true)
+
+    private val service = TeamInviteService(
+        teamRepository = teamRepository,
+        teamMemberRepository = teamMemberRepository,
+        teamInviteRepository = teamInviteRepository,
+        teamEventPublisher = teamEventPublisher,
+    )
+
+    private val team = Team(id = 1L, name = "테스트팀", description = null, iconUrl = null, ownerId = 10L)
+    private val ownerMember = TeamMember(team = team, userId = 10L, role = TeamRole.OWNER)
+    private val normalMember = TeamMember(team = team, userId = 42L, role = TeamRole.MEMBER)
+
+    @BeforeEach
+    fun setUp() {
+        TransactionSynchronizationManager.initSynchronization()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        TransactionSynchronizationManager.clear()
+    }
+
+    private fun fireAfterCommit() {
+        TransactionSynchronizationManager.getSynchronizations().forEach { it.afterCommit() }
+    }
+
+    private fun makeInvite(
+        inviteCode: String = "aB3xK9mZ",
+        createdBy: Long = 42L,
+        duration: String = "7d",
+        expiresAt: LocalDateTime? = LocalDateTime.now().plusDays(7),
+        deletedAt: LocalDateTime? = null,
+    ) = TeamInvite(
+        team = team,
+        inviteCode = inviteCode,
+        createdBy = createdBy,
+        duration = duration,
+        expiresAt = expiresAt,
+    ).also {
+        it.deletedAt = deletedAt
+        // createdAt은 JPA auditing이 채우지만 테스트에서는 직접 설정
+        val field = TeamInvite::class.java.getDeclaredField("createdAt").also { f -> f.isAccessible = true }
+        field.set(it, LocalDateTime.now())
+    }
+
+    // ──────────────────────────────────────────────
+    // createInvite
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `createInvite는 멤버가 7d 초대 링크를 생성하면 InviteResponse를 반환`() {
+        every { teamMemberRepository.findByTeamIdAndUserId(1L, 42L) } returns normalMember
+        every { teamRepository.findById(1L) } returns Optional.of(team)
+        every { teamInviteRepository.existsByInviteCode(any()) } returns false
+        val saved = makeInvite()
+        every { teamInviteRepository.save(any()) } returns saved
+
+        val result = service.createInvite(42L, 1L, CreateInviteRequest(InviteDuration.SEVEN_DAYS))
+
+        assertEquals("aB3xK9mZ", result.inviteCode)
+        assertEquals("7d", result.duration)
+        assertEquals(false, result.expired)
+    }
+
+    @Test
+    fun `createInvite는 팀 멤버가 아니면 403`() {
+        every { teamMemberRepository.findByTeamIdAndUserId(1L, 99L) } returns null
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.createInvite(99L, 1L, CreateInviteRequest(InviteDuration.SEVEN_DAYS))
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    // ──────────────────────────────────────────────
+    // getInvites
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `getInvites는 만료된 링크 포함 전체 목록을 반환`() {
+        every { teamMemberRepository.findByTeamIdAndUserId(1L, 42L) } returns normalMember
+        val active = makeInvite(inviteCode = "active01")
+        val expired = makeInvite(inviteCode = "expird01", expiresAt = LocalDateTime.now().minusDays(1))
+        every { teamInviteRepository.findAllByTeamId(1L) } returns listOf(active, expired)
+
+        val result = service.getInvites(42L, 1L)
+
+        assertEquals(2, result.size)
+        assertEquals(false, result.first { it.inviteCode == "active01" }.expired)
+        assertEquals(true, result.first { it.inviteCode == "expird01" }.expired)
+    }
+
+    @Test
+    fun `getInvites는 팀 멤버가 아니면 403`() {
+        every { teamMemberRepository.findByTeamIdAndUserId(1L, 99L) } returns null
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.getInvites(99L, 1L)
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    // ──────────────────────────────────────────────
+    // deleteInvite
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `deleteInvite는 생성자 본인이면 soft delete 성공`() {
+        every { teamMemberRepository.findByTeamIdAndUserId(1L, 42L) } returns normalMember
+        val invite = makeInvite(createdBy = 42L)
+        every { teamInviteRepository.findByTeamIdAndInviteCode(1L, "aB3xK9mZ") } returns invite
+
+        service.deleteInvite(42L, 1L, "aB3xK9mZ")
+
+        assertEquals(true, invite.isDeleted())
+    }
+
+    @Test
+    fun `deleteInvite는 OWNER가 타인 링크를 삭제할 수 있다`() {
+        every { teamMemberRepository.findByTeamIdAndUserId(1L, 10L) } returns ownerMember
+        val invite = makeInvite(createdBy = 42L)
+        every { teamInviteRepository.findByTeamIdAndInviteCode(1L, "aB3xK9mZ") } returns invite
+
+        service.deleteInvite(10L, 1L, "aB3xK9mZ")
+
+        assertEquals(true, invite.isDeleted())
+    }
+
+    @Test
+    fun `deleteInvite는 생성자도 OWNER_ADMIN도 아니면 403`() {
+        val otherMember = TeamMember(team = team, userId = 55L, role = TeamRole.MEMBER)
+        every { teamMemberRepository.findByTeamIdAndUserId(1L, 55L) } returns otherMember
+        val invite = makeInvite(createdBy = 42L)
+        every { teamInviteRepository.findByTeamIdAndInviteCode(1L, "aB3xK9mZ") } returns invite
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.deleteInvite(55L, 1L, "aB3xK9mZ")
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `deleteInvite는 존재하지 않는 코드면 404`() {
+        every { teamMemberRepository.findByTeamIdAndUserId(1L, 42L) } returns normalMember
+        every { teamInviteRepository.findByTeamIdAndInviteCode(1L, "notfound") } returns null
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.deleteInvite(42L, 1L, "notfound")
+        }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+
+    // ──────────────────────────────────────────────
+    // joinTeam
+    // ──────────────────────────────────────────────
+
+    @Test
+    fun `joinTeam은 유효한 코드로 가입 성공 시 MEMBER_JOINED 이벤트를 발행`() {
+        val invite = makeInvite(createdBy = 10L)
+        every { teamInviteRepository.findActiveByInviteCode("aB3xK9mZ") } returns invite
+        every { teamMemberRepository.existsByTeamIdAndUserId(1L, 99L) } returns false
+        val newMember = TeamMember(team = team, userId = 99L).also {
+            val f = TeamMember::class.java.getDeclaredField("joinedAt").also { f -> f.isAccessible = true }
+            f.set(it, LocalDateTime.now())
+        }
+        every { teamMemberRepository.save(any()) } returns newMember
+
+        val captured = slot<TeamEventPayload>()
+        every { teamEventPublisher.publishLifecycle(capture(captured)) } just Runs
+
+        val result = service.joinTeam(99L, "aB3xK9mZ")
+        fireAfterCommit()
+
+        assertEquals(1L, result.teamId)
+        assertEquals(99L, result.userId)
+        assertEquals("MEMBER", result.role)
+        verify(exactly = 1) { teamEventPublisher.publishLifecycle(any()) }
+        assertEquals("MEMBER_JOINED", captured.captured.eventType)
+        assertEquals(listOf(99L), captured.captured.targetUserIds)
+    }
+
+    @Test
+    fun `joinTeam은 만료된 코드면 410`() {
+        val expired = makeInvite(expiresAt = LocalDateTime.now().minusHours(1))
+        every { teamInviteRepository.findActiveByInviteCode("aB3xK9mZ") } returns expired
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.joinTeam(99L, "aB3xK9mZ")
+        }
+        assertEquals(HttpStatus.GONE, ex.statusCode)
+    }
+
+    @Test
+    fun `joinTeam은 이미 팀 멤버면 409`() {
+        val invite = makeInvite()
+        every { teamInviteRepository.findActiveByInviteCode("aB3xK9mZ") } returns invite
+        every { teamMemberRepository.existsByTeamIdAndUserId(1L, 42L) } returns true
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.joinTeam(42L, "aB3xK9mZ")
+        }
+        assertEquals(HttpStatus.CONFLICT, ex.statusCode)
+    }
+
+    @Test
+    fun `joinTeam은 존재하지 않거나 삭제된 코드면 404`() {
+        every { teamInviteRepository.findActiveByInviteCode("invalid") } returns null
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.joinTeam(99L, "invalid")
+        }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+}

--- a/docs/20260526_TODO.md
+++ b/docs/20260526_TODO.md
@@ -15,7 +15,7 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 | 2  | ~~Gateway 프로젝트 reorder 라우팅~~     | ~~cowork-gateway~~    | 🔴   | ~~[바로가기](./todo/01-urgent/gateway-reorder-routing.md)~~     |
 | 3  | ~~팀 정보 수정·삭제 API~~               | ~~cowork-team~~       | 🟠   | ~~[바로가기](./todo/02-management/team-crud.md)~~               |
 | 4  | ~~팀 멤버 관리 API (추방·역할변경·탈퇴)~~     | ~~cowork-team~~       | 🟠   | ~~[바로가기](./todo/02-management/team-members.md)~~            |
-| 5  | 팀 초대 링크 API                      | cowork-team           | 🟠   | [바로가기](./todo/02-management/team-invite.md)                 |
+| 5  | ~~팀 초대 링크 API~~                   | ~~cowork-team~~       | 🟠   | ~~[바로가기](./todo/02-management/team-invite.md)~~             |
 | 6  | ~~채널 수정·삭제 API~~                 | ~~cowork-channel~~    | 🟠   | ~~[바로가기](./todo/02-management/channel-crud.md)~~            |
 | 7  | ~~채널별 멤버 권한 (비공개 채널 초대)~~        | ~~cowork-channel~~    | 🟠   | ~~[바로가기](./todo/02-management/channel-permissions.md)~~     |
 | 8  | ~~채널 메시지 고정 API~~                | ~~cowork-chat~~       | 🟠   | ~~[바로가기](./todo/02-management/message-pin.md)~~             |

--- a/docs/plan-team-invite.md
+++ b/docs/plan-team-invite.md
@@ -1,0 +1,134 @@
+# 팀 초대 링크 API 구현 계획
+
+## 결정 사항
+
+| 항목 | 결정 |
+|------|------|
+| 초대 코드 형식 | 8자리 alphanumeric (SecureRandom + Base62) |
+| 만료 정책 | 서버 옵션: `1d` / `7d` / `30d` / `never` |
+| 팀당 활성 링크 수 | 무제한 |
+| 생성 권한 | 모든 팀 멤버 |
+| 가입 기본 역할 | `MEMBER` 고정 |
+| 중복 가입 | `409 Conflict` |
+| 가입 이벤트 | `MEMBER_JOINED` → `team.lifecycle` |
+| 삭제 권한 | 생성자 본인 또는 OWNER/ADMIN |
+| 목록 조회 범위 | 전체 (만료 포함) |
+| 목록 조회 권한 | 모든 팀 멤버 |
+
+---
+
+## API
+
+| 메서드 | 경로 | 권한 |
+|--------|------|------|
+| `POST` | `/teams/{teamId}/invites` | 팀 멤버 |
+| `GET` | `/teams/{teamId}/invites` | 팀 멤버 |
+| `DELETE` | `/teams/{teamId}/invites/{inviteCode}` | 생성자 본인 또는 OWNER/ADMIN |
+| `POST` | `/teams/join/{inviteCode}` | 인증된 사용자 (비멤버) |
+
+---
+
+## 요청 / 응답
+
+### POST /teams/{teamId}/invites → 201
+
+```json
+// Request
+{ "duration": "7d" }
+
+// Response
+{
+  "inviteCode": "aB3xK9mZ",
+  "teamId": 1,
+  "createdBy": 42,
+  "duration": "7d",
+  "expiresAt": "2026-06-13T00:00:00",  // never면 null
+  "createdAt": "2026-06-06T00:00:00"
+}
+```
+
+### GET /teams/{teamId}/invites → 200
+
+```json
+[
+  {
+    "inviteCode": "aB3xK9mZ",
+    "teamId": 1,
+    "createdBy": 42,
+    "duration": "7d",
+    "expiresAt": "2026-06-13T00:00:00",
+    "expired": false,
+    "createdAt": "2026-06-06T00:00:00"
+  }
+]
+```
+
+### DELETE /teams/{teamId}/invites/{inviteCode} → 204
+
+- 없는 코드 / 다른 팀 코드 → 404
+- 권한 없음 → 403
+
+### POST /teams/join/{inviteCode} → 200
+
+```json
+{ "teamId": 1, "userId": 99, "role": "MEMBER", "joinedAt": "..." }
+```
+
+- 없거나 삭제된 코드 → 404
+- 만료된 코드 → 410 Gone
+- 이미 멤버 → 409 Conflict
+
+---
+
+## DB: V4__add_team_invites.sql
+
+```sql
+CREATE TABLE tb_team_invites
+(
+    id          BIGINT      AUTO_INCREMENT PRIMARY KEY,
+    team_id     BIGINT      NOT NULL,
+    invite_code VARCHAR(8)  NOT NULL UNIQUE,
+    created_by  BIGINT      NOT NULL,
+    duration    VARCHAR(10) NOT NULL,        -- '1d' | '7d' | '30d' | 'never'
+    expires_at  DATETIME(6) NULL,            -- NULL = 영구
+    deleted_at  DATETIME(6) NULL,            -- NULL = 활성, NOT NULL = 수동 삭제
+    created_at  DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    INDEX idx_tb_team_invites_team_id (team_id),
+    INDEX idx_tb_team_invites_invite_code (invite_code)
+);
+```
+
+- 활성 링크 조건: `deleted_at IS NULL AND (expires_at IS NULL OR expires_at > NOW())`
+- soft delete → 목록 히스토리 유지 가능
+
+---
+
+## 구현 파일 목록
+
+```
+cowork-team/src/main/kotlin/com/cowork/team/
+├── domain/TeamInvite.kt
+├── repository/TeamInviteRepository.kt
+├── service/TeamInviteService.kt
+├── controller/TeamInviteController.kt
+└── dto/
+    ├── CreateInviteRequest.kt
+    ├── InviteResponse.kt
+    └── JoinTeamResponse.kt
+
+cowork-team/src/main/resources/db/migration/
+└── V4__add_team_invites.sql
+```
+
+---
+
+## 구현 순서
+
+1. `V4__add_team_invites.sql`
+2. `TeamInvite.kt` (Entity)
+3. `TeamInviteRepository.kt`
+4. DTO 3개
+5. `TeamInviteService.kt`
+6. `TeamInviteController.kt`
+7. `TeamEventPublisher.publishMemberJoined()` 추가
+8. `TeamInviteServiceTest.kt`


### PR DESCRIPTION
## 개요

`cowork-team` 서비스에 팀 초대 링크 API를 구현하였습니다. 팀 멤버라면 누구나 초대 링크를 생성할 수 있으며, 초대 코드를 통해 비멤버가 팀에 가입할 수 있습니다.

## 본문

### 신규 API

| 메서드 | 경로 | 설명 |
|--------|------|------|
| `POST` | `/teams/{teamId}/invites` | 초대 링크 생성 |
| `GET` | `/teams/{teamId}/invites` | 초대 링크 목록 조회 (만료 포함) |
| `DELETE` | `/teams/{teamId}/invites/{inviteCode}` | 초대 링크 무효화 |
| `POST` | `/teams/join/{inviteCode}` | 초대 코드로 팀 가입 |

### 주요 설계 결정

- **초대 코드**: `SecureRandom` + Base62로 생성한 8자리 alphanumeric 문자열
- **만료 정책**: 생성 시 `duration` 필드로 `1d` / `7d` / `30d` / `never` 선택
- **생성 권한**: 모든 팀 멤버 허용
- **삭제 권한**: 생성자 본인 또는 `OWNER` / `ADMIN`
- **Soft delete**: `deleted_at` 컬럼으로 처리하여 목록 조회 시 히스토리 유지
- **가입 역할**: 초대 코드 가입 시 항상 `MEMBER`로 고정
- **이벤트**: 가입 성공 시 `MEMBER_JOINED` 이벤트를 `team.lifecycle` 토픽으로 발행

### 변경 파일

- `V4__add_team_invites.sql` — `tb_team_invites` 테이블 생성
- `TeamInvite.kt` — Entity (`soft delete`, 만료 여부 판별 메서드 포함)
- `TeamInviteRepository.kt` — 활성 코드 조회 시 `JOIN FETCH` 적용
- `CreateInviteRequest.kt` — `InviteDuration` enum 포함
- `TeamInviteService.kt` — 비즈니스 로직 (코드 중복 체크 포함)
- `TeamInviteController.kt` — REST 컨트롤러
- `TeamEventPublisher.kt` — `publishMemberJoined()` 메서드 추가
- `TeamInviteServiceTest.kt` — 12개 단위 테스트 (전부 통과)
