### PR TITLE
[global] 전체 검색 API 구현 (메시지·채널·멤버)

### DIFF
--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/SearchChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/SearchChannelController.kt
@@ -1,0 +1,36 @@
+package com.cowork.channel.controller
+
+import com.cowork.channel.dto.ChannelResponse
+import com.cowork.channel.service.ChannelService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "검색", description = "전체 검색 API")
+@RestController
+@RequestMapping("/search")
+class SearchChannelController(
+    private val channelService: ChannelService,
+) {
+
+    @Operation(summary = "채널 검색", security = [SecurityRequirement(name = "BearerAuth")])
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "검색 성공"),
+        ApiResponse(responseCode = "403", description = "팀 멤버가 아님"),
+    )
+    @GetMapping("/channels")
+    fun searchChannels(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @RequestParam teamId: Long,
+        @RequestParam q: String,
+    ): List<ChannelResponse> =
+        channelService.searchChannels(userId, teamId, q)
+}

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/repository/ChannelRepository.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/repository/ChannelRepository.kt
@@ -23,4 +23,7 @@ interface ChannelRepository : JpaRepository<Channel, Long> {
 
     @Query("SELECT c.id FROM Channel c WHERE c.teamId = :teamId AND c.createdBy <> :createdBy ORDER BY c.id ASC")
     fun findIdsByTeamIdAndCreatedByNot(@Param("teamId") teamId: Long, @Param("createdBy") createdBy: Long): List<Long>
+
+    @Query("SELECT c FROM Channel c WHERE c.teamId = :teamId AND LOWER(c.name) LIKE LOWER(CONCAT('%', :q, '%')) ORDER BY c.position ASC, c.id ASC")
+    fun searchByTeamIdAndName(@Param("teamId") teamId: Long, @Param("q") q: String): List<Channel>
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
@@ -131,6 +131,7 @@ class ChannelService(
 
     fun searchChannels(userId: Long, teamId: Long, q: String): List<ChannelResponse> {
         teamPermissionService.requireTeamMember(teamId, userId)
+        if (q.isBlank()) return emptyList()
         return channelRepository.searchByTeamIdAndName(teamId, q).map { ChannelResponse.of(it) }
     }
 

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
@@ -129,6 +129,11 @@ class ChannelService(
         return ChannelResponse.of(channel)
     }
 
+    fun searchChannels(userId: Long, teamId: Long, q: String): List<ChannelResponse> {
+        teamPermissionService.requireTeamMember(teamId, userId)
+        return channelRepository.searchByTeamIdAndName(teamId, q).map { ChannelResponse.of(it) }
+    }
+
     fun listProjectChannels(userId: Long, projectId: Long): List<ChannelResponse> {
         val teamId = projectClient.getTeamId(projectId)
         teamPermissionService.requireTeamMember(teamId, userId)

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -10,6 +10,7 @@ import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
 import { ProjectMessageController } from './project-message.controller';
 import { TeamUnreadController } from './team-unread.controller';
+import { TeamSearchController } from './team-search.controller';
 import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { NotificationTriggerProducer } from './kafka/notification-trigger.producer';
@@ -110,7 +111,7 @@ function createLogStream() {
         MinioModule,
         SearchModule,
     ],
-    controllers: [ChatController, ProjectMessageController, TeamUnreadController, HealthController],
+    controllers: [ChatController, ProjectMessageController, TeamUnreadController, TeamSearchController, HealthController],
     providers: [
         ChatGateway,
         ChatService,

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -28,6 +28,7 @@ import {
 import { CreateGithubIssueDto } from './dto/create-github-issue.dto';
 import { SlashCommand, SlashCommandDto } from './dto/slash-command.dto';
 import { SearchMessagesDto } from './dto/search-messages.dto';
+import { SearchTeamMessagesDto } from './dto/search-team-messages.dto';
 import { SearchMessagesResponseDto } from './dto/search-message-response.dto';
 import { FileListQueryDto, FileListResponseDto } from './dto/file-list.dto';
 import { MessageRepository, MessageRow } from './repository/message.repository';
@@ -342,6 +343,38 @@ export class ChatService {
         const { hits, nextCursor } = await this.elasticsearchService.searchMessages({
             projectId,
             accessibleChannelIds: filteredChannelIds,
+            q: dto.q,
+            authorId: dto.authorId,
+            type: dto.type,
+            hasFile: dto.hasFile,
+            before: dto.before,
+            limit: dto.limit ?? 50,
+        });
+
+        return { messages: hits, nextCursor };
+    }
+
+    async searchTeamMessages(
+        teamId: number,
+        dto: SearchTeamMessagesDto,
+        ctx: UserContext,
+    ): Promise<SearchMessagesResponseDto> {
+        const isMember = await this.channelMemberRepository.existsByTeam(teamId, ctx.userId);
+        if (!isMember) throw new ForbiddenException('팀 접근 권한이 없습니다');
+
+        const memberships = await this.channelMemberRepository.findMembersByTeam(teamId, ctx.userId);
+        let accessibleChannelIds = memberships.map((m) => m.channelId);
+
+        if (dto.channelId !== undefined) {
+            if (!accessibleChannelIds.includes(dto.channelId)) {
+                throw new ForbiddenException('채널 접근 권한이 없습니다');
+            }
+            accessibleChannelIds = [dto.channelId];
+        }
+
+        const { hits, nextCursor } = await this.elasticsearchService.searchTeamMessages({
+            teamId,
+            accessibleChannelIds,
             q: dto.q,
             authorId: dto.authorId,
             type: dto.type,

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -372,6 +372,10 @@ export class ChatService {
             accessibleChannelIds = [dto.channelId];
         }
 
+        if (accessibleChannelIds.length === 0) {
+            return { messages: [], nextCursor: null };
+        }
+
         const { hits, nextCursor } = await this.elasticsearchService.searchTeamMessages({
             teamId,
             accessibleChannelIds,

--- a/cowork-chat/src/chat/dto/search-team-messages.dto.ts
+++ b/cowork-chat/src/chat/dto/search-team-messages.dto.ts
@@ -1,0 +1,29 @@
+import { IsString, IsOptional, IsInt, IsEnum, IsBoolean, Min, Max, MinLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Transform, Type } from 'class-transformer';
+
+export class SearchTeamMessagesDto {
+    @ApiProperty({ description: '검색 키워드 (최소 1자)', minLength: 1 })
+    @IsString() @MinLength(1) q!: string;
+
+    @ApiProperty({ description: '팀 ID' })
+    @IsInt() @Type(() => Number) teamId!: number;
+
+    @ApiPropertyOptional({ description: '특정 채널로 범위 축소' })
+    @IsInt() @IsOptional() @Type(() => Number) channelId?: number;
+
+    @ApiPropertyOptional({ description: '특정 작성자 필터' })
+    @IsInt() @IsOptional() @Type(() => Number) authorId?: number;
+
+    @ApiPropertyOptional({ enum: ['TEXT', 'FILE', 'SYSTEM'], description: '메시지 타입 필터' })
+    @IsEnum(['TEXT', 'FILE', 'SYSTEM']) @IsOptional() type?: string;
+
+    @ApiPropertyOptional({ description: '첨부파일 포함 메시지만 조회' })
+    @IsBoolean() @IsOptional() @Transform(({ value }) => value === 'true' || value === true) hasFile?: boolean;
+
+    @ApiPropertyOptional({ description: '커서: 이전 응답의 nextCursor 값' })
+    @IsString() @IsOptional() before?: string;
+
+    @ApiPropertyOptional({ description: '페이지 크기 (기본 50, 최대 100)', default: 50 })
+    @IsInt() @Min(1) @Max(100) @IsOptional() @Type(() => Number) limit?: number;
+}

--- a/cowork-chat/src/chat/team-search.controller.ts
+++ b/cowork-chat/src/chat/team-search.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { ApiHeader, ApiOperation, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { ChatService } from './chat.service';
+import { SearchTeamMessagesDto } from './dto/search-team-messages.dto';
+import { SearchMessagesResponseDto } from './dto/search-message-response.dto';
+import { UserId } from '../common/decorator/user.decorator';
+
+@ApiTags('Search')
+@ApiHeader({ name: 'X-User-Id', description: 'Gateway 주입 유저 ID', required: true })
+@Controller('search')
+export class TeamSearchController {
+    constructor(private readonly chatService: ChatService) {}
+
+    @Get('messages')
+    @ApiOperation({
+        summary: '팀 채팅 메시지 전체 검색',
+        description:
+            'Elasticsearch 기반 팀 단위 메시지 전문 검색.\n\n' +
+            '- 요청자가 속한 채널 내 메시지만 반환\n' +
+            '- 한국어 nori 형태소 분석 + fuzzy matching 적용\n' +
+            '- 결과는 최신순 정렬 (createdAt DESC)\n' +
+            '- 커서 기반 페이지네이션: 응답의 `nextCursor`를 다음 요청의 `before`에 전달',
+    })
+    @ApiQuery({ name: 'q', description: '검색 키워드 (최소 1자)', required: true })
+    @ApiQuery({ name: 'teamId', description: '팀 ID', required: true })
+    @ApiQuery({ name: 'channelId', description: '특정 채널로 범위 축소', required: false })
+    @ApiQuery({ name: 'authorId', description: '특정 작성자 ID 필터', required: false })
+    @ApiQuery({ name: 'type', enum: ['TEXT', 'FILE', 'SYSTEM'], description: '메시지 타입 필터', required: false })
+    @ApiQuery({ name: 'hasFile', description: '첨부파일 포함 메시지만 조회 (true/false)', required: false })
+    @ApiQuery({ name: 'before', description: '커서: 이전 응답의 nextCursor 값', required: false })
+    @ApiQuery({ name: 'limit', description: '페이지 크기 (기본 50, 최대 100)', required: false })
+    @ApiResponse({ status: 200, type: SearchMessagesResponseDto })
+    @ApiResponse({ status: 403, description: '팀 멤버 아님 또는 채널 접근 권한 없음' })
+    async searchTeamMessages(
+        @Query() dto: SearchTeamMessagesDto,
+        @UserId() userId: number,
+    ): Promise<SearchMessagesResponseDto> {
+        return this.chatService.searchTeamMessages(dto.teamId, dto, { userId });
+    }
+}

--- a/cowork-chat/src/search/elasticsearch.service.ts
+++ b/cowork-chat/src/search/elasticsearch.service.ts
@@ -29,6 +29,17 @@ export interface SearchMessagesParams {
     limit: number;
 }
 
+export interface SearchTeamMessagesParams {
+    teamId: number;
+    accessibleChannelIds: number[];
+    q: string;
+    authorId?: number;
+    type?: string;
+    hasFile?: boolean;
+    before?: string;
+    limit: number;
+}
+
 export interface SearchHit {
     messageId: string;
     channelId: number;
@@ -137,6 +148,82 @@ export class ElasticsearchService implements OnModuleInit {
             if (err?.statusCode === 404) return;
             this.logger.error(`ES 메시지 삭제 실패 id=${messageId}`, err);
         }
+    }
+
+    async searchTeamMessages(params: SearchTeamMessagesParams): Promise<{ hits: SearchHit[]; nextCursor: string | null }> {
+        const { teamId, accessibleChannelIds, q, authorId, type, hasFile, before, limit } = params;
+
+        const filter: any[] = [];
+        if (authorId !== undefined) filter.push({ term: { authorId } });
+        if (type !== undefined) filter.push({ term: { type } });
+        if (hasFile === true) filter.push({ term: { hasAttachments: true } });
+
+        let searchAfter: any[] | undefined;
+        if (before) {
+            try {
+                searchAfter = JSON.parse(Buffer.from(before, 'base64').toString());
+            } catch {
+                searchAfter = undefined;
+            }
+        }
+
+        const response = await this.client.search({
+            index: INDEX,
+            body: {
+                query: {
+                    bool: {
+                        must: [
+                            { term: { teamId } },
+                            { terms: { channelId: accessibleChannelIds } },
+                            {
+                                bool: {
+                                    should: [
+                                        { match: { content: { query: q, fuzziness: 'AUTO' } } },
+                                        { match_phrase: { content: { query: q, boost: 2 } } },
+                                    ],
+                                    minimum_should_match: 1,
+                                },
+                            },
+                        ],
+                        filter,
+                    },
+                },
+                highlight: {
+                    fields: {
+                        content: {
+                            pre_tags: ['<em>'],
+                            post_tags: ['</em>'],
+                            number_of_fragments: 3,
+                            fragment_size: 150,
+                        },
+                    },
+                },
+                sort: [{ createdAt: 'desc' }, { messageId: 'desc' }],
+                size: limit,
+                ...(searchAfter ? { search_after: searchAfter } : {}),
+            },
+        });
+
+        const rawHits = (response as any).hits?.hits ?? [];
+
+        const hits: SearchHit[] = rawHits.map((hit: any) => ({
+            messageId: hit._source.messageId,
+            channelId: hit._source.channelId,
+            authorId: hit._source.authorId,
+            content: hit._source.content,
+            highlight: hit.highlight?.content ?? [],
+            type: hit._source.type,
+            hasAttachments: hit._source.hasAttachments,
+            isPinned: hit._source.isPinned,
+            createdAt: hit._source.createdAt,
+        }));
+
+        const lastHit = rawHits.at(-1);
+        const nextCursor = hits.length === limit && lastHit?.sort
+            ? Buffer.from(JSON.stringify(lastHit.sort)).toString('base64')
+            : null;
+
+        return { hits, nextCursor };
     }
 
     async searchMessages(params: SearchMessagesParams): Promise<{ hits: SearchHit[]; nextCursor: string | null }> {

--- a/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
@@ -95,6 +95,31 @@ spring:
                 name: defaultCB
                 fallbackUri: forward:/fallback
 
+        - id: chat-service-team-search
+          uri: lb://cowork-chat
+          predicates:
+            - Path=/api/search/messages
+            - Method=GET
+          filters:
+            - StripPrefix=1
+            - PrefixPath=/chat
+            - name: CircuitBreaker
+              args:
+                name: defaultCB
+                fallbackUri: forward:/fallback
+
+        - id: channel-service-search
+          uri: lb://cowork-channel
+          predicates:
+            - Path=/api/search/channels
+            - Method=GET
+          filters:
+            - StripPrefix=1
+            - name: CircuitBreaker
+              args:
+                name: defaultCB
+                fallbackUri: forward:/fallback
+
         - id: project-service
           uri: lb://cowork-project
           predicates:

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -133,6 +133,23 @@ spring:
             - StripPrefix=1
             - PrefixPath=/chat
 
+        - id: chat-service-team-search
+          uri: lb://cowork-chat
+          predicates:
+            - Path=/api/search/messages
+            - Method=GET
+          filters:
+            - StripPrefix=1
+            - PrefixPath=/chat
+
+        - id: channel-service-search
+          uri: lb://cowork-channel
+          predicates:
+            - Path=/api/search/channels
+            - Method=GET
+          filters:
+            - StripPrefix=1
+
         - id: project-service
           uri: lb://cowork-project
           predicates:

--- a/cowork-user/lib/cowork_user/accounts.ex
+++ b/cowork-user/lib/cowork_user/accounts.ex
@@ -233,7 +233,7 @@ defmodule CoworkUser.Accounts do
         |> maybe_equals(:student_role, Map.get(params, "student_role"), :account)
         |> maybe_equals(:status, Map.get(params, "status"), :account)
         |> maybe_role(Map.get(params, "role"))
-        |> maybe_query(Map.get(params, "query"))
+        |> maybe_query(Map.get(params, "q") || Map.get(params, "query"))
         |> maybe_user_ids(Map.get(params, "user_ids"))
 
       total_count =

--- a/docs/20260526_TODO.md
+++ b/docs/20260526_TODO.md
@@ -27,7 +27,7 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 | 14 | ~~읽음 상태 및 미읽 카운트~~               | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/04-notification/read-status.md)~~           |
 | 15 | ~~알림 설정 (preference 모듈 확장)~~     | ~~cowork-preference~~ | 🟡   | ~~[바로가기](./todo/04-notification/notification-settings.md)~~ |
 | 16 | ~~프로필 필드 수정 + 커스텀 상태 메시지~~       | ~~cowork-user~~       | 🟡   | ~~[바로가기](./todo/05-user-search/profile-edit.md)~~           |
-| 17 | 전체 검색 API                        | 신규 or gateway         | 🟡   | [바로가기](./todo/05-user-search/global-search.md)              |
+| 17 | ~~전체 검색 API~~                      | ~~신규 or gateway~~      | 🟡   | ~~[바로가기](./todo/05-user-search/global-search.md)~~          |
 | 18 | AccountShare 채널 설계·구현            | TBD                   | 🟢   | [바로가기](./todo/06-future/account-share.md)                   |
 | 19 | ~~다이렉트 메시지(DM)~~                 | ~~신규~~                | 🟢   | ~~[바로가기](./todo/06-future/direct-message.md)~~              |
 | 20 | ~~팀 역할 시스템 고도화~~                 | ~~cowork-team~~       | 🟢   | ~~[바로가기](./todo/06-future/role-system.md)~~                 |


### PR DESCRIPTION
## 개요

`cowork-chat`, `cowork-channel`, `cowork-user` 세 서비스에 걸쳐 전체 검색 API 세 개를 구현하였습니다. 팀 단위 메시지 검색, 채널 이름 검색, 멤버 검색을 각각 담당하며, `cowork-gateway`에 해당 라우팅을 추가하였습니다.

## 본문

### `GET /api/search/messages?q=...&teamId=...` (cowork-chat)

- `ElasticsearchService`에 `searchTeamMessages` 메서드를 추가하였습니다. 기존 `searchMessages`가 `projectId` 단위로 검색하던 것과 달리 `teamId`를 기준으로 필터링합니다.
- 요청자가 속한 채널 ID만 `accessibleChannelIds`로 전달하여 비공개 채널 메시지가 노출되지 않도록 하였습니다.
- `SearchTeamMessagesDto`, `TeamSearchController`를 신규 생성하였고 `ChatModule`에 등록하였습니다.
- `channelId`, `authorId`, `type`, `hasFile`, 커서 기반 페이지네이션(`before`, `limit`) 필터를 모두 지원합니다.

### `GET /api/search/channels?q=...&teamId=...` (cowork-channel)

- `ChannelRepository`에 `searchByTeamIdAndName` JPQL 쿼리를 추가하였습니다. 팀 내 채널 이름을 대소문자 구분 없이 `LIKE` 검색합니다.
- `ChannelService.searchChannels`에서 팀 멤버십을 검증한 후 결과를 반환합니다.
- `SearchChannelController`를 `/search/channels` 경로로 신규 생성하였습니다.

### `GET /api/users/search?q=...&teamId=...` (cowork-user)

- 기존 `Accounts.search_users`는 `query` 파라미터로 이름·닉네임을 검색하고, `teamId`로 팀 멤버 범위를 좁히는 기능이 이미 구현되어 있었습니다.
- 클라이언트 계약(`q` 파라미터)에 맞춰 `Map.get(params, "q")` 를 우선 사용하고, `query` 파라미터도 하위 호환으로 유지하였습니다.

### Gateway 라우팅 (cowork-config)

- `cowork-gateway-dev.yml`, `cowork-gateway-local.yml` 양쪽에 아래 두 라우트를 추가하였습니다.
  - `chat-service-team-search`: `GET /api/search/messages` → `cowork-chat` (`StripPrefix=1` + `PrefixPath=/chat`)
  - `channel-service-search`: `GET /api/search/channels` → `cowork-channel` (`StripPrefix=1`)
