### PR TITLE
[channel] AccountShare 채널 서비스 단위 테스트 추가

### DIFF
--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/CredentialEncryptionServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/CredentialEncryptionServiceTest.kt
@@ -1,0 +1,47 @@
+package com.cowork.channel.service
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.Base64
+
+class CredentialEncryptionServiceTest {
+
+    private val testKey = Base64.getEncoder().encodeToString(ByteArray(32) { it.toByte() })
+    private val service = CredentialEncryptionService(testKey)
+
+    @Test
+    fun `encrypt와 decrypt는 라운드트립이 일치함`() {
+        val plain = "mySecretPassword123"
+        assertEquals(plain, service.decrypt(service.encrypt(plain)))
+    }
+
+    @Test
+    fun `encrypt는 매번 다른 IV를 사용하여 다른 암호문을 생성함`() {
+        val plain = "same-password"
+        assertNotEquals(service.encrypt(plain), service.encrypt(plain))
+    }
+
+    @Test
+    fun `mask는 4자 이하 문자열을 전체 마스킹함`() {
+        assertEquals("••••", service.mask("abc"))
+        assertEquals("••••", service.mask("1234"))
+    }
+
+    @Test
+    fun `mask는 5자 이상이면 ••••로 시작하고 마지막 자리를 노출함`() {
+        val result = service.mask("password123")
+        assertTrue(result.startsWith("••••"))
+        assertTrue(result.length > 4)
+        assertTrue("password123".endsWith(result.removePrefix("••••")))
+    }
+
+    @Test
+    fun `decrypt는 콜론이 없는 잘못된 형식이면 예외가 발생함`() {
+        assertThrows<IllegalArgumentException> {
+            service.decrypt("invalidformatnocolon")
+        }
+    }
+}

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/OAuthAccountServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/OAuthAccountServiceTest.kt
@@ -105,6 +105,7 @@ class OAuthAccountServiceTest {
     // RestClient POST 체인 stubbing 헬퍼
     private fun stubPostReturns(responseBody: Map<*, *>) {
         val postBodySpec = mockk<RestClient.RequestBodySpec>()
+        every { postBodySpec.header(any(), any()) } returns postBodySpec
         every { postBodySpec.contentType(any()) } returns postBodySpec
         every { postBodySpec.accept(any()) } returns postBodySpec
         every { postBodySpec.body(any<Any>()) } returns postBodySpec

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/OAuthAccountServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/OAuthAccountServiceTest.kt
@@ -1,0 +1,247 @@
+package com.cowork.channel.service
+
+import com.cowork.channel.config.OAuthProperties
+import com.cowork.channel.config.OAuthProviderConfig
+import com.cowork.channel.domain.AccountProvider
+import com.cowork.channel.domain.Channel
+import com.cowork.channel.domain.ChannelType
+import com.cowork.channel.domain.ChannelViewType
+import com.cowork.channel.domain.SharedAccount
+import com.cowork.channel.repository.SharedAccountRepository
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestClient
+import team.themoment.sdk.exception.ExpectedException
+import java.time.Instant
+import java.util.Base64
+import java.util.UUID
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+class OAuthAccountServiceTest {
+
+    private val objectMapper = jacksonObjectMapper()
+    private val STATE_SECRET = "test-state-secret-key"
+
+    private val oAuthProperties = OAuthProperties(
+        callbackBaseUrl = "https://example.com",
+        clientRedirectUrl = "https://client.example.com",
+        stateSecret = STATE_SECRET,
+        github = OAuthProviderConfig("gh-id", "gh-secret",
+            "https://github.com/login/oauth/access_token", "https://api.github.com/user", "read:user"),
+        notion = OAuthProviderConfig("no-id", "no-secret",
+            "https://api.notion.com/v1/oauth/token", "https://api.notion.com/v1/users/me", ""),
+        jira = OAuthProviderConfig("jira-id", "jira-secret",
+            "https://auth.atlassian.com/oauth/token", "https://api.atlassian.com/me", "read:me"),
+        google = OAuthProviderConfig("go-id", "go-secret",
+            "https://oauth2.googleapis.com/token", "https://openidconnect.googleapis.com/v1/userinfo", "openid email"),
+        facebook = OAuthProviderConfig("fb-id", "fb-secret",
+            "https://graph.facebook.com/v18.0/oauth/access_token", "https://graph.facebook.com/me", "public_profile"),
+    )
+
+    private val sharedAccountRepository = mockk<SharedAccountRepository>(relaxed = true)
+    private val credentialEncryptionService = mockk<CredentialEncryptionService>(relaxed = true)
+    private val channelService = mockk<ChannelService>()
+    private val teamPermissionService = mockk<TeamPermissionService>()
+
+    private val mockRestClient = mockk<RestClient>(relaxed = true)
+    private val restClientBuilder = mockk<RestClient.Builder>().also {
+        every { it.build() } returns mockRestClient
+    }
+
+    private val service = OAuthAccountService(
+        oAuthProperties,
+        sharedAccountRepository,
+        credentialEncryptionService,
+        channelService,
+        teamPermissionService,
+        objectMapper,
+        restClientBuilder,
+    )
+
+    private fun accountShareChannel(teamId: Long = 100L) = Channel(
+        id = 1L, teamId = teamId, name = "ch", type = ChannelType.TEXT,
+        viewType = ChannelViewType.ACCOUNT_SHARE, description = null,
+        isPrivate = false, position = 0, createdBy = 1L, projectId = null,
+    )
+
+    private fun textChannel() = Channel(
+        id = 1L, teamId = 100L, name = "ch", type = ChannelType.TEXT,
+        viewType = ChannelViewType.TEXT, description = null,
+        isPrivate = false, position = 0, createdBy = 1L, projectId = null,
+    )
+
+    // OAuthAccountService와 동일한 알고리즘으로 state 생성
+    private fun buildValidState(
+        channelId: Long = 1L,
+        userId: Long = 1L,
+        provider: AccountProvider = AccountProvider.GITHUB,
+        expOffset: Long = 300L,
+    ): String {
+        val payload = mapOf(
+            "channelId" to channelId,
+            "userId" to userId,
+            "provider" to provider.name,
+            "nonce" to UUID.randomUUID().toString(),
+            "exp" to (Instant.now().epochSecond + expOffset),
+        )
+        val encoder = Base64.getUrlEncoder().withoutPadding()
+        val payloadB64 = encoder.encodeToString(
+            objectMapper.writeValueAsString(payload).toByteArray(Charsets.UTF_8)
+        )
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(STATE_SECRET.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+        val signature = encoder.encodeToString(mac.doFinal(payloadB64.toByteArray(Charsets.UTF_8)))
+        return "$payloadB64.$signature"
+    }
+
+    // RestClient POST 체인 stubbing 헬퍼
+    private fun stubPostReturns(responseBody: Map<*, *>) {
+        val postBodySpec = mockk<RestClient.RequestBodySpec>()
+        every { postBodySpec.contentType(any()) } returns postBodySpec
+        every { postBodySpec.accept(any()) } returns postBodySpec
+        every { postBodySpec.body(any<Any>()) } returns postBodySpec
+        val postResponseSpec = mockk<RestClient.ResponseSpec>()
+        every { postBodySpec.retrieve() } returns postResponseSpec
+        every { postResponseSpec.body(Map::class.java) } returns responseBody
+
+        val postUriSpec = mockk<RestClient.RequestBodyUriSpec>()
+        every { postUriSpec.uri(any<String>()) } returns postBodySpec
+        every { mockRestClient.post() } returns postUriSpec
+    }
+
+    // RestClient GET 체인 stubbing 헬퍼
+    private fun stubGetReturns(responseBody: Map<*, *>) {
+        val getHeadersSpec = mockk<RestClient.RequestHeadersSpec<*>>()
+        every { getHeadersSpec.header(any(), any()) } returns getHeadersSpec
+        val getResponseSpec = mockk<RestClient.ResponseSpec>()
+        every { getHeadersSpec.retrieve() } returns getResponseSpec
+        every { getResponseSpec.body(Map::class.java) } returns responseBody
+
+        val getUriSpec = mockk<RestClient.RequestHeadersUriSpec<*>>()
+        every { getUriSpec.uri(any<String>()) } returns getHeadersSpec
+        every { mockRestClient.get() } returns getUriSpec
+    }
+
+    // ── buildAuthorizeUrl ──────────────────────────────────────────────────────
+
+    @Test
+    fun `buildAuthorizeUrl는 ACCOUNT_SHARE 채널이 아니면 BAD_REQUEST`() {
+        every { channelService.findChannelOrThrow(1L) } returns textChannel()
+
+        val ex = assertThrows<ExpectedException> {
+            service.buildAuthorizeUrl(1L, 1L, AccountProvider.GITHUB)
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    @Test
+    fun `buildAuthorizeUrl는 팀 비멤버이면 FORBIDDEN`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 7L) } throws
+            ExpectedException("팀 멤버만 접근할 수 있습니다.", HttpStatus.FORBIDDEN)
+
+        val ex = assertThrows<ExpectedException> {
+            service.buildAuthorizeUrl(1L, 7L, AccountProvider.GITHUB)
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `buildAuthorizeUrl는 OAuth 미지원 provider이면 BAD_REQUEST`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+
+        val ex = assertThrows<ExpectedException> {
+            service.buildAuthorizeUrl(1L, 1L, AccountProvider.NPM)
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    @Test
+    fun `buildAuthorizeUrl는 GITHUB provider이면 github 인증 URL을 반환함`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+
+        val url = service.buildAuthorizeUrl(1L, 1L, AccountProvider.GITHUB)
+
+        assertTrue(url.startsWith("https://github.com/login/oauth/authorize"))
+        assertTrue(url.contains("client_id=gh-id"))
+        assertTrue(url.contains("state="))
+    }
+
+    // ── handleCallback — state 검증 실패 ───────────────────────────────────────
+
+    @Test
+    fun `handleCallback는 지원하지 않는 provider 이름이면 BAD_REQUEST`() {
+        val ex = assertThrows<ExpectedException> {
+            service.handleCallback("UNKNOWN_PROVIDER", "code", "state")
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    @Test
+    fun `handleCallback는 서명이 변조된 state이면 BAD_REQUEST`() {
+        val payloadB64 = buildValidState().split(".")[0]
+
+        val ex = assertThrows<ExpectedException> {
+            service.handleCallback("github", "code", "$payloadB64.invalidsignature")
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    @Test
+    fun `handleCallback는 만료된 state이면 BAD_REQUEST`() {
+        val expiredState = buildValidState(expOffset = -1L)
+
+        val ex = assertThrows<ExpectedException> {
+            service.handleCallback("github", "code", expiredState)
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    @Test
+    fun `handleCallback는 provider가 state와 불일치하면 BAD_REQUEST`() {
+        val githubState = buildValidState(provider = AccountProvider.GITHUB)
+
+        val ex = assertThrows<ExpectedException> {
+            service.handleCallback("notion", "code", githubState)
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    // ── handleCallback — 중복 계정 처리 ───────────────────────────────────────
+
+    @Test
+    fun `handleCallback는 이미 등록된 계정이면 기존 계정을 반환하고 save를 호출하지 않음`() {
+        val existingAccount = SharedAccount(
+            id = 10L, channelId = 1L, provider = AccountProvider.GITHUB,
+            providerLabel = null, accountIdentifier = "ghuser",
+            credential = null, connectedViaOAuth = true, createdBy = 1L,
+        )
+        val validState = buildValidState(channelId = 1L, userId = 1L, provider = AccountProvider.GITHUB)
+
+        stubPostReturns(mapOf("access_token" to "gh_token"))
+        stubGetReturns(mapOf("login" to "ghuser"))
+
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+        every {
+            sharedAccountRepository.findByChannelIdAndProviderAndAccountIdentifier(
+                1L, AccountProvider.GITHUB, "ghuser"
+            )
+        } returns existingAccount
+
+        val result = service.handleCallback("github", "auth-code", validState)
+
+        assertEquals(existingAccount.id, result.id)
+        verify(exactly = 0) { sharedAccountRepository.save(any()) }
+    }
+}

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/SharedAccountServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/SharedAccountServiceTest.kt
@@ -232,10 +232,11 @@ class SharedAccountServiceTest {
         every { credentialEncryptionService.decrypt(any()) } returns "plain"
         every { credentialEncryptionService.mask(any()) } returns "••••in"
 
-        service.updateAccount(
+        val result = service.updateAccount(
             1L, 1L, 10L,
             UpdateSharedAccountRequest(accountIdentifier = null, credential = null, providerLabel = null)
         )
+        assertEquals(acc.id, result.id)
     }
 
     @Test
@@ -248,10 +249,11 @@ class SharedAccountServiceTest {
         every { credentialEncryptionService.decrypt(any()) } returns "plain"
         every { credentialEncryptionService.mask(any()) } returns "••••in"
 
-        service.updateAccount(
+        val result = service.updateAccount(
             1L, 1L, 10L,
             UpdateSharedAccountRequest(accountIdentifier = null, credential = null, providerLabel = null)
         )
+        assertEquals(acc.id, result.id)
     }
 
     @Test

--- a/cowork-channel/src/test/kotlin/com/cowork/channel/service/SharedAccountServiceTest.kt
+++ b/cowork-channel/src/test/kotlin/com/cowork/channel/service/SharedAccountServiceTest.kt
@@ -1,0 +1,366 @@
+package com.cowork.channel.service
+
+import com.cowork.channel.domain.AccountCredentialCopy
+import com.cowork.channel.domain.AccountProvider
+import com.cowork.channel.domain.Channel
+import com.cowork.channel.domain.ChannelType
+import com.cowork.channel.domain.ChannelViewType
+import com.cowork.channel.domain.SharedAccount
+import com.cowork.channel.dto.CreateSharedAccountRequest
+import com.cowork.channel.dto.UpdateSharedAccountRequest
+import com.cowork.channel.repository.AccountCredentialCopyRepository
+import com.cowork.channel.repository.SharedAccountRepository
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpStatus
+import team.themoment.sdk.exception.ExpectedException
+
+class SharedAccountServiceTest {
+
+    private val sharedAccountRepository = mockk<SharedAccountRepository>(relaxed = true)
+    private val accountCredentialCopyRepository = mockk<AccountCredentialCopyRepository>(relaxed = true)
+    private val channelService = mockk<ChannelService>()
+    private val teamPermissionService = mockk<TeamPermissionService>()
+    private val credentialEncryptionService = mockk<CredentialEncryptionService>()
+
+    private val service = SharedAccountService(
+        sharedAccountRepository,
+        accountCredentialCopyRepository,
+        channelService,
+        teamPermissionService,
+        credentialEncryptionService,
+    )
+
+    private fun accountShareChannel(
+        id: Long = 1L,
+        teamId: Long = 100L,
+        createdBy: Long = 1L,
+    ) = Channel(
+        id = id, teamId = teamId, name = "ch", type = ChannelType.TEXT,
+        viewType = ChannelViewType.ACCOUNT_SHARE, description = null,
+        isPrivate = false, position = 0, createdBy = createdBy, projectId = null,
+    )
+
+    private fun textChannel() = Channel(
+        id = 1L, teamId = 100L, name = "ch", type = ChannelType.TEXT,
+        viewType = ChannelViewType.TEXT, description = null,
+        isPrivate = false, position = 0, createdBy = 1L, projectId = null,
+    )
+
+    private fun account(
+        id: Long = 10L,
+        channelId: Long = 1L,
+        provider: AccountProvider = AccountProvider.GITHUB,
+        credential: String? = "iv:ciphertext",
+        createdBy: Long = 1L,
+    ) = SharedAccount(
+        id = id, channelId = channelId, provider = provider,
+        providerLabel = null, accountIdentifier = "user",
+        credential = credential, connectedViaOAuth = false, createdBy = createdBy,
+    )
+
+    // ── listAccounts ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `listAccounts는 ACCOUNT_SHARE 채널이 아니면 BAD_REQUEST`() {
+        every { channelService.findChannelOrThrow(1L) } returns textChannel()
+
+        val ex = assertThrows<ExpectedException> { service.listAccounts(1L, 1L) }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    @Test
+    fun `listAccounts는 팀 비멤버이면 FORBIDDEN`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 7L) } throws
+            ExpectedException("팀 멤버만 접근할 수 있습니다.", HttpStatus.FORBIDDEN)
+
+        val ex = assertThrows<ExpectedException> { service.listAccounts(7L, 1L) }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `listAccounts는 credential을 ••••로 마스킹하여 반환함`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+        every { sharedAccountRepository.findAllByChannelIdOrderByCreatedAtAscIdAsc(1L) } returns
+            listOf(account(credential = "encrypted"))
+
+        val result = service.listAccounts(1L, 1L)
+
+        assertEquals(1, result.size)
+        assertEquals("••••", result[0].maskedCredential)
+    }
+
+    @Test
+    fun `listAccounts는 credential이 null이면 maskedCredential도 null임`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+        every { sharedAccountRepository.findAllByChannelIdOrderByCreatedAtAscIdAsc(1L) } returns
+            listOf(account(credential = null))
+
+        val result = service.listAccounts(1L, 1L)
+
+        assertNull(result[0].maskedCredential)
+    }
+
+    // ── getAccount ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `getAccount는 계정이 없으면 NOT_FOUND`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+        every { sharedAccountRepository.findByIdAndChannelId(99L, 1L) } returns null
+
+        val ex = assertThrows<ExpectedException> { service.getAccount(1L, 1L, 99L) }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+
+    @Test
+    fun `getAccount는 credential을 복호화 후 마스킹하여 반환함`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+        every { sharedAccountRepository.findByIdAndChannelId(10L, 1L) } returns account(credential = "encrypted")
+        every { credentialEncryptionService.decrypt("encrypted") } returns "plainPassword"
+        every { credentialEncryptionService.mask("plainPassword") } returns "••••word"
+
+        val result = service.getAccount(1L, 1L, 10L)
+
+        assertEquals("••••word", result.maskedCredential)
+    }
+
+    // ── createAccount ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `createAccount는 CUSTOM provider에 providerLabel이 없으면 BAD_REQUEST`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+
+        val ex = assertThrows<ExpectedException> {
+            service.createAccount(
+                1L, 1L,
+                CreateSharedAccountRequest(
+                    provider = AccountProvider.CUSTOM,
+                    providerLabel = null,
+                    accountIdentifier = null,
+                    credential = null,
+                )
+            )
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+
+    @Test
+    fun `createAccount는 credential을 암호화하여 저장함`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+        every { credentialEncryptionService.encrypt("plainPwd") } returns "encryptedPwd"
+        every { credentialEncryptionService.decrypt("encryptedPwd") } returns "plainPwd"
+        every { credentialEncryptionService.mask("plainPwd") } returns "••••wd"
+
+        val saved = slot<SharedAccount>()
+        every { sharedAccountRepository.save(capture(saved)) } answers { saved.captured }
+
+        service.createAccount(
+            1L, 1L,
+            CreateSharedAccountRequest(
+                provider = AccountProvider.GITHUB,
+                providerLabel = null,
+                accountIdentifier = "ghuser",
+                credential = "plainPwd",
+            )
+        )
+
+        assertEquals("encryptedPwd", saved.captured.credential)
+        assertEquals(false, saved.captured.connectedViaOAuth)
+        assertEquals(1L, saved.captured.createdBy)
+    }
+
+    @Test
+    fun `createAccount는 credential이 null이면 암호화를 수행하지 않음`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+
+        val saved = slot<SharedAccount>()
+        every { sharedAccountRepository.save(capture(saved)) } answers { saved.captured }
+
+        service.createAccount(
+            1L, 1L,
+            CreateSharedAccountRequest(
+                provider = AccountProvider.GITHUB,
+                providerLabel = null,
+                accountIdentifier = "ghuser",
+                credential = null,
+            )
+        )
+
+        assertNull(saved.captured.credential)
+        verify(exactly = 0) { credentialEncryptionService.encrypt(any()) }
+    }
+
+    // ── updateAccount ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `updateAccount는 계정 등록자가 수정 가능함`() {
+        val ch = accountShareChannel(createdBy = 99L)
+        val acc = account(createdBy = 1L)
+        every { channelService.findChannelOrThrow(1L) } returns ch
+        every { sharedAccountRepository.findByIdAndChannelId(10L, 1L) } returns acc
+        every { credentialEncryptionService.decrypt(any()) } returns "plain"
+        every { credentialEncryptionService.mask(any()) } returns "••••in"
+
+        val result = service.updateAccount(
+            1L, 1L, 10L,
+            UpdateSharedAccountRequest(accountIdentifier = "newUser", credential = null, providerLabel = null)
+        )
+
+        assertEquals("newUser", result.accountIdentifier)
+    }
+
+    @Test
+    fun `updateAccount는 채널 생성자가 수정 가능함`() {
+        val ch = accountShareChannel(createdBy = 1L)
+        val acc = account(createdBy = 99L)
+        every { channelService.findChannelOrThrow(1L) } returns ch
+        every { sharedAccountRepository.findByIdAndChannelId(10L, 1L) } returns acc
+        every { credentialEncryptionService.decrypt(any()) } returns "plain"
+        every { credentialEncryptionService.mask(any()) } returns "••••in"
+
+        service.updateAccount(
+            1L, 1L, 10L,
+            UpdateSharedAccountRequest(accountIdentifier = null, credential = null, providerLabel = null)
+        )
+    }
+
+    @Test
+    fun `updateAccount는 팀 Admin이 수정 가능함`() {
+        val ch = accountShareChannel(createdBy = 99L)
+        val acc = account(createdBy = 88L)
+        every { channelService.findChannelOrThrow(1L) } returns ch
+        every { sharedAccountRepository.findByIdAndChannelId(10L, 1L) } returns acc
+        every { teamPermissionService.isTeamOwnerOrAdmin(100L, 1L) } returns true
+        every { credentialEncryptionService.decrypt(any()) } returns "plain"
+        every { credentialEncryptionService.mask(any()) } returns "••••in"
+
+        service.updateAccount(
+            1L, 1L, 10L,
+            UpdateSharedAccountRequest(accountIdentifier = null, credential = null, providerLabel = null)
+        )
+    }
+
+    @Test
+    fun `updateAccount는 권한 없는 사용자이면 FORBIDDEN`() {
+        val ch = accountShareChannel(createdBy = 99L)
+        val acc = account(createdBy = 88L)
+        every { channelService.findChannelOrThrow(1L) } returns ch
+        every { sharedAccountRepository.findByIdAndChannelId(10L, 1L) } returns acc
+        every { teamPermissionService.isTeamOwnerOrAdmin(100L, 1L) } returns false
+
+        val ex = assertThrows<ExpectedException> {
+            service.updateAccount(
+                1L, 1L, 10L,
+                UpdateSharedAccountRequest(accountIdentifier = null, credential = null, providerLabel = null)
+            )
+        }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `updateAccount는 계정이 없으면 NOT_FOUND`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { sharedAccountRepository.findByIdAndChannelId(99L, 1L) } returns null
+
+        val ex = assertThrows<ExpectedException> {
+            service.updateAccount(
+                1L, 1L, 99L,
+                UpdateSharedAccountRequest(accountIdentifier = null, credential = null, providerLabel = null)
+            )
+        }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+
+    // ── deleteAccount ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `deleteAccount 정상 흐름`() {
+        val ch = accountShareChannel(createdBy = 1L)
+        val acc = account(createdBy = 1L)
+        every { channelService.findChannelOrThrow(1L) } returns ch
+        every { sharedAccountRepository.findByIdAndChannelId(10L, 1L) } returns acc
+
+        service.deleteAccount(1L, 1L, 10L)
+
+        verify { sharedAccountRepository.delete(acc) }
+    }
+
+    @Test
+    fun `deleteAccount는 권한 없는 사용자이면 FORBIDDEN`() {
+        val ch = accountShareChannel(createdBy = 99L)
+        val acc = account(createdBy = 88L)
+        every { channelService.findChannelOrThrow(1L) } returns ch
+        every { sharedAccountRepository.findByIdAndChannelId(10L, 1L) } returns acc
+        every { teamPermissionService.isTeamOwnerOrAdmin(100L, 1L) } returns false
+
+        val ex = assertThrows<ExpectedException> { service.deleteAccount(1L, 1L, 10L) }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `deleteAccount는 계정이 없으면 NOT_FOUND`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { sharedAccountRepository.findByIdAndChannelId(99L, 1L) } returns null
+
+        val ex = assertThrows<ExpectedException> { service.deleteAccount(1L, 1L, 99L) }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+
+    // ── copyCredential ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `copyCredential은 복호화된 credential을 반환하고 접근 로그를 저장함`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+        every { sharedAccountRepository.findByIdAndChannelId(10L, 1L) } returns account(credential = "encrypted")
+        every { credentialEncryptionService.decrypt("encrypted") } returns "plainPassword"
+        every { accountCredentialCopyRepository.save(any()) } answers { firstArg() }
+
+        val result = service.copyCredential(1L, 1L, 10L)
+
+        assertEquals("plainPassword", result)
+        verify { accountCredentialCopyRepository.save(any<AccountCredentialCopy>()) }
+    }
+
+    @Test
+    fun `copyCredential은 credential이 null이면 NOT_FOUND`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 1L) } returns Unit
+        every { sharedAccountRepository.findByIdAndChannelId(10L, 1L) } returns account(credential = null)
+
+        val ex = assertThrows<ExpectedException> { service.copyCredential(1L, 1L, 10L) }
+        assertEquals(HttpStatus.NOT_FOUND, ex.statusCode)
+    }
+
+    @Test
+    fun `copyCredential은 팀 비멤버이면 FORBIDDEN`() {
+        every { channelService.findChannelOrThrow(1L) } returns accountShareChannel()
+        every { teamPermissionService.requireTeamMember(100L, 7L) } throws
+            ExpectedException("팀 멤버만 접근할 수 있습니다.", HttpStatus.FORBIDDEN)
+
+        val ex = assertThrows<ExpectedException> { service.copyCredential(7L, 1L, 10L) }
+        assertEquals(HttpStatus.FORBIDDEN, ex.statusCode)
+    }
+
+    @Test
+    fun `copyCredential은 ACCOUNT_SHARE 채널이 아니면 BAD_REQUEST`() {
+        every { channelService.findChannelOrThrow(1L) } returns textChannel()
+
+        val ex = assertThrows<ExpectedException> { service.copyCredential(1L, 1L, 10L) }
+        assertEquals(HttpStatus.BAD_REQUEST, ex.statusCode)
+    }
+}

--- a/docs/20260526_TODO.md
+++ b/docs/20260526_TODO.md
@@ -27,8 +27,8 @@ Discord/Slack 기준으로 있어야 할 기능을 전수 점검한 결과입니
 | 14 | ~~읽음 상태 및 미읽 카운트~~               | ~~cowork-chat~~       | 🟡   | ~~[바로가기](./todo/04-notification/read-status.md)~~           |
 | 15 | ~~알림 설정 (preference 모듈 확장)~~     | ~~cowork-preference~~ | 🟡   | ~~[바로가기](./todo/04-notification/notification-settings.md)~~ |
 | 16 | ~~프로필 필드 수정 + 커스텀 상태 메시지~~       | ~~cowork-user~~       | 🟡   | ~~[바로가기](./todo/05-user-search/profile-edit.md)~~           |
-| 17 | ~~전체 검색 API~~                      | ~~신규 or gateway~~      | 🟡   | ~~[바로가기](./todo/05-user-search/global-search.md)~~          |
-| 18 | AccountShare 채널 설계·구현            | TBD                   | 🟢   | [바로가기](./todo/06-future/account-share.md)                   |
+| 17 | ~~전체 검색 API~~                    | ~~신규 or gateway~~      | 🟡   | ~~[바로가기](./todo/05-user-search/global-search.md)~~          |
+| 18 | ~~AccountShare 채널 설계·구현~~            | ~~TBD~~                   | 🟢   | ~~[바로가기](./todo/06-future/account-share.md)~~                   |
 | 19 | ~~다이렉트 메시지(DM)~~                 | ~~신규~~                | 🟢   | ~~[바로가기](./todo/06-future/direct-message.md)~~              |
 | 20 | ~~팀 역할 시스템 고도화~~                 | ~~cowork-team~~       | 🟢   | ~~[바로가기](./todo/06-future/role-system.md)~~                 |
 | 21 | ~~회의록 수정·삭제, 템플릿 관리~~            | ~~cowork-channel~~~   | 🟢   | ~~[바로가기](./todo/06-future/meeting-note-management.md)       |


### PR DESCRIPTION
## 개요

`ACCOUNT_SHARE` 채널의 서비스 레이어 3개(`SharedAccountService`, `OAuthAccountService`, `CredentialEncryptionService`)에 대한 단위 테스트를 추가하였습니다. 기존에 구현이 완료된 상태였으나 테스트가 전무하였으며, 이번 작업으로 31개 테스트 케이스가 추가되었습니다.

## 본문

### 추가된 테스트 파일

**`CredentialEncryptionServiceTest`** (5개)
- `AES-256-GCM` 기반 `encrypt`/`decrypt` 라운드트립 검증
- 매 암호화마다 다른 IV가 사용됨을 확인 (암호문 재사용 방지)
- `mask()` 메서드의 4자 이하 전체 마스킹 및 5자 이상 부분 노출 규칙 검증
- 잘못된 형식 입력 시 `IllegalArgumentException` 발생 확인

**`SharedAccountServiceTest`** (17개)
- `listAccounts`: `ACCOUNT_SHARE` 채널 타입 검증, 팀 권한 검증, `credential` `••••` 마스킹 확인
- `getAccount`: 계정 미존재 시 `NOT_FOUND`, 복호화 후 마스킹 반환 확인
- `createAccount`: `CUSTOM` provider의 `providerLabel` 필수 검증, credential 암호화 저장, null credential 시 암호화 미수행 확인
- `updateAccount`: 등록자·채널 생성자·팀 Admin 수정 허용, 권한 없으면 `FORBIDDEN`, 계정 미존재 시 `NOT_FOUND`
- `deleteAccount`: 정상 삭제, 권한 없으면 `FORBIDDEN`, 계정 미존재 시 `NOT_FOUND`
- `copyCredential`: 복호화된 credential 반환 및 접근 로그 저장 확인, credential null이면 `NOT_FOUND`

**`OAuthAccountServiceTest`** (9개)
- `buildAuthorizeUrl`: 비`ACCOUNT_SHARE` 채널 `BAD_REQUEST`, 팀 비멤버 `FORBIDDEN`, OAuth 미지원 provider `BAD_REQUEST`, GitHub 인증 URL 형식 검증
- `handleCallback` state 검증: 미지원 provider명·서명 변조·만료·provider 불일치 시 각각 `BAD_REQUEST`
- 중복 계정 처리: 동일 계정이 이미 존재하면 기존 계정을 반환하고 `save()`가 호출되지 않음을 확인