### PR TITLE
[dm] 보안 취약점 수정 및 WebSocket 입력 방어 처리 추가

### DIFF
--- a/cowork-dm/src/gateway/dm.gateway.ts
+++ b/cowork-dm/src/gateway/dm.gateway.ts
@@ -66,10 +66,15 @@ export class DmGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @SubscribeMessage('join')
     async handleJoin(
         @ConnectedSocket() client: Socket,
-        @MessageBody() payload: { conversationId: string },
+        @MessageBody() payload?: { conversationId: string },
     ) {
+        const conversationId = payload?.conversationId ?? '';
+        if (!conversationId) {
+            client.emit('error', { message: '대화방 ID가 필요합니다' });
+            return;
+        }
         const { userId } = client.data;
-        const conversation = await this.conversationRepository.findById(payload.conversationId);
+        const conversation = await this.conversationRepository.findById(conversationId);
         if (!conversation) {
             client.emit('error', { message: '대화방을 찾을 수 없습니다' });
             return;
@@ -81,25 +86,32 @@ export class DmGateway implements OnGatewayConnection, OnGatewayDisconnect {
             return;
         }
 
-        client.join(`dm:${payload.conversationId}`);
-        this.logger.log(`userId=${userId} joined dm:${payload.conversationId}`);
+        client.join(`dm:${conversationId}`);
+        this.logger.log(`userId=${userId} joined dm:${conversationId}`);
     }
 
     @SubscribeMessage('leave')
     handleLeave(
         @ConnectedSocket() client: Socket,
-        @MessageBody() payload: { conversationId: string },
+        @MessageBody() payload?: { conversationId: string },
     ) {
-        client.leave(`dm:${payload.conversationId}`);
+        const conversationId = payload?.conversationId ?? '';
+        if (!conversationId) return;
+        client.leave(`dm:${conversationId}`);
     }
 
     @SubscribeMessage('typing:start')
     handleTypingStart(
         @ConnectedSocket() client: Socket,
-        @MessageBody() payload: { conversationId: string },
+        @MessageBody() payload?: { conversationId: string },
     ) {
-        client.to(`dm:${payload.conversationId}`).emit('typing', {
-            conversationId: payload.conversationId,
+        const conversationId = payload?.conversationId ?? '';
+        if (!conversationId) return;
+        const room = `dm:${conversationId}`;
+        if (!client.rooms.has(room)) return;
+
+        client.to(room).emit('typing', {
+            conversationId,
             userId: client.data.userId,
             isTyping: true,
         });
@@ -108,10 +120,15 @@ export class DmGateway implements OnGatewayConnection, OnGatewayDisconnect {
     @SubscribeMessage('typing:stop')
     handleTypingStop(
         @ConnectedSocket() client: Socket,
-        @MessageBody() payload: { conversationId: string },
+        @MessageBody() payload?: { conversationId: string },
     ) {
-        client.to(`dm:${payload.conversationId}`).emit('typing', {
-            conversationId: payload.conversationId,
+        const conversationId = payload?.conversationId ?? '';
+        if (!conversationId) return;
+        const room = `dm:${conversationId}`;
+        if (!client.rooms.has(room)) return;
+
+        client.to(room).emit('typing', {
+            conversationId,
             userId: client.data.userId,
             isTyping: false,
         });

--- a/cowork-dm/src/message/message.service.ts
+++ b/cowork-dm/src/message/message.service.ts
@@ -1,4 +1,5 @@
 import {
+    BadRequestException,
     ConflictException,
     ForbiddenException,
     forwardRef,
@@ -215,6 +216,8 @@ export class MessageService {
         emoji: string,
         action: 'ADD' | 'REMOVE',
     ): Promise<void> {
+        if (!Types.ObjectId.isValid(messageId)) throw new BadRequestException('유효하지 않은 메시지 ID입니다');
+
         const conversation = await this.conversationRepository.findById(conversationId);
         if (!conversation) throw new NotFoundException('대화방을 찾을 수 없습니다');
 
@@ -252,6 +255,8 @@ export class MessageService {
      * @throws ForbiddenException 사용자가 대화방 참여자가 아닌 경우
      */
     async markRead(conversationId: string, userId: number, messageId: string): Promise<void> {
+        if (!Types.ObjectId.isValid(messageId)) throw new BadRequestException('유효하지 않은 메시지 ID입니다');
+
         const conversation = await this.conversationRepository.findById(conversationId);
         if (!conversation) throw new NotFoundException('대화방을 찾을 수 없습니다');
 

--- a/cowork-dm/src/storage/storage.controller.ts
+++ b/cowork-dm/src/storage/storage.controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/swagger';
 import { IsNumber, IsPositive, IsString } from 'class-validator';
 import { MinioService } from './minio.service';
+import { ConversationService } from '../conversation/conversation.service';
 import { UserId } from '../common/decorator/user.decorator';
 
 class PresignedUploadRequestDto {
@@ -38,7 +39,10 @@ class PresignedUploadResponseDto {
 @ApiTags('storage')
 @Controller('conversations/:conversationId/upload')
 export class StorageController {
-    constructor(private readonly minioService: MinioService) {}
+    constructor(
+        private readonly minioService: MinioService,
+        private readonly conversationService: ConversationService,
+    ) {}
 
     @Post()
     @HttpCode(HttpStatus.CREATED)
@@ -47,11 +51,13 @@ export class StorageController {
     @ApiCreatedResponse({ type: PresignedUploadResponseDto, description: 'Presigned URL 및 object key 반환' })
     @ApiNotFoundResponse({ description: '대화방 없음' })
     @ApiForbiddenResponse({ description: '대화방 참여자 아님' })
-    createPresignedUpload(
+    async createPresignedUpload(
         @UserId() userId: number,
         @Param('conversationId') conversationId: string,
         @Body() dto: PresignedUploadRequestDto,
     ) {
+        await this.conversationService.getConversationOrThrow(conversationId, userId);
+
         return this.minioService.createPresignedUpload({
             conversationId,
             userId,


### PR DESCRIPTION
## 개요

Gemini 코드 리뷰에서 발견된 3가지 보안 및 안정성 이슈를 수정하였습니다. 권한 검증 누락, WebSocket 페이로드 null-safety 미처리, 유효하지 않은 `messageId` 입력 시 500 에러 반환 문제를 각각 수정하였습니다.

## 본문

### `StorageController` — presigned URL 권한 검증 누락 수정

`POST /conversations/:conversationId/upload` 엔드포인트에서 presigned URL 발급 시 요청자가 해당 대화방의 참여자인지 검증하지 않던 문제를 수정하였습니다. `ConversationService.getConversationOrThrow(conversationId, userId)`를 호출하여 대화방 존재 여부와 참여 권한을 함께 검증합니다.

### `DmGateway` — WebSocket 페이로드 null-safety 및 타이핑 이벤트 룸 참여 검증

`join`, `leave`, `typing:start`, `typing:stop` 이벤트 핸들러에서 클라이언트가 페이로드 없이 이벤트를 전송할 경우 `TypeError`로 서버가 크래시되던 문제를 수정하였습니다. `payload?.conversationId ?? ''` 패턴으로 안전하게 추출하고, 빈 값이면 조기 반환합니다. 또한 `typing:start`·`typing:stop` 핸들러에 `client.rooms.has(room)` 검증을 추가하여 룸에 참여하지 않은 클라이언트가 임의의 대화방으로 타이핑 이벤트를 스팸하는 것을 방지하였습니다.

### `MessageService` — 유효하지 않은 `messageId` 입력 시 500 에러 방지

`reactMessage`, `markRead` 메서드에서 유효하지 않은 형식의 `messageId`가 전달될 경우 Mongoose의 `CastError` 또는 `BSONError`로 인해 500 에러가 반환되던 문제를 수정하였습니다. `Types.ObjectId.isValid(messageId)` 검증을 추가하여 유효하지 않은 ID는 `BadRequestException`(400)으로 처리합니다.
