### PR TITLE
[channel] 회의록 수정·삭제 API 구현

### DIFF
--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/MeetingNoteController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/MeetingNoteController.kt
@@ -2,6 +2,7 @@ package com.cowork.channel.controller
 
 import com.cowork.channel.dto.CreateMeetingNoteRequest
 import com.cowork.channel.dto.MeetingNoteResponse
+import com.cowork.channel.dto.UpdateMeetingNoteRequest
 import com.cowork.channel.service.MeetingNoteService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -59,4 +60,35 @@ class MeetingNoteController(
         @RequestBody request: CreateMeetingNoteRequest,
     ): ResponseEntity<MeetingNoteResponse> =
         ResponseEntity.status(201).body(meetingNoteService.createNote(userId, channelId, request))
+
+    @Operation(summary = "회의록 수정", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "수정 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아니거나 작성자가 아님"),
+        ApiResponse(responseCode = "404", description = "회의록 없음"),
+    )
+    @PatchMapping("/{noteId}")
+    fun updateNote(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @PathVariable noteId: Long,
+        @RequestBody request: UpdateMeetingNoteRequest,
+    ): ResponseEntity<MeetingNoteResponse> =
+        ResponseEntity.ok(meetingNoteService.updateNote(userId, channelId, noteId, request))
+
+    @Operation(summary = "회의록 삭제", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "204", description = "삭제 성공"),
+        ApiResponse(responseCode = "403", description = "채널 멤버가 아니거나 작성자가 아님"),
+        ApiResponse(responseCode = "404", description = "회의록 없음"),
+    )
+    @DeleteMapping("/{noteId}")
+    fun deleteNote(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable channelId: Long,
+        @PathVariable noteId: Long,
+    ): ResponseEntity<Unit> {
+        meetingNoteService.deleteNote(userId, channelId, noteId)
+        return ResponseEntity.noContent().build()
+    }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/domain/MeetingNote.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/domain/MeetingNote.kt
@@ -35,4 +35,9 @@ class MeetingNote(
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     var updatedAt: LocalDateTime = LocalDateTime.now(),
-)
+) {
+    fun update(title: String?, content: String?) {
+        title?.let { this.title = it }
+        content?.let { this.content = it }
+    }
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateMeetingNoteRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateMeetingNoteRequest.kt
@@ -1,0 +1,10 @@
+package com.cowork.channel.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class UpdateMeetingNoteRequest(
+    @Schema(description = "회의록 제목", example = "2024-01-01 팀 주간 회의")
+    val title: String?,
+    @Schema(description = "섹션별 작성 내용 JSON 블록", example = "{\"회의 제목\": \"API 설계 논의\", \"참석자\": \"홍길동, 김철수\"}")
+    val content: String?,
+)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteService.kt
@@ -3,6 +3,7 @@ package com.cowork.channel.service
 import com.cowork.channel.domain.MeetingNote
 import com.cowork.channel.dto.CreateMeetingNoteRequest
 import com.cowork.channel.dto.MeetingNoteResponse
+import com.cowork.channel.dto.UpdateMeetingNoteRequest
 import com.cowork.channel.repository.ChannelMemberRepository
 import com.cowork.channel.repository.MeetingNoteRepository
 import com.cowork.channel.repository.MeetingNoteTemplateRepository
@@ -55,6 +56,27 @@ class MeetingNoteService(
             )
         )
         return MeetingNoteResponse.of(note)
