### PR TITLE
[global] 버전 범프 동기화 누락 보완

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 # Coexists with Gradle: only cowork-gateway has a BUILD.bazel, other modules are ignored by Bazel.
 module(
     name = "cowork_server",
-    version = "0.0.0",
+    version = "20260602.0",
 )
 
 bazel_dep(name = "rules_kotlin", version = "2.3.20")

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ bump:
 	@./scripts/bump.sh
 
 tag:
-	git add VERSION MODULE.bazel cowork-*/build.gradle.kts cowork-*/package.json \
+	git add VERSION MODULE.bazel cowork-*/build.gradle.kts cowork-*/package.json cowork-*/pom.xml \
 	        cowork-user/mix.exs \
 	        cowork-authorization/cmd/main.go \
 	        cowork-notification/cmd/server/main.go \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ bump:
 	@./scripts/bump.sh
 
 tag:
-	git add VERSION cowork-*/build.gradle.kts cowork-chat/package.json \
+	git add VERSION MODULE.bazel cowork-*/build.gradle.kts cowork-*/package.json \
 	        cowork-user/mix.exs \
 	        cowork-authorization/cmd/main.go \
 	        cowork-notification/cmd/server/main.go \

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -15,15 +15,15 @@ for FILE in "$ROOT_DIR"/cowork-*/build.gradle.kts; do
   perl -i -pe "s/^version = \".*\"/version = \"${NEW_VERSION}\"/" "$FILE"
 done
 
-perl -i -pe "s/^(\s*version\s*=\s*\").*(\",)/\${1}${NEW_VERSION}\${2}/" "$ROOT_DIR/MODULE.bazel"
+perl -i -pe "s/^(\s*version\s*=\s*\")[^\"]*/\${1}${NEW_VERSION}/" "$ROOT_DIR/MODULE.bazel"
 
 for FILE in "$ROOT_DIR"/cowork-*/pom.xml; do
   perl -i -0pe "s|(<artifactId>cowork-[^<]+</artifactId>\s*<version>)[^<]+|\${1}${NEW_VERSION}|" "$FILE"
 done
 
 for FILE in "$ROOT_DIR"/cowork-*/package.json; do
-  if grep -q "\"version\":" "$FILE"; then
-    perl -i -pe "s/\"version\": \".*\"/\"version\": \"${NEW_VERSION}\"/" "$FILE"
+  if grep -q "^\s*\"version\"\s*:" "$FILE"; then
+    perl -i -pe "s/^(\s*\"version\"\s*:\s*\")[^\"]*/\${1}${NEW_VERSION}.0/" "$FILE"
   fi
 done
 

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -15,7 +15,13 @@ for FILE in "$ROOT_DIR"/cowork-*/build.gradle.kts; do
   perl -i -pe "s/^version = \".*\"/version = \"${NEW_VERSION}\"/" "$FILE"
 done
 
-perl -i -pe "s/\"version\": \".*\"/\"version\": \"${NEW_VERSION}\"/" "$ROOT_DIR/cowork-chat/package.json"
+perl -i -pe "s/^(\s*version\s*=\s*\").*(\",)/\${1}${NEW_VERSION}\${2}/" "$ROOT_DIR/MODULE.bazel"
+
+for FILE in "$ROOT_DIR"/cowork-*/package.json; do
+  if grep -q "\"version\":" "$FILE"; then
+    perl -i -pe "s/\"version\": \".*\"/\"version\": \"${NEW_VERSION}\"/" "$FILE"
+  fi
+done
 
 perl -i -pe "s/(\s+version: \").*\"/\${1}${NEW_VERSION}.0\"/" "$ROOT_DIR/cowork-user/mix.exs"
 
@@ -27,4 +33,3 @@ for FILE in \
 done
 
 echo "Version set to v${NEW_VERSION}"
-

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -17,6 +17,10 @@ done
 
 perl -i -pe "s/^(\s*version\s*=\s*\").*(\",)/\${1}${NEW_VERSION}\${2}/" "$ROOT_DIR/MODULE.bazel"
 
+for FILE in "$ROOT_DIR"/cowork-*/pom.xml; do
+  perl -i -0pe "s|(<artifactId>cowork-[^<]+</artifactId>\s*<version>)[^<]+|\${1}${NEW_VERSION}|" "$FILE"
+done
+
 for FILE in "$ROOT_DIR"/cowork-*/package.json; do
   if grep -q "\"version\":" "$FILE"; then
     perl -i -pe "s/\"version\": \".*\"/\"version\": \"${NEW_VERSION}\"/" "$FILE"

--- a/scripts/bump.sh
+++ b/scripts/bump.sh
@@ -18,11 +18,13 @@ done
 perl -i -pe "s/^(\s*version\s*=\s*\")[^\"]*/\${1}${NEW_VERSION}/" "$ROOT_DIR/MODULE.bazel"
 
 for FILE in "$ROOT_DIR"/cowork-*/pom.xml; do
-  perl -i -0pe "s|(<artifactId>cowork-[^<]+</artifactId>\s*<version>)[^<]+|\${1}${NEW_VERSION}|" "$FILE"
+  if [ -f "$FILE" ]; then
+    perl -i -0pe "s|(<artifactId>cowork-[^<]+</artifactId>\s*<version>)[^<]+|\${1}${NEW_VERSION}|" "$FILE"
+  fi
 done
 
 for FILE in "$ROOT_DIR"/cowork-*/package.json; do
-  if grep -q "^\s*\"version\"\s*:" "$FILE"; then
+  if [ -f "$FILE" ] && grep -q "^\s*\"version\"\s*:" "$FILE"; then
     perl -i -pe "s/^(\s*\"version\"\s*:\s*\")[^\"]*/\${1}${NEW_VERSION}.0/" "$FILE"
   fi
 done


### PR DESCRIPTION
## 개요

`MODULE.bazel`과 각 서비스 `package.json`의 버전 범프 동기화 누락을 보완하였습니다. `Makefile`의 `tag` 대상이 변경된 버전 파일을 함께 스테이징하도록 수정하였습니다.

## 본문

`scripts/bump.sh`에서 `MODULE.bazel`의 `version` 값을 신규 버전으로 갱신하도록 추가하였습니다. 기존에는 `cowork-chat/package.json`만 갱신하던 로직을 `cowork-*` 하위 `package.json` 전체 중 `version` 필드가 있는 파일을 대상으로 처리하도록 확장하였습니다. `Makefile`의 `tag` 대상에는 `VERSION`, `MODULE.bazel`, `cowork-*/package.json`을 포함하여 릴리즈 태그 생성 시 버전 변경 누락이 발생하지 않도록 하였습니다.
