### PR TITLE
[preference] 빌드 도구 Amper 마이그레이션

### DIFF
--- a/.github/workflows/cowork-prod-ci.yml
+++ b/.github/workflows/cowork-prod-ci.yml
@@ -150,69 +150,69 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             MATRIX='{"include":[
-              {"service":"cowork-gateway","lang":"kotlin","gradle-task":":cowork-gateway:build"},
-              {"service":"cowork-config","lang":"kotlin","gradle-task":":cowork-config:build"},
-              {"service":"cowork-user","lang":"elixir","working-directory":"cowork-user","elixir-version":"1.17.3","otp-version":"27.1.1"},
-              {"service":"cowork-notification","lang":"go","working-directory":"cowork-notification","go-version-file":"cowork-notification/go.mod","go-build":"go build ./cmd/server"},
-              {"service":"cowork-preference","lang":"kotlin","gradle-task":":cowork-preference:build"},
-              {"service":"cowork-team","lang":"kotlin","gradle-task":":cowork-team:build"},
-              {"service":"cowork-project","lang":"kotlin","gradle-task":":cowork-project:build"},
-              {"service":"cowork-channel","lang":"kotlin","gradle-task":":cowork-channel:build"},
-              {"service":"cowork-authorization","lang":"go","working-directory":"cowork-authorization","go-version-file":"cowork-authorization/go.mod","go-build":"go build ./..."},
-              {"service":"cowork-voice","lang":"go","working-directory":"cowork-voice","go-version-file":"cowork-voice/go.mod","go-build":"go build ./cmd/server"},
-              {"service":"cowork-chat","lang":"node","working-directory":"cowork-chat","node-version":"22"},
-              {"service":"cowork-promotion","lang":"node","working-directory":"cowork-promotion","node-version":"22"},
-              {"service":"cowork-dm","lang":"node","working-directory":"cowork-dm","node-version":"22"},
-              {"service":"cowork-channel","lang":"kotlin","gradle-task":":cowork-channel:build"}
+              {"service":"cowork-gateway","build":"gradle","working-directory":"."},
+              {"service":"cowork-config","build":"gradle","working-directory":"."},
+              {"service":"cowork-user","build":"elixir","working-directory":"cowork-user","elixir-version":"1.17.3","otp-version":"27.1.1"},
+              {"service":"cowork-notification","build":"go","working-directory":"cowork-notification","go-version-file":"cowork-notification/go.mod","build-command":"go build ./cmd/server"},
+              {"service":"cowork-preference","build":"amper","working-directory":"cowork-preference"},
+              {"service":"cowork-team","build":"gradle","working-directory":"."},
+              {"service":"cowork-project","build":"gradle","working-directory":"."},
+              {"service":"cowork-channel","build":"gradle","working-directory":"."},
+              {"service":"cowork-authorization","build":"go","working-directory":"cowork-authorization","go-version-file":"cowork-authorization/go.mod","build-command":"go build ./..."},
+              {"service":"cowork-voice","build":"go","working-directory":"cowork-voice","go-version-file":"cowork-voice/go.mod","build-command":"go build ./cmd/server"},
+              {"service":"cowork-chat","build":"node","working-directory":"cowork-chat","node-version":"22"},
+              {"service":"cowork-promotion","build":"node","working-directory":"cowork-promotion","node-version":"22"},
+              {"service":"cowork-dm","build":"node","working-directory":"cowork-dm","node-version":"22"},
+              {"service":"cowork-channel","build":"gradle","working-directory":"."}
             ]}'
             SERVICES="cowork-gateway, cowork-config, cowork-user, cowork-notification, cowork-preference, cowork-team, cowork-project, cowork-channel, cowork-authorization, cowork-voice, cowork-chat, cowork-promotion, cowork-dm"
           else
             MATRIX='{"include":[]}'
             SERVICES=""
             [ "${{ steps.filter.outputs.cowork-gateway }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-gateway","lang":"kotlin","gradle-task":":cowork-gateway:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-gateway","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-gateway"
             [ "${{ steps.filter.outputs.cowork-config }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-config","lang":"kotlin","gradle-task":":cowork-config:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-config","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-config"
             [ "${{ steps.filter.outputs.cowork-user }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-user","lang":"elixir","working-directory":"cowork-user","elixir-version":"1.17.3","otp-version":"27.1.1"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-user","build":"elixir","working-directory":"cowork-user","elixir-version":"1.17.3","otp-version":"27.1.1"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-user"
             [ "${{ steps.filter.outputs.cowork-notification }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-notification","lang":"go","working-directory":"cowork-notification","go-version-file":"cowork-notification/go.mod","go-build":"go build ./cmd/server"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-notification","build":"go","working-directory":"cowork-notification","go-version-file":"cowork-notification/go.mod","build-command":"go build ./cmd/server"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-notification"
             [ "${{ steps.filter.outputs.cowork-preference }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-preference","lang":"kotlin","gradle-task":":cowork-preference:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-preference","build":"amper","working-directory":"cowork-preference"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-preference"
             [ "${{ steps.filter.outputs.cowork-team }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-team","lang":"kotlin","gradle-task":":cowork-team:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-team","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-team"
             [ "${{ steps.filter.outputs.cowork-project }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-project","lang":"kotlin","gradle-task":":cowork-project:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-project","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-project"
             [ "${{ steps.filter.outputs.cowork-channel }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-channel","lang":"kotlin","gradle-task":":cowork-channel:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-channel","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-channel"
             [ "${{ steps.filter.outputs.cowork-authorization }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-authorization","lang":"go","working-directory":"cowork-authorization","go-version-file":"cowork-authorization/go.mod","go-build":"go build ./..."}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-authorization","build":"go","working-directory":"cowork-authorization","go-version-file":"cowork-authorization/go.mod","build-command":"go build ./..."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-authorization"
             [ "${{ steps.filter.outputs.cowork-voice }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-voice","lang":"go","working-directory":"cowork-voice","go-version-file":"cowork-voice/go.mod","go-build":"go build ./cmd/server"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-voice","build":"go","working-directory":"cowork-voice","go-version-file":"cowork-voice/go.mod","build-command":"go build ./cmd/server"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-voice"
             [ "${{ steps.filter.outputs.cowork-chat }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-chat","lang":"node","working-directory":"cowork-chat","node-version":"22"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-chat","build":"node","working-directory":"cowork-chat","node-version":"22"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-chat"
             [ "${{ steps.filter.outputs.cowork-promotion }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-promotion","lang":"node","working-directory":"cowork-promotion","node-version":"22"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-promotion","build":"node","working-directory":"cowork-promotion","node-version":"22"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-promotion"
             [ "${{ steps.filter.outputs.cowork-channel }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-channel","lang":"kotlin","gradle-task":":cowork-channel:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-channel","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-channel"
             [ "${{ steps.filter.outputs.cowork-dm }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-dm","lang":"node","working-directory":"cowork-dm","node-version":"22"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-dm","build":"node","working-directory":"cowork-dm","node-version":"22"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-dm"
             if [ "$(echo "$MATRIX" | jq '.include | length')" == "0" ]; then
-              MATRIX='{"include":[{"service":"변경 없음","lang":"skip"}]}'
+              MATRIX='{"include":[{"service":"변경 없음","build":"skip"}]}'
               SERVICES="없음"
             fi
           fi
@@ -234,40 +234,49 @@ jobs:
 
     steps:
       - name: No Changed Services
-        if: matrix.lang == 'skip'
+        if: matrix.build == 'skip'
         run: echo "변경된 서비스가 없습니다."
       - name: Checkout Code
-        if: matrix.lang != 'skip'
+        if: matrix.build != 'skip'
         uses: actions/checkout@v6
-      - name: Setup JDK 21
-        if: matrix.lang == 'kotlin'
+      - name: Setup JDK
+        if: matrix.build == 'gradle'
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
       - name: Setup Gradle
-        if: matrix.lang == 'kotlin'
+        if: matrix.build == 'gradle'
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
           cache-cleanup: always
-      - name: Build & Test (Kotlin)
-        if: matrix.lang == 'kotlin'
-        run: ./gradlew ${{ matrix.gradle-task }} --build-cache
+      - name: Build & Test (Gradle)
+        if: matrix.build == 'gradle'
+        working-directory: ${{ matrix.working-directory }}
+        run: ./gradlew :${{ matrix.service }}:build --build-cache
+      - name: Build & Test (Amper)
+        if: matrix.build == 'amper'
+        working-directory: ${{ matrix.working-directory }}
+        run: |
+          curl -fsSL https://kotl.in/install.sh | KOTLIN_CLI_NO_MODIFY_PATH=1 sh
+          export PATH="$HOME/.local/bin:$PATH"
+          kotlin build
+          kotlin test
       - name: Setup Go
-        if: matrix.lang == 'go'
+        if: matrix.build == 'go'
         uses: actions/setup-go@v6
         with:
           go-version-file: ${{ matrix.go-version-file }}
           cache-dependency-path: ${{ matrix.working-directory }}/go.sum
       - name: Setup Elixir
-        if: matrix.lang == 'elixir'
+        if: matrix.build == 'elixir'
         uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.elixir-version }}
           otp-version: ${{ matrix.otp-version }}
       - name: Cache Elixir Dependencies
-        if: matrix.lang == 'elixir'
+        if: matrix.build == 'elixir'
         uses: actions/cache@v5
         with:
           path: |
@@ -276,35 +285,28 @@ jobs:
           key: ${{ runner.os }}-elixir-${{ matrix.service }}-${{ hashFiles(format('{0}/mix.lock', matrix.working-directory)) }}
           restore-keys: |
             ${{ runner.os }}-elixir-${{ matrix.service }}-
-      - name: Vet (Go)
-        if: matrix.lang == 'go'
+      - name: Build & Test (Go)
+        if: matrix.build == 'go'
         working-directory: ${{ matrix.working-directory }}
-        run: go vet ./...
-      - name: Test (Go)
-        if: matrix.lang == 'go'
-        working-directory: ${{ matrix.working-directory }}
-        run: go test ./...
-      - name: Build (Go)
-        if: matrix.lang == 'go'
-        working-directory: ${{ matrix.working-directory }}
-        run: ${{ matrix.go-build }}
+        run: |
+          go vet ./...
+          go test ./...
+          ${{ matrix.build-command }}
       - name: Setup Node.js
-        if: matrix.lang == 'node'
+        if: matrix.build == 'node'
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: ${{ matrix.working-directory }}/package-lock.json
-      - name: Install Dependencies (Node)
-        if: matrix.lang == 'node'
+      - name: Build & Test (Node)
+        if: matrix.build == 'node'
         working-directory: ${{ matrix.working-directory }}
-        run: npm ci
-      - name: Build (Node)
-        if: matrix.lang == 'node'
-        working-directory: ${{ matrix.working-directory }}
-        run: npm run build
+        run: |
+          npm ci
+          npm run build
       - name: Build & Test (Elixir)
-        if: matrix.lang == 'elixir'
+        if: matrix.build == 'elixir'
         working-directory: ${{ matrix.working-directory }}
         run: |
           mix deps.get

--- a/.github/workflows/cowork-prod-ci.yml
+++ b/.github/workflows/cowork-prod-ci.yml
@@ -258,8 +258,15 @@ jobs:
       - name: Build & Test (Amper)
         if: matrix.build == 'amper'
         working-directory: ${{ matrix.working-directory }}
+        env:
+          KOTLIN_CLI_VERSION: '0.11.0'
+          KOTLIN_CLI_WRAPPER_SHA256: f53d26ee0bb6ef3078c33bda3c180d19fbca665408c27b62b7dfce335551c3d7
         run: |
-          curl -fsSL https://kotl.in/install.sh | KOTLIN_CLI_NO_MODIFY_PATH=1 sh
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL -o "$HOME/.local/bin/kotlin" \
+            "https://packages.jetbrains.team/maven/p/amper/amper/org/jetbrains/kotlin/kotlin-cli/${KOTLIN_CLI_VERSION}/kotlin-cli-${KOTLIN_CLI_VERSION}-wrapper"
+          echo "${KOTLIN_CLI_WRAPPER_SHA256}  $HOME/.local/bin/kotlin" | sha256sum -c -
+          chmod +x "$HOME/.local/bin/kotlin"
           export PATH="$HOME/.local/bin:$PATH"
           kotlin build
           kotlin test

--- a/.github/workflows/cowork-stage-ci.yml
+++ b/.github/workflows/cowork-stage-ci.yml
@@ -123,66 +123,66 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             MATRIX='{"include":[
-              {"service":"cowork-gateway","lang":"kotlin","gradle-task":":cowork-gateway:build"},
-              {"service":"cowork-config","lang":"kotlin","gradle-task":":cowork-config:build"},
-              {"service":"cowork-user","lang":"elixir","working-directory":"cowork-user","elixir-version":"1.17.3","otp-version":"27.1.1"},
-              {"service":"cowork-notification","lang":"go","working-directory":"cowork-notification","go-version-file":"cowork-notification/go.mod","go-build":"go build ./cmd/server"},
-              {"service":"cowork-preference","lang":"kotlin","gradle-task":":cowork-preference:build"},
-              {"service":"cowork-project","lang":"kotlin","gradle-task":":cowork-project:build"},
-              {"service":"cowork-channel","lang":"kotlin","gradle-task":":cowork-channel:build"},
-              {"service":"cowork-authorization","lang":"go","working-directory":"cowork-authorization","go-version-file":"cowork-authorization/go.mod","go-build":"go build ./..."},
-              {"service":"cowork-voice","lang":"go","working-directory":"cowork-voice","go-version-file":"cowork-voice/go.mod","go-build":"go build ./cmd/server"},
-              {"service":"cowork-chat","lang":"node","working-directory":"cowork-chat","node-version":"22"},
-              {"service":"cowork-promotion","lang":"node","working-directory":"cowork-promotion","node-version":"22"},
-              {"service":"cowork-dm","lang":"node","working-directory":"cowork-dm","node-version":"22"},
-              {"service":"cowork-channel","lang":"kotlin","gradle-task":":cowork-channel:build"},
-              {"service":"cowork-team","lang":"kotlin","gradle-task":":cowork-team:build"}
+              {"service":"cowork-gateway","build":"gradle","working-directory":"."},
+              {"service":"cowork-config","build":"gradle","working-directory":"."},
+              {"service":"cowork-user","build":"elixir","working-directory":"cowork-user","elixir-version":"1.17.3","otp-version":"27.1.1"},
+              {"service":"cowork-notification","build":"go","working-directory":"cowork-notification","go-version-file":"cowork-notification/go.mod","build-command":"go build ./cmd/server"},
+              {"service":"cowork-preference","build":"amper","working-directory":"cowork-preference"},
+              {"service":"cowork-project","build":"gradle","working-directory":"."},
+              {"service":"cowork-channel","build":"gradle","working-directory":"."},
+              {"service":"cowork-authorization","build":"go","working-directory":"cowork-authorization","go-version-file":"cowork-authorization/go.mod","build-command":"go build ./..."},
+              {"service":"cowork-voice","build":"go","working-directory":"cowork-voice","go-version-file":"cowork-voice/go.mod","build-command":"go build ./cmd/server"},
+              {"service":"cowork-chat","build":"node","working-directory":"cowork-chat","node-version":"22"},
+              {"service":"cowork-promotion","build":"node","working-directory":"cowork-promotion","node-version":"22"},
+              {"service":"cowork-dm","build":"node","working-directory":"cowork-dm","node-version":"22"},
+              {"service":"cowork-channel","build":"gradle","working-directory":"."},
+              {"service":"cowork-team","build":"gradle","working-directory":"."}
             ]}'
             SERVICES="cowork-gateway, cowork-config, cowork-user, cowork-notification, cowork-preference, cowork-project, cowork-channel, cowork-authorization, cowork-voice, cowork-chat, cowork-promotion"
           else
             MATRIX='{"include":[]}'
             SERVICES=""
             [ "${{ steps.filter.outputs.cowork-gateway }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-gateway","lang":"kotlin","gradle-task":":cowork-gateway:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-gateway","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-gateway"
             [ "${{ steps.filter.outputs.cowork-config }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-config","lang":"kotlin","gradle-task":":cowork-config:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-config","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-config"
             [ "${{ steps.filter.outputs.cowork-user }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-user","lang":"elixir","working-directory":"cowork-user","elixir-version":"1.17.3","otp-version":"27.1.1"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-user","build":"elixir","working-directory":"cowork-user","elixir-version":"1.17.3","otp-version":"27.1.1"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-user"
             [ "${{ steps.filter.outputs.cowork-notification }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-notification","lang":"go","working-directory":"cowork-notification","go-version-file":"cowork-notification/go.mod","go-build":"go build ./cmd/server"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-notification","build":"go","working-directory":"cowork-notification","go-version-file":"cowork-notification/go.mod","build-command":"go build ./cmd/server"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-notification"
             [ "${{ steps.filter.outputs.cowork-preference }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-preference","lang":"kotlin","gradle-task":":cowork-preference:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-preference","build":"amper","working-directory":"cowork-preference"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-preference"
             [ "${{ steps.filter.outputs.cowork-project }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-project","lang":"kotlin","gradle-task":":cowork-project:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-project","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-project"
             [ "${{ steps.filter.outputs.cowork-channel }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-channel","lang":"kotlin","gradle-task":":cowork-channel:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-channel","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-channel"
             [ "${{ steps.filter.outputs.cowork-authorization }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-authorization","lang":"go","working-directory":"cowork-authorization","go-version-file":"cowork-authorization/go.mod","go-build":"go build ./..."}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-authorization","build":"go","working-directory":"cowork-authorization","go-version-file":"cowork-authorization/go.mod","build-command":"go build ./..."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-authorization"
             [ "${{ steps.filter.outputs.cowork-voice }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-voice","lang":"go","working-directory":"cowork-voice","go-version-file":"cowork-voice/go.mod","go-build":"go build ./cmd/server"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-voice","build":"go","working-directory":"cowork-voice","go-version-file":"cowork-voice/go.mod","build-command":"go build ./cmd/server"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-voice"
             [ "${{ steps.filter.outputs.cowork-chat }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-chat","lang":"node","working-directory":"cowork-chat","node-version":"22"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-chat","build":"node","working-directory":"cowork-chat","node-version":"22"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-chat"
             [ "${{ steps.filter.outputs.cowork-channel }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-channel","lang":"kotlin","gradle-task":":cowork-channel:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-channel","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-channel"
             [ "${{ steps.filter.outputs.cowork-team }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-team","lang":"kotlin","gradle-task":":cowork-team:build"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-team","build":"gradle","working-directory":"."}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-team"
             [ "${{ steps.filter.outputs.cowork-dm }}" == "true" ] && \
-              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-dm","lang":"node","working-directory":"cowork-dm","node-version":"22"}]') && \
+              MATRIX=$(echo "$MATRIX" | jq '.include += [{"service":"cowork-dm","build":"node","working-directory":"cowork-dm","node-version":"22"}]') && \
               SERVICES="${SERVICES:+$SERVICES, }cowork-dm"
             if [ "$(echo "$MATRIX" | jq '.include | length')" == "0" ]; then
-              MATRIX='{"include":[{"service":"변경 없음","lang":"skip"}]}'
+              MATRIX='{"include":[{"service":"변경 없음","build":"skip"}]}'
               SERVICES="없음"
             fi
           fi
@@ -201,40 +201,49 @@ jobs:
 
     steps:
       - name: No Changed Services
-        if: matrix.lang == 'skip'
+        if: matrix.build == 'skip'
         run: echo "변경된 서비스가 없습니다."
       - name: Checkout Code
-        if: matrix.lang != 'skip'
+        if: matrix.build != 'skip'
         uses: actions/checkout@v6
-      - name: Setup JDK 21
-        if: matrix.lang == 'kotlin'
+      - name: Setup JDK
+        if: matrix.build == 'gradle'
         uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
       - name: Setup Gradle
-        if: matrix.lang == 'kotlin'
+        if: matrix.build == 'gradle'
         uses: gradle/actions/setup-gradle@v6
         with:
           cache-read-only: false
           cache-cleanup: always
-      - name: Build & Test (Kotlin)
-        if: matrix.lang == 'kotlin'
-        run: ./gradlew ${{ matrix.gradle-task }} --build-cache
+      - name: Build & Test (Gradle)
+        if: matrix.build == 'gradle'
+        working-directory: ${{ matrix.working-directory }}
+        run: ./gradlew :${{ matrix.service }}:build --build-cache
+      - name: Build & Test (Amper)
+        if: matrix.build == 'amper'
+        working-directory: ${{ matrix.working-directory }}
+        run: |
+          curl -fsSL https://kotl.in/install.sh | KOTLIN_CLI_NO_MODIFY_PATH=1 sh
+          export PATH="$HOME/.local/bin:$PATH"
+          kotlin build
+          kotlin test
       - name: Setup Go
-        if: matrix.lang == 'go'
+        if: matrix.build == 'go'
         uses: actions/setup-go@v6
         with:
           go-version-file: ${{ matrix.go-version-file }}
           cache-dependency-path: ${{ matrix.working-directory }}/go.sum
       - name: Setup Elixir
-        if: matrix.lang == 'elixir'
+        if: matrix.build == 'elixir'
         uses: erlef/setup-beam@v1
         with:
           elixir-version: ${{ matrix.elixir-version }}
           otp-version: ${{ matrix.otp-version }}
       - name: Cache Elixir Dependencies
-        if: matrix.lang == 'elixir'
+        if: matrix.build == 'elixir'
         uses: actions/cache@v5
         with:
           path: |
@@ -243,35 +252,28 @@ jobs:
           key: ${{ runner.os }}-elixir-${{ matrix.service }}-${{ hashFiles(format('{0}/mix.lock', matrix.working-directory)) }}
           restore-keys: |
             ${{ runner.os }}-elixir-${{ matrix.service }}-
-      - name: Vet (Go)
-        if: matrix.lang == 'go'
+      - name: Build & Test (Go)
+        if: matrix.build == 'go'
         working-directory: ${{ matrix.working-directory }}
-        run: go vet ./...
-      - name: Test (Go)
-        if: matrix.lang == 'go'
-        working-directory: ${{ matrix.working-directory }}
-        run: go test ./...
-      - name: Build (Go)
-        if: matrix.lang == 'go'
-        working-directory: ${{ matrix.working-directory }}
-        run: ${{ matrix.go-build }}
+        run: |
+          go vet ./...
+          go test ./...
+          ${{ matrix.build-command }}
       - name: Setup Node.js
-        if: matrix.lang == 'node'
+        if: matrix.build == 'node'
         uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: ${{ matrix.working-directory }}/package-lock.json
-      - name: Install Dependencies (Node)
-        if: matrix.lang == 'node'
+      - name: Build & Test (Node)
+        if: matrix.build == 'node'
         working-directory: ${{ matrix.working-directory }}
-        run: npm ci
-      - name: Build (Node)
-        if: matrix.lang == 'node'
-        working-directory: ${{ matrix.working-directory }}
-        run: npm run build
+        run: |
+          npm ci
+          npm run build
       - name: Build & Test (Elixir)
-        if: matrix.lang == 'elixir'
+        if: matrix.build == 'elixir'
         working-directory: ${{ matrix.working-directory }}
         run: |
           mix deps.get

--- a/.github/workflows/cowork-stage-ci.yml
+++ b/.github/workflows/cowork-stage-ci.yml
@@ -225,8 +225,15 @@ jobs:
       - name: Build & Test (Amper)
         if: matrix.build == 'amper'
         working-directory: ${{ matrix.working-directory }}
+        env:
+          KOTLIN_CLI_VERSION: '0.11.0'
+          KOTLIN_CLI_WRAPPER_SHA256: f53d26ee0bb6ef3078c33bda3c180d19fbca665408c27b62b7dfce335551c3d7
         run: |
-          curl -fsSL https://kotl.in/install.sh | KOTLIN_CLI_NO_MODIFY_PATH=1 sh
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL -o "$HOME/.local/bin/kotlin" \
+            "https://packages.jetbrains.team/maven/p/amper/amper/org/jetbrains/kotlin/kotlin-cli/${KOTLIN_CLI_VERSION}/kotlin-cli-${KOTLIN_CLI_VERSION}-wrapper"
+          echo "${KOTLIN_CLI_WRAPPER_SHA256}  $HOME/.local/bin/kotlin" | sha256sum -c -
+          chmod +x "$HOME/.local/bin/kotlin"
           export PATH="$HOME/.local/bin:$PATH"
           kotlin build
           kotlin test

--- a/cowork-preference/build.gradle.kts
+++ b/cowork-preference/build.gradle.kts
@@ -29,7 +29,13 @@ fun amperTask(name: String, vararg amperArgs: String, taskGroup: String, desc: S
         doFirst {
             // Validate only for explicit paths; PATH-resolved command names are left to the OS.
             if (kotlinCli.contains('/') || kotlinCli.contains('\\')) {
-                val cli = file(kotlinCli)
+                // Gradle's file() does not expand a leading '~', so expand it explicitly.
+                val expanded = if (kotlinCli.startsWith("~")) {
+                    kotlinCli.replaceFirst("~", System.getProperty("user.home"))
+                } else {
+                    kotlinCli
+                }
+                val cli = file(expanded)
                 if (!cli.exists()) {
                     throw GradleException(
                         "Kotlin CLI not found at '${cli.absolutePath}'. Install the Kotlin Toolchain " +

--- a/cowork-preference/build.gradle.kts
+++ b/cowork-preference/build.gradle.kts
@@ -12,8 +12,13 @@ plugins {
 group = "com.cowork"
 version = "20260602.0"
 
+// On Windows the Kotlin CLI is installed as kotlin.bat.
+val isWindows = System.getProperty("os.name").lowercase().contains("win")
 val kotlinCli: String = providers.environmentVariable("KOTLIN_CLI")
-    .orElse(providers.systemProperty("user.home").map { "$it/.local/bin/kotlin" })
+    .orElse(
+        providers.systemProperty("user.home")
+            .map { "$it/.local/bin/kotlin${if (isWindows) ".bat" else ""}" }
+    )
     .get()
 
 fun amperTask(name: String, vararg amperArgs: String, taskGroup: String, desc: String) =
@@ -21,6 +26,18 @@ fun amperTask(name: String, vararg amperArgs: String, taskGroup: String, desc: S
         group = taskGroup
         description = desc
         workingDir = projectDir
+        doFirst {
+            // Validate only for explicit paths; PATH-resolved command names are left to the OS.
+            if (kotlinCli.contains('/') || kotlinCli.contains('\\')) {
+                val cli = file(kotlinCli)
+                if (!cli.exists()) {
+                    throw GradleException(
+                        "Kotlin CLI not found at '${cli.absolutePath}'. Install the Kotlin Toolchain " +
+                            "(Amper) or set the KOTLIN_CLI environment variable to its location."
+                    )
+                }
+            }
+        }
         commandLine(kotlinCli, *amperArgs)
     }
 

--- a/cowork-preference/build.gradle.kts
+++ b/cowork-preference/build.gradle.kts
@@ -1,54 +1,42 @@
+// cowork-preference is built by the Kotlin Toolchain (Amper).
+// module.yaml is the single source of truth for dependencies and compilation settings; this Gradle
+// file is only a wrapper that keeps the module in the multi-module build (settings.gradle.kts).
+// Every build action is delegated to the kotlin CLI.
+//
+// The kotlin CLI location can be overridden via the KOTLIN_CLI environment variable; it defaults to
+// the install-script path ~/.local/bin/kotlin.
 plugins {
-    alias(libs.plugins.kotlin.jvm)
-    application
+    base
 }
 
 group = "com.cowork"
 version = "20260602.0"
 
-java {
-    toolchain { languageVersion = JavaLanguageVersion.of(21) }
+val kotlinCli: String = providers.environmentVariable("KOTLIN_CLI")
+    .orElse(providers.systemProperty("user.home").map { "$it/.local/bin/kotlin" })
+    .get()
+
+fun amperTask(name: String, vararg amperArgs: String, taskGroup: String, desc: String) =
+    tasks.register<Exec>(name) {
+        group = taskGroup
+        description = desc
+        workingDir = projectDir
+        commandLine(kotlinCli, *amperArgs)
+    }
+
+val amperBuild = amperTask("amperBuild", "build", taskGroup = "build", desc = "Compile from module.yaml (Amper)")
+val amperPackage = amperTask("amperPackage", "package", taskGroup = "build", desc = "Build the executable JAR (Amper)")
+val amperTest = amperTask("amperTest", "test", taskGroup = "verification", desc = "Run tests (Amper)")
+val amperClean = amperTask("amperClean", "clean", taskGroup = "build", desc = "Clean Amper build output and caches")
+
+
+tasks.named("assemble") { dependsOn(amperBuild, amperPackage) }
+tasks.named("check") { dependsOn(amperTest) }
+tasks.named("clean") { dependsOn(amperClean) }
+
+tasks.register<Exec>("run") {
+    group = "application"
+    description = "Run the application (Amper)"
+    workingDir = projectDir
+    commandLine(kotlinCli, "run")
 }
-
-dependencies {
-    implementation(platform(libs.vertx.stack.depchain))
-    implementation(libs.vertx.core)
-    implementation(libs.vertx.web)
-    implementation(libs.vertx.lang.kotlin)
-    implementation(libs.vertx.lang.kotlin.coroutines)
-    implementation(libs.vertx.config)
-    implementation(libs.vertx.pg.client)
-    implementation(libs.scram.client)
-    implementation(libs.vertx.redis.client)
-    implementation(libs.vertx.kafka.client)
-    implementation(libs.vertx.service.discovery)
-    implementation(libs.vertx.micrometer.metrics)
-    implementation(libs.micrometer.registry.prometheus.simpleclient)
-    implementation(libs.eureka.client)
-
-    // Flyway (JDBC, 시작 시 블로킹 실행)
-    implementation(libs.flyway.core)
-    implementation(libs.flyway.database.postgresql)
-    implementation(libs.postgresql)
-
-    // JSON 로깅
-    implementation(libs.log4j.core)
-    implementation(libs.log4j.layout.template.json)
-    implementation(libs.log4j.slf4j2.impl)
-
-    implementation(libs.kotlin.reflect)
-    implementation(libs.kotlinx.coroutines.core)
-
-    testImplementation(kotlin("test"))
-    testImplementation(libs.vertx.junit5)
-}
-
-application {
-    mainClass.set("com.cowork.preference.CoworkPreferenceMainKt")
-}
-
-kotlin {
-    compilerOptions { freeCompilerArgs.addAll("-Xjsr305=strict") }
-}
-
-tasks.withType<Test> { useJUnitPlatform() }

--- a/cowork-preference/local.dockerfile
+++ b/cowork-preference/local.dockerfile
@@ -1,21 +1,21 @@
-FROM eclipse-temurin:21-jdk-alpine AS builder
-WORKDIR /workspace
-COPY gradlew gradlew
-COPY gradle gradle
-COPY settings.gradle.kts build.gradle.kts ./
-COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
-COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
-COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
-COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
-COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
-COPY cowork-preference/src cowork-preference/src
-RUN chmod +x gradlew && ./gradlew :cowork-preference:installDist -x test --no-daemon
+# Build stage: compile and package with the Kotlin Toolchain (Amper) CLI.
+# A glibc-based image is used because the Kotlin CLI launcher is not musl-compatible.
+FROM eclipse-temurin:21-jdk AS builder
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://kotl.in/install.sh | KOTLIN_CLI_NO_MODIFY_PATH=1 sh
+ENV PATH="/root/.local/bin:$PATH"
+WORKDIR /workspace/cowork-preference
+COPY cowork-preference/module.yaml module.yaml
+COPY cowork-preference/src src
+RUN kotlin package
 
+# Runtime stage: the executable JAR is a plain JVM artifact, so a small alpine JRE is enough.
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 USER app
 WORKDIR /app
-COPY --from=builder /workspace/cowork-preference/build/install/cowork-preference .
+COPY --from=builder /workspace/cowork-preference/build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar app.jar
 EXPOSE 9001
-ENTRYPOINT ["./bin/cowork-preference"]
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/cowork-preference/local.dockerfile
+++ b/cowork-preference/local.dockerfile
@@ -21,6 +21,9 @@ FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
 COPY --chown=app:app --from=builder /workspace/cowork-preference/build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar app.jar
+# Write logs to a writable, volume-friendly path owned by the non-root user.
+ENV PREFERENCE_LOG_DIR=/var/log/cowork/preference
+RUN mkdir -p /var/log/cowork/preference && chown -R app:app /var/log/cowork
 USER app
 EXPOSE 9001
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/cowork-preference/local.dockerfile
+++ b/cowork-preference/local.dockerfile
@@ -4,8 +4,13 @@ FROM eclipse-temurin:21-jdk AS builder
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://kotl.in/install.sh | KOTLIN_CLI_NO_MODIFY_PATH=1 sh
-ENV PATH="/root/.local/bin:$PATH"
+# Pinned, checksum-verified Kotlin Toolchain (Amper) CLI wrapper for reproducible builds.
+ARG KOTLIN_CLI_VERSION=0.11.0
+ARG KOTLIN_CLI_WRAPPER_SHA256=f53d26ee0bb6ef3078c33bda3c180d19fbca665408c27b62b7dfce335551c3d7
+RUN curl -fsSL -o /usr/local/bin/kotlin \
+      "https://packages.jetbrains.team/maven/p/amper/amper/org/jetbrains/kotlin/kotlin-cli/${KOTLIN_CLI_VERSION}/kotlin-cli-${KOTLIN_CLI_VERSION}-wrapper" \
+    && echo "${KOTLIN_CLI_WRAPPER_SHA256}  /usr/local/bin/kotlin" | sha256sum -c - \
+    && chmod +x /usr/local/bin/kotlin
 WORKDIR /workspace/cowork-preference
 COPY cowork-preference/module.yaml module.yaml
 COPY cowork-preference/src src
@@ -14,8 +19,8 @@ RUN kotlin package
 # Runtime stage: the executable JAR is a plain JVM artifact, so a small alpine JRE is enough.
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
-USER app
 WORKDIR /app
-COPY --from=builder /workspace/cowork-preference/build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar app.jar
+COPY --chown=app:app --from=builder /workspace/cowork-preference/build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar app.jar
+USER app
 EXPOSE 9001
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/cowork-preference/module.yaml
+++ b/cowork-preference/module.yaml
@@ -1,0 +1,36 @@
+product: jvm/app
+layout: maven-like
+dependencies:
+  - bom: io.vertx:vertx-stack-depchain:4.5.10
+  - io.vertx:vertx-core
+  - io.vertx:vertx-web
+  - io.vertx:vertx-lang-kotlin
+  - io.vertx:vertx-lang-kotlin-coroutines
+  - io.vertx:vertx-config
+  - io.vertx:vertx-pg-client
+  - io.vertx:vertx-redis-client
+  - io.vertx:vertx-kafka-client
+  - io.vertx:vertx-service-discovery
+  - io.vertx:vertx-micrometer-metrics
+  - com.ongres.scram:client:2.1
+  - io.micrometer:micrometer-registry-prometheus-simpleclient:1.14.5
+  - com.netflix.eureka:eureka-client:2.0.6
+  - org.flywaydb:flyway-core:10.15.0
+  - org.flywaydb:flyway-database-postgresql:10.15.0
+  - org.postgresql:postgresql:42.7.3
+  - org.apache.logging.log4j:log4j-core:2.24.3
+  - org.apache.logging.log4j:log4j-layout-template-json:2.24.3
+  - org.apache.logging.log4j:log4j-slf4j2-impl:2.24.3
+  - $kotlin.reflect
+  - org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1
+
+test-dependencies:
+  - io.vertx:vertx-junit5:4.5.10
+
+settings:
+  jvm:
+    mainClass: com.cowork.preference.CoworkPreferenceMainKt
+    release: 21
+  kotlin:
+    version: 2.1.20
+    freeCompilerArgs: [-Xjsr305=strict]

--- a/cowork-preference/prod.dockerfile
+++ b/cowork-preference/prod.dockerfile
@@ -1,22 +1,22 @@
-FROM eclipse-temurin:21-jdk-alpine AS builder
-WORKDIR /workspace
-COPY gradlew gradlew
-COPY gradle gradle
-COPY settings.gradle.kts build.gradle.kts ./
-COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
-COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
-COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
-COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
-COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
-COPY cowork-preference/src cowork-preference/src
-RUN chmod +x gradlew && ./gradlew :cowork-preference:installDist -x test --no-daemon
+# Build stage: compile and package with the Kotlin Toolchain (Amper) CLI.
+# A glibc-based image is used because the Kotlin CLI launcher is not musl-compatible.
+FROM eclipse-temurin:21-jdk AS builder
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -fsSL https://kotl.in/install.sh | KOTLIN_CLI_NO_MODIFY_PATH=1 sh
+ENV PATH="/root/.local/bin:$PATH"
+WORKDIR /workspace/cowork-preference
+COPY cowork-preference/module.yaml module.yaml
+COPY cowork-preference/src src
+RUN kotlin package
 
+# Runtime stage: the executable JAR is a plain JVM artifact, so a small alpine JRE is enough.
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
-COPY --from=builder /workspace/cowork-preference/build/install/cowork-preference .
+COPY --from=builder /workspace/cowork-preference/build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar app.jar
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
 USER app
 EXPOSE 9001
-ENTRYPOINT ["./bin/cowork-preference"]
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/cowork-preference/prod.dockerfile
+++ b/cowork-preference/prod.dockerfile
@@ -22,6 +22,9 @@ RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
 COPY --chown=app:app --from=builder /workspace/cowork-preference/build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar app.jar
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
+# Write logs to a writable, volume-friendly path owned by the non-root user.
+ENV PREFERENCE_LOG_DIR=/var/log/cowork/preference
+RUN mkdir -p /var/log/cowork/preference && chown -R app:app /var/log/cowork
 USER app
 EXPOSE 9001
 ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]

--- a/cowork-preference/prod.dockerfile
+++ b/cowork-preference/prod.dockerfile
@@ -4,8 +4,13 @@ FROM eclipse-temurin:21-jdk AS builder
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL https://kotl.in/install.sh | KOTLIN_CLI_NO_MODIFY_PATH=1 sh
-ENV PATH="/root/.local/bin:$PATH"
+# Pinned, checksum-verified Kotlin Toolchain (Amper) CLI wrapper for reproducible builds.
+ARG KOTLIN_CLI_VERSION=0.11.0
+ARG KOTLIN_CLI_WRAPPER_SHA256=f53d26ee0bb6ef3078c33bda3c180d19fbca665408c27b62b7dfce335551c3d7
+RUN curl -fsSL -o /usr/local/bin/kotlin \
+      "https://packages.jetbrains.team/maven/p/amper/amper/org/jetbrains/kotlin/kotlin-cli/${KOTLIN_CLI_VERSION}/kotlin-cli-${KOTLIN_CLI_VERSION}-wrapper" \
+    && echo "${KOTLIN_CLI_WRAPPER_SHA256}  /usr/local/bin/kotlin" | sha256sum -c - \
+    && chmod +x /usr/local/bin/kotlin
 WORKDIR /workspace/cowork-preference
 COPY cowork-preference/module.yaml module.yaml
 COPY cowork-preference/src src
@@ -15,7 +20,7 @@ RUN kotlin package
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
-COPY --from=builder /workspace/cowork-preference/build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar app.jar
+COPY --chown=app:app --from=builder /workspace/cowork-preference/build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar app.jar
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
 USER app
 EXPOSE 9001


### PR DESCRIPTION
## 개요

`cowork-preference` 모듈의 빌드를 Gradle에서 Amper(Kotlin Toolchain)로 전환하였습니다. 멀티모듈 통합은 그대로 유지하기 위해 `settings.gradle.kts`의 `include`를 남기고, Gradle 빌드를 Amper CLI에 위임하는 래퍼 구조를 사용하였습니다. 더불어 CI 빌드 매트릭스의 스키마를 빌드 방식(`build`) 단일 축으로 일관화하였습니다.

## 본문

### `cowork-preference` Amper 전환

- `module.yaml`을 추가하여 의존성과 컴파일 설정의 단일 출처로 삼았습니다. `layout: maven-like`를 사용해 기존 `src/main/kotlin` 디렉터리 구조를 그대로 유지하였습니다.
- `build.gradle.kts`를 Exec 위임 래퍼로 교체하였습니다. `base` 플러그인의 lifecycle(`assemble`/`check`/`clean`)에 연결되어 `./gradlew :cowork-preference:build` 같은 기존 명령이 그대로 동작하며, 실제 빌드는 `kotlin` CLI로 위임됩니다. CLI 위치는 `KOTLIN_CLI` 환경변수로 재정의할 수 있습니다.
- `local.dockerfile`, `prod.dockerfile`을 `installDist` 방식에서 Amper의 executable JAR 방식으로 변경하였습니다. 빌더 스테이지에서 Kotlin Toolchain CLI를 설치해 `kotlin package`를 수행하고, 런타임 스테이지에서 `java -jar`로 실행합니다.

### CI 빌드 매트릭스 일관화

- 매트릭스의 `lang` 필드를 빌드 방식을 의미하는 `build` 필드로 통일하였습니다(`gradle`/`amper`/`go`/`node`/`elixir`). 이로써 `amper`가 다른 빌드 방식과 동일한 1급 항목으로 자리잡았습니다.
- 모든 entry가 `working-directory`를 갖도록 정리하고, `gradle-task`는 제거하여 `service` 값에서 `:${service}:build`로 유도하도록 하였습니다. `go-build`는 `build-command`로 이름을 통일하였습니다.
- 빌드 스텝 이름을 `Build & Test (...)` 패턴으로 통일하고, 흩어져 있던 `Vet (Go)`/`Test (Go)`/`Build (Go)`와 `Install Dependencies (Node)`/`Build (Node)` 스텝을 각각 하나로 통합하였습니다.
- `cowork-stage-ci.yml`, `cowork-prod-ci.yml` 양쪽에 동일하게 적용하였습니다.

### 검증

- `kotlin build` / `kotlin package` 성공 및 executable JAR 실행(메인 진입, 로깅, Config Server 연결 시도)을 확인하였습니다.
- `./gradlew :cowork-preference:build` 위임 빌드와 `clean` 위임 동작을 확인하였습니다.
- 양쪽 워크플로의 YAML 유효성과 dispatch 매트릭스 JSON 파싱을 확인하였습니다.

> 참고: Amper는 아직 experimental 단계로, 이번 전환은 Spring에 의존하지 않는 `cowork-preference`(Vert.x) 한정 적용입니다. Docker 이미지 빌드는 로컬 환경 제약으로 실연하지 못하여, 빌더 스테이지의 `kotlin package` 동작은 최초 이미지 빌드 시 확인이 필요합니다.
