### PR TITLE
[user] 프로필 수정 API 필드 확장 및 커스텀 상태 메시지 API 추가

### DIFF
--- a/cowork-user/lib/cowork_user/accounts.ex
+++ b/cowork-user/lib/cowork_user/accounts.ex
@@ -49,29 +49,33 @@ defmodule CoworkUser.Accounts do
   end
 
   def update_my_status(user_id, attrs) do
-    case load_profile(user_id) do
-      nil -> {:error, :not_found}
-      profile ->
-        status_attrs =
-          Enum.reduce(
-            [{"status", :status}, {"message", :status_message}, {"expiresAt", :status_expires_at}],
-            %{last_modified_by: user_id},
-            fn {key, field}, acc ->
-              if Map.has_key?(attrs, key) do
-                Map.put(acc, field, attrs[key])
-              else
-                acc
+    if Map.has_key?(attrs, "status") do
+      case load_profile(user_id) do
+        nil -> {:error, :not_found}
+        profile ->
+          status_attrs =
+            Enum.reduce(
+              [{"status", :status}, {"message", :status_message}, {"expiresAt", :status_expires_at}],
+              %{last_modified_by: user_id},
+              fn {key, field}, acc ->
+                if Map.has_key?(attrs, key) do
+                  Map.put(acc, field, attrs[key])
+                else
+                  acc
+                end
               end
-            end
-          )
+            )
 
-        profile.account
-        |> Account.status_changeset(status_attrs)
-        |> Repo.update()
-        |> case do
-          {:ok, _} -> get_my_profile(user_id)
-          {:error, changeset} -> {:error, {:validation, format_changeset_errors(changeset)}}
-        end
+          profile.account
+          |> Account.status_changeset(status_attrs)
+          |> Repo.update()
+          |> case do
+            {:ok, _} -> get_my_profile(user_id)
+            {:error, changeset} -> {:error, {:validation, format_changeset_errors(changeset)}}
+          end
+      end
+    else
+      {:error, {:validation, "status 필드는 필수입니다."}}
     end
   end
 

--- a/cowork-user/lib/cowork_user/accounts.ex
+++ b/cowork-user/lib/cowork_user/accounts.ex
@@ -52,12 +52,18 @@ defmodule CoworkUser.Accounts do
     case load_profile(user_id) do
       nil -> {:error, :not_found}
       profile ->
-        status_attrs = %{
-          status: Map.get(attrs, "status"),
-          status_message: Map.get(attrs, "message"),
-          status_expires_at: Map.get(attrs, "expiresAt"),
-          last_modified_by: user_id
-        }
+        status_attrs =
+          Enum.reduce(
+            [{"status", :status}, {"message", :status_message}, {"expiresAt", :status_expires_at}],
+            %{last_modified_by: user_id},
+            fn {key, field}, acc ->
+              if Map.has_key?(attrs, key) do
+                Map.put(acc, field, attrs[key])
+              else
+                acc
+              end
+            end
+          )
 
         profile.account
         |> Account.status_changeset(status_attrs)

--- a/cowork-user/lib/cowork_user/accounts.ex
+++ b/cowork-user/lib/cowork_user/accounts.ex
@@ -19,14 +19,25 @@ defmodule CoworkUser.Accounts do
   def update_my_profile(user_id, attrs) do
     with %Profile{} = profile <- load_profile(user_id) do
       roles = attrs["roles"] |> normalize_roles()
+      account_update_attrs = build_profile_account_attrs(attrs, user_id)
 
-      Multi.new()
-      |> Multi.update(:profile, Profile.changeset(profile, %{
-        nickname: Map.get(attrs, "nickname"),
-        description: Map.get(attrs, "description"),
-        last_modified_by: user_id
-      }))
-      |> replace_roles(profile.id, roles)
+      multi =
+        Multi.new()
+        |> Multi.update(:profile, Profile.changeset(profile, %{
+          nickname: Map.get(attrs, "nickname"),
+          description: Map.get(attrs, "description"),
+          last_modified_by: user_id
+        }))
+        |> replace_roles(profile.id, roles)
+
+      multi =
+        if map_size(account_update_attrs) > 1 do
+          Multi.update(multi, :account, Account.profile_update_changeset(profile.account, account_update_attrs))
+        else
+          multi
+        end
+
+      multi
       |> Repo.transaction()
       |> case do
         {:ok, _} -> get_my_profile(user_id)
@@ -34,6 +45,27 @@ defmodule CoworkUser.Accounts do
       end
     else
       nil -> {:error, :not_found}