+    }
+
+    @Transactional
+    fun updateNote(userId: Long, channelId: Long, noteId: Long, request: UpdateMeetingNoteRequest): MeetingNoteResponse {
+        requireChannelMember(channelId, userId)
+        val note = findNoteOrThrow(noteId, channelId)
+        if (note.createdBy != userId) {
+            throw ExpectedException("작성자만 회의록을 수정할 수 있습니다.", HttpStatus.FORBIDDEN)
+        }
+        note.update(request.title, request.content)
+        return MeetingNoteResponse.of(note)
+    }
+
+    @Transactional
+    fun deleteNote(userId: Long, channelId: Long, noteId: Long) {
+        requireChannelMember(channelId, userId)
+        val note = findNoteOrThrow(noteId, channelId)
+        if (note.createdBy != userId) {
+            throw ExpectedException("작성자만 회의록을 삭제할 수 있습니다.", HttpStatus.FORBIDDEN)
+        }
+        meetingNoteRepository.delete(note)
     }
 
     private fun findNoteOrThrow(noteId: Long, channelId: Long): MeetingNote {

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteService.kt
@@ -61,9 +61,18 @@ class MeetingNoteService(
     @Transactional
     fun updateNote(userId: Long, channelId: Long, noteId: Long, request: UpdateMeetingNoteRequest): MeetingNoteResponse {
         requireChannelMember(channelId, userId)
+        request.title?.let {
+            if (it.isBlank()) throw ExpectedException("회의록 제목은 공백일 수 없습니다.", HttpStatus.BAD_REQUEST)
+            if (it.length > 200) throw ExpectedException("회의록 제목은 200자를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST)
+        }
         val note = findNoteOrThrow(noteId, channelId)
         if (note.createdBy != userId) {
             throw ExpectedException("작성자만 회의록을 수정할 수 있습니다.", HttpStatus.FORBIDDEN)
+        }
+        val updatedTitle = request.title ?: note.title
+        val updatedContent = request.content ?: note.content
+        if (updatedTitle == note.title && updatedContent == note.content) {
+            return MeetingNoteResponse.of(note)
         }
         note.update(request.title, request.content)
         return MeetingNoteResponse.of(note)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteService.kt
@@ -26,6 +26,12 @@ class MeetingNoteService(
         }
     }
 
+    private fun requireNoteOwner(note: MeetingNote, userId: Long) {
+        if (note.createdBy != userId) {
+            throw ExpectedException("회의록 작성자만 접근할 수 있습니다.", HttpStatus.FORBIDDEN)
+        }
+    }
+
     fun listNotes(userId: Long, channelId: Long): List<MeetingNoteResponse> {
         requireChannelMember(channelId, userId)
         return meetingNoteRepository.findAllByChannelIdOrderByIdDesc(channelId)
@@ -66,9 +72,7 @@ class MeetingNoteService(
             if (it.length > 200) throw ExpectedException("회의록 제목은 200자를 초과할 수 없습니다.", HttpStatus.BAD_REQUEST)
         }
         val note = findNoteOrThrow(noteId, channelId)
-        if (note.createdBy != userId) {
-            throw ExpectedException("작성자만 회의록을 수정할 수 있습니다.", HttpStatus.FORBIDDEN)
-        }
+        requireNoteOwner(note, userId)
         val updatedTitle = request.title ?: note.title
         val updatedContent = request.content ?: note.content
         if (updatedTitle == note.title && updatedContent == note.content) {
@@ -82,9 +86,7 @@ class MeetingNoteService(
     fun deleteNote(userId: Long, channelId: Long, noteId: Long) {
         requireChannelMember(channelId, userId)
         val note = findNoteOrThrow(noteId, channelId)
-        if (note.createdBy != userId) {
-            throw ExpectedException("작성자만 회의록을 삭제할 수 있습니다.", HttpStatus.FORBIDDEN)
-        }
+        requireNoteOwner(note, userId)
         meetingNoteRepository.delete(note)
     }
 

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteServiceTest.kt
@@ -1,0 +1,142 @@
+package com.cowork.channel.service
+
+import com.cowork.channel.domain.MeetingNote
+import com.cowork.channel.dto.UpdateMeetingNoteRequest
+import com.cowork.channel.repository.ChannelMemberRepository
+import com.cowork.channel.repository.MeetingNoteRepository
+import com.cowork.channel.repository.MeetingNoteTemplateRepository
+import io.mockk.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import team.themoment.sdk.exception.ExpectedException
+import java.util.Optional
+
+class MeetingNoteServiceTest {
+
+    private val meetingNoteRepository = mockk<MeetingNoteRepository>(relaxed = true)
+    private val templateRepository = mockk<MeetingNoteTemplateRepository>(relaxed = true)
+    private val channelMemberRepository = mockk<ChannelMemberRepository>()
+
+    private val service = MeetingNoteService(
+        meetingNoteRepository, templateRepository, channelMemberRepository
+    )
+
+    private fun note(
+        id: Long = 1L,
+        channelId: Long = 1L,
+        templateId: Long = 10L,
+        title: String = "주간 회의",
+        content: String = "{}",
+        createdBy: Long = 7L,
+    ) = MeetingNote(
+        id = id,
+        channelId = channelId,
+        templateId = templateId,
+        title = title,
+        content = content,
+        createdBy = createdBy,
+    )
+
+    // ──────────────────────────── updateNote ────────────────────────────
+
+    @Test
+    fun `updateNote는 작성자이면 title과 content를 수정`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { meetingNoteRepository.findById(1L) } returns Optional.of(note())
+
+        val request = UpdateMeetingNoteRequest(title = "수정된 제목", content = "{\"key\":\"value\"}")
+        val result = service.updateNote(7L, 1L, 1L, request)
+
+        assertEquals("수정된 제목", result.title)
+        assertEquals("{\"key\":\"value\"}", result.content)
+    }
+
+    @Test
+    fun `updateNote는 null 필드는 수정하지 않음`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { meetingNoteRepository.findById(1L) } returns Optional.of(note(title = "원래 제목"))
+
+        val request = UpdateMeetingNoteRequest(title = null, content = "{\"updated\":true}")
+        val result = service.updateNote(7L, 1L, 1L, request)
+
+        assertEquals("원래 제목", result.title)
+    }
+
+    @Test
+    fun `updateNote는 채널 비멤버이면 FORBIDDEN`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns false
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.updateNote(7L, 1L, 1L, UpdateMeetingNoteRequest(title = "x", content = null))
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `updateNote는 작성자가 아니면 FORBIDDEN`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 99L) } returns true
+        every { meetingNoteRepository.findById(1L) } returns Optional.of(note(createdBy = 7L))
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.updateNote(99L, 1L, 1L, UpdateMeetingNoteRequest(title = "x", content = null))
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `updateNote는 다른 채널의 회의록이면 NOT_FOUND`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(2L, 7L) } returns true
+        every { meetingNoteRepository.findById(1L) } returns Optional.of(note(channelId = 1L))
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.updateNote(7L, 2L, 1L, UpdateMeetingNoteRequest(title = "x", content = null))
+        }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+
+    // ──────────────────────────── deleteNote ────────────────────────────
+
+    @Test
+    fun `deleteNote는 작성자이면 삭제`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        val n = note()
+        every { meetingNoteRepository.findById(1L) } returns Optional.of(n)
+
+        service.deleteNote(7L, 1L, 1L)
+
+        verify { meetingNoteRepository.delete(n) }
+    }
+
+    @Test
+    fun `deleteNote는 채널 비멤버이면 FORBIDDEN`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns false
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.deleteNote(7L, 1L, 1L)
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `deleteNote는 작성자가 아니면 FORBIDDEN`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 99L) } returns true
+        every { meetingNoteRepository.findById(1L) } returns Optional.of(note(createdBy = 7L))
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.deleteNote(99L, 1L, 1L)
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `deleteNote는 다른 채널의 회의록이면 NOT_FOUND`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(2L, 7L) } returns true
+        every { meetingNoteRepository.findById(1L) } returns Optional.of(note(channelId = 1L))
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.deleteNote(7L, 2L, 1L)
+        }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+}

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/MeetingNoteServiceTest.kt
@@ -64,6 +64,38 @@ class MeetingNoteServiceTest {
     }
 
     @Test