+    end
+  end
+
+  def update_my_status(user_id, attrs) do
+    case load_profile(user_id) do
+      nil -> {:error, :not_found}
+      profile ->
+        status_attrs = %{
+          status: Map.get(attrs, "status"),
+          status_message: Map.get(attrs, "message"),
+          status_expires_at: Map.get(attrs, "expiresAt"),
+          last_modified_by: user_id
+        }
+
+        profile.account
+        |> Account.status_changeset(status_attrs)
+        |> Repo.update()
+        |> case do
+          {:ok, _} -> get_my_profile(user_id)
+          {:error, changeset} -> {:error, {:validation, format_changeset_errors(changeset)}}
+        end
     end
   end
 
@@ -232,6 +264,16 @@ defmodule CoworkUser.Accounts do
     end
   end
 
+  defp build_profile_account_attrs(attrs, user_id) do
+    Enum.reduce([{"name", :name}, {"github_id", :github}], %{last_modified_by: user_id}, fn {key, field}, acc ->
+      if Map.has_key?(attrs, key) do
+        Map.put(acc, field, attrs[key])
+      else
+        acc
+      end
+    end)
+  end
+
   defp account_attrs(user_id, attrs) do
     %{
       id: user_id,
@@ -409,6 +451,8 @@ defmodule CoworkUser.Accounts do
       major: profile.account.major,
       specialty: profile.account.specialty,
       status: profile.account.status,
+      status_message: profile.account.status_message,
+      status_expires_at: profile.account.status_expires_at,
       profile_image_url: image_url,
       nickname: profile.nickname,
       roles: profile.profile_roles |> Enum.map(& &1.role) |> Enum.uniq() |> Enum.sort(),

--- a/cowork-user/lib/cowork_user/accounts/account.ex
+++ b/cowork-user/lib/cowork_user/accounts/account.ex
@@ -15,7 +15,7 @@ defmodule CoworkUser.Accounts.Account do
     field :specialty, :string
     field :status, :string
     field :status_message, :string
-    field :status_expires_at, :naive_datetime
+    field :status_expires_at, :utc_datetime
     field :created_by, :integer
     field :last_modified_by, :integer
 
@@ -49,6 +49,7 @@ defmodule CoworkUser.Accounts.Account do
   def profile_update_changeset(account, attrs) do
     account
     |> cast(attrs, [:name, :github, :last_modified_by])
+    |> validate_required([:name])
   end
 
   def status_changeset(account, attrs) do

--- a/cowork-user/lib/cowork_user/accounts/account.ex
+++ b/cowork-user/lib/cowork_user/accounts/account.ex
@@ -14,6 +14,8 @@ defmodule CoworkUser.Accounts.Account do
     field :major, :string
     field :specialty, :string
     field :status, :string
+    field :status_message, :string
+    field :status_expires_at, :naive_datetime
     field :created_by, :integer
     field :last_modified_by, :integer
 
@@ -36,9 +38,22 @@ defmodule CoworkUser.Accounts.Account do
       :major,
       :specialty,
       :status,
+      :status_message,
+      :status_expires_at,
       :created_by,
       :last_modified_by
     ])
     |> validate_required([:id, :name, :email, :sex, :status])
+  end
+
+  def profile_update_changeset(account, attrs) do
+    account
+    |> cast(attrs, [:name, :github, :last_modified_by])
+  end
+
+  def status_changeset(account, attrs) do
+    account
+    |> cast(attrs, [:status, :status_message, :status_expires_at, :last_modified_by])
+    |> validate_required([:status])
   end
 end

--- a/cowork-user/lib/cowork_user/open_api.ex
+++ b/cowork-user/lib/cowork_user/open_api.ex
@@ -114,7 +114,7 @@ defmodule CoworkUser.OpenAPI do
       properties: %{
         status: %{type: "string", example: "DO_NOT_DISTURB"},
         message: %{type: "string", nullable: true, example: "집중 중"},
-        expiresAt: %{type: "string", format: "date-time", nullable: true, example: "2026-05-26T18:00:00"}
+        expiresAt: %{type: "string", format: "date-time", nullable: true, example: "2026-05-26T18:00:00Z"}
       }
     }
   end

--- a/cowork-user/lib/cowork_user/open_api.ex
+++ b/cowork-user/lib/cowork_user/open_api.ex
@@ -12,6 +12,9 @@ defmodule CoworkUser.OpenAPI do
           get: %{summary: "내 프로필 조회", responses: responses(user_schema())},
           patch: %{summary: "내 프로필 수정", requestBody: json_body(update_profile_schema()), responses: responses(user_schema())}
         },
+        "/users/me/status" => %{
+          patch: %{summary: "상태 및 커스텀 상태 메시지 설정", requestBody: json_body(update_status_schema()), responses: responses(user_schema())}
+        },
         "/users/me/profile-image/presigned" => %{
           post: %{summary: "프로필 이미지 업로드 URL 발급", requestBody: json_body(%{type: "object", required: ["content_type"], properties: %{content_type: %{type: "string"}}}), responses: responses(%{type: "object", properties: %{upload_url: %{type: "string"}, object_key: %{type: "string"}}})}
         },
@@ -96,8 +99,22 @@ defmodule CoworkUser.OpenAPI do
       type: "object",
       properties: %{
         nickname: %{type: "string"},
+        name: %{type: "string"},
         description: %{type: "string"},
+        github_id: %{type: "string", nullable: true},
         roles: %{type: "array", items: %{type: "string"}}
+      }
+    }
+  end
+
+  defp update_status_schema do
+    %{
+      type: "object",
+      required: ["status"],
+      properties: %{
+        status: %{type: "string", example: "DO_NOT_DISTURB"},
+        message: %{type: "string", nullable: true, example: "집중 중"},
+        expiresAt: %{type: "string", format: "date-time", nullable: true, example: "2026-05-26T18:00:00"}
       }
     }
   end
@@ -148,6 +165,8 @@ defmodule CoworkUser.OpenAPI do
         major: %{type: "string", nullable: true},
         specialty: %{type: "string", nullable: true},
         status: %{type: "string"},
+        status_message: %{type: "string", nullable: true},
+        status_expires_at: %{type: "string", format: "date-time", nullable: true},
         profile_image_url: %{type: "string", nullable: true},
         nickname: %{type: "string", nullable: true},
         roles: %{type: "array", items: %{type: "string"}},

--- a/cowork-user/lib/cowork_user/router.ex
+++ b/cowork-user/lib/cowork_user/router.ex
@@ -56,6 +56,17 @@ defmodule CoworkUser.Router do
     end
   end
 
+  patch "/users/me/status" do
+    with {:ok, user_id} <- user_id_from_header(conn),
+         {:ok, profile} <- Accounts.update_my_status(user_id, conn.body_params) do
+      JSON.send(conn, 200, profile)
+    else
+      {:error, :not_found} -> JSON.error(conn, 404, "사용자를 찾을 수 없습니다.")
+      {:error, :missing_user_id} -> JSON.error(conn, 400, "X-User-Id 헤더가 누락되었습니다.")
+      {:error, {:validation, message}} -> JSON.error(conn, 400, message)
+    end
+  end
+
   post "/users/me/profile-image/presigned" do
     with {:ok, user_id} <- user_id_from_header(conn),
          {:ok, response} <- Accounts.generate_presigned_url(user_id, conn.body_params) do

--- a/cowork-user/src/main/resources/db/migration/V5__add_status_message.sql
+++ b/cowork-user/src/main/resources/db/migration/V5__add_status_message.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tb_accounts
+    ADD COLUMN status_message    VARCHAR(100) NULL AFTER status,
+    ADD COLUMN status_expires_at DATETIME(6)  NULL AFTER status_message;

--- a/docs/20260526_TODO.md
+++ b/docs/20260526_TODO.md
@@ -15,7 +15,7 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 | 2  | ~~Gateway 프로젝트 reorder 라우팅~~     | ~~cowork-gateway~~    | 🔴   | ~~[바로가기](./todo/01-urgent/gateway-reorder-routing.md)~~     |
 | 3  | ~~팀 정보 수정·삭제 API~~               | ~~cowork-team~~       | 🟠   | ~~[바로가기](./todo/02-management/team-crud.md)~~               |
 | 4  | ~~팀 멤버 관리 API (추방·역할변경·탈퇴)~~     | ~~cowork-team~~       | 🟠   | ~~[바로가기](./todo/02-management/team-members.md)~~            |