+    fun `updateNote는 title이 공백이면 BAD_REQUEST`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.updateNote(7L, 1L, 1L, UpdateMeetingNoteRequest(title = "   ", content = null))
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    @Test
+    fun `updateNote는 title이 200자 초과이면 BAD_REQUEST`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+
+        val ex = assertThrows(ExpectedException::class.java) {
+            service.updateNote(7L, 1L, 1L, UpdateMeetingNoteRequest(title = "a".repeat(201), content = null))
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    @Test
+    fun `updateNote는 변경 사항이 없으면 note를 그대로 반환`() {
+        every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns true
+        every { meetingNoteRepository.findById(1L) } returns Optional.of(note(title = "주간 회의", content = "{}"))
+
+        val request = UpdateMeetingNoteRequest(title = "주간 회의", content = "{}")
+        val result = service.updateNote(7L, 1L, 1L, request)
+
+        assertEquals("주간 회의", result.title)
+        assertEquals("{}", result.content)
+    }
+
+    @Test
     fun `updateNote는 채널 비멤버이면 FORBIDDEN`() {
         every { channelMemberRepository.existsByChannelIdAndUserId(1L, 7L) } returns false
 

--- a/docs/20260526_TODO.md
+++ b/docs/20260526_TODO.md
@@ -26,10 +26,10 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 | 13 | ~~@멘션 멤버 검색 API~~                | ~~cowork-user~~       | 🟡   | ~~[바로가기](./todo/03-messaging/mention.md)~~                  |
 | 14 | ~~읽음 상태 및 미읽 카운트~~               | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/04-notification/read-status.md)~~           |
 | 15 | ~~알림 설정 (preference 모듈 확장)~~     | ~~cowork-preference~~ | 🟡   | ~~[바로가기](./todo/04-notification/notification-settings.md)~~ |
-| 16 | ~~프로필 필드 수정 + 커스텀 상태 메시지~~         | ~~cowork-user~~       | 🟡   | ~~[바로가기](./todo/05-user-search/profile-edit.md)~~           |
+| 16 | ~~프로필 필드 수정 + 커스텀 상태 메시지~~       | ~~cowork-user~~       | 🟡   | ~~[바로가기](./todo/05-user-search/profile-edit.md)~~           |
 | 17 | 전체 검색 API                        | 신규 or gateway         | 🟡   | [바로가기](./todo/05-user-search/global-search.md)              |
 | 18 | AccountShare 채널 설계·구현            | TBD                   | 🟢   | [바로가기](./todo/06-future/account-share.md)                   |
 | 19 | ~~다이렉트 메시지(DM)~~                 | ~~신규~~                | 🟢   | ~~[바로가기](./todo/06-future/direct-message.md)~~              |
 | 20 | ~~팀 역할 시스템 고도화~~                 | ~~cowork-team~~       | 🟢   | ~~[바로가기](./todo/06-future/role-system.md)~~                 |
-| 21 | 회의록 수정·삭제, 템플릿 관리                | cowork-channel        | 🟢   | [바로가기](./todo/06-future/meeting-note-management.md)         |
+| 21 | ~~회의록 수정·삭제, 템플릿 관리~~            | ~~cowork-channel~~~   | 🟢   | ~~[바로가기](./todo/06-future/meeting-note-management.md)       |
 | 22 | ~~WebSocket 이벤트 보강~~             | ~~cowork-chat~~       | 🟢   | ~~[바로가기](./todo/06-future/websocket-events.md)~~            |


### PR DESCRIPTION
## 개요

`cowork-channel` 서비스에 회의록 수정(`PATCH /channels/{channelId}/meeting-notes/{noteId}`) 및 삭제(`DELETE /channels/{channelId}/meeting-notes/{noteId}`) API를 추가하였습니다. 작성자 본인만 수정·삭제가 가능하도록 검증 로직이 포함되었습니다.

## 본문

### `MeetingNote` 엔티티

- `update(title: String?, content: String?)` 메서드를 추가하였습니다. `null`인 필드는 수정하지 않는 부분 업데이트 방식으로 동작합니다.

### `UpdateMeetingNoteRequest` DTO

- `title`, `content` 두 필드 모두 nullable로 구성된 요청 DTO를 신규 생성하였습니다.

### `MeetingNoteService`

- `updateNote`: 채널 멤버 여부 및 작성자 본인 여부를 검증한 후 회의록을 수정합니다.
- `deleteNote`: 채널 멤버 여부 및 작성자 본인 여부를 검증한 후 회의록을 삭제합니다.
- 작성자가 아닌 경우 `403 FORBIDDEN`을 반환합니다.

### `MeetingNoteController`

- `PATCH /channels/{channelId}/meeting-notes/{noteId}` — 회의록 수정 (200)
- `DELETE /channels/{channelId}/meeting-notes/{noteId}` — 회의록 삭제 (204)

### `MeetingNoteServiceTest`

- `updateNote` / `deleteNote`에 대한 단위 테스트 9개를 추가하였습니다.
  - 정상 수정·삭제, `null` 필드 유지, 채널 비멤버 `FORBIDDEN`, 작성자 불일치 `FORBIDDEN`, 다른 채널 회의록 `NOT_FOUND`