-| 5  | ~~팀 초대 링크 API~~                   | ~~cowork-team~~       | 🟠   | ~~[바로가기](./todo/02-management/team-invite.md)~~             |
+| 5  | ~~팀 초대 링크 API~~                  | ~~cowork-team~~       | 🟠   | ~~[바로가기](./todo/02-management/team-invite.md)~~             |
 | 6  | ~~채널 수정·삭제 API~~                 | ~~cowork-channel~~    | 🟠   | ~~[바로가기](./todo/02-management/channel-crud.md)~~            |
 | 7  | ~~채널별 멤버 권한 (비공개 채널 초대)~~        | ~~cowork-channel~~    | 🟠   | ~~[바로가기](./todo/02-management/channel-permissions.md)~~     |
 | 8  | ~~채널 메시지 고정 API~~                | ~~cowork-chat~~       | 🟠   | ~~[바로가기](./todo/02-management/message-pin.md)~~             |
@@ -26,10 +26,10 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 | 13 | ~~@멘션 멤버 검색 API~~                | ~~cowork-user~~       | 🟡   | ~~[바로가기](./todo/03-messaging/mention.md)~~                  |
 | 14 | ~~읽음 상태 및 미읽 카운트~~               | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/04-notification/read-status.md)~~           |
 | 15 | ~~알림 설정 (preference 모듈 확장)~~     | ~~cowork-preference~~ | 🟡   | ~~[바로가기](./todo/04-notification/notification-settings.md)~~ |
-| 16 | 프로필 필드 수정 + 커스텀 상태 메시지           | cowork-user           | 🟡   | [바로가기](./todo/05-user-search/profile-edit.md)               |
+| 16 | ~~프로필 필드 수정 + 커스텀 상태 메시지~~         | ~~cowork-user~~       | 🟡   | ~~[바로가기](./todo/05-user-search/profile-edit.md)~~           |
 | 17 | 전체 검색 API                        | 신규 or gateway         | 🟡   | [바로가기](./todo/05-user-search/global-search.md)              |
 | 18 | AccountShare 채널 설계·구현            | TBD                   | 🟢   | [바로가기](./todo/06-future/account-share.md)                   |
-| 19 | 다이렉트 메시지(DM)                     | 신규                    | 🟢   | [바로가기](./todo/06-future/direct-message.md)                  |
+| 19 | ~~다이렉트 메시지(DM)~~                 | ~~신규~~                | 🟢   | ~~[바로가기](./todo/06-future/direct-message.md)~~              |
 | 20 | ~~팀 역할 시스템 고도화~~                 | ~~cowork-team~~       | 🟢   | ~~[바로가기](./todo/06-future/role-system.md)~~                 |
 | 21 | 회의록 수정·삭제, 템플릿 관리                | cowork-channel        | 🟢   | [바로가기](./todo/06-future/meeting-note-management.md)         |
 | 22 | ~~WebSocket 이벤트 보강~~             | ~~cowork-chat~~       | 🟢   | ~~[바로가기](./todo/06-future/websocket-events.md)~~            |


### PR DESCRIPTION
## 개요

`cowork-user` 서비스에서 프로필 수정 API(`PATCH /users/me`)에 `name`, `github_id` 필드 수정 기능을 추가하였습니다. 또한 커스텀 상태 메시지 설정을 위한 신규 API(`PATCH /users/me/status`)를 구현하였습니다.

## 본문

### 변경 사항

**`PATCH /users/me` 확장**

기존에는 `nickname`, `description`, `roles`(Profile 엔티티 필드)만 수정 가능하였습니다. 이번 변경으로 `name`, `github_id`를 요청 바디에 포함하면 `tb_accounts`의 해당 컬럼도 함께 수정됩니다. 제공되지 않은 필드는 업데이트하지 않으며, `null`을 명시적으로 전달하면 해당 값을 지웁니다.

**`PATCH /users/me/status` 신규 추가**

커스텀 상태 메시지 설정을 위한 엔드포인트를 추가하였습니다.

```json
{
  "status": "DO_NOT_DISTURB",
  "message": "집중 중",
  "expiresAt": "2026-05-26T18:00:00"
}
```

`status`는 필수이며, `message`와 `expiresAt`은 선택 사항입니다. `Account.status_changeset/2`를 통해 `status`, `status_message`, `status_expires_at` 필드를 부분 업데이트합니다.

**DB 마이그레이션 (`V5__add_status_message.sql`)**

`tb_accounts`에 `status_message VARCHAR(100)`와 `status_expires_at DATETIME(6)` 컬럼을 추가하였습니다.

**엔티티 및 응답 확장**

- `Account` 엔티티에 `status_message`, `status_expires_at` 필드 추가
- `profile_update_changeset/2`, `status_changeset/2` 추가
- `to_user_response/1` 응답에 `status_message`, `status_expires_at` 포함
- `OpenAPI` 스펙에 신규 엔드포인트 및 필드 반영
