### PR TITLE
[global] 운영 도커파일 빌더 스테이지 제거

### DIFF
--- a/cowork-authorization/prod.dockerfile
+++ b/cowork-authorization/prod.dockerfile
@@ -1,15 +1,10 @@
-FROM golang:1.25-alpine AS builder
-WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o cowork-authorization ./cmd
-
+# 빌드 전 cowork-authorization (CGO_ENABLED=0 GOOS=linux 정적 바이너리)이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM alpine:3.20
 RUN apk --no-cache add ca-certificates tzdata && \
     addgroup -S app && adduser -S app -G app
-USER app
 WORKDIR /app
-COPY --from=builder /app/cowork-authorization /usr/local/bin/cowork-authorization
+COPY --chown=app:app cowork-authorization /usr/local/bin/cowork-authorization
+USER app
 EXPOSE 8081
 CMD ["cowork-authorization"]

--- a/cowork-channel/build.gradle.kts
+++ b/cowork-channel/build.gradle.kts
@@ -63,3 +63,7 @@ kotlin {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+tasks.named("jar") {
+    enabled = false
+}

--- a/cowork-channel/prod.dockerfile
+++ b/cowork-channel/prod.dockerfile
@@ -1,29 +1,17 @@
-FROM eclipse-temurin:21-jdk-alpine AS builder
-WORKDIR /workspace
-COPY gradlew gradlew
-COPY gradle gradle
-COPY settings.gradle.kts build.gradle.kts ./
-COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
-COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
-COPY cowork-channel/src cowork-channel/src
-COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
-COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
-COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
-RUN chmod +x gradlew && ./gradlew :cowork-channel:bootJar -x test --no-daemon
-
+# 빌드 전 build/libs/*.jar (gradle :cowork-channel:bootJar) 산출물이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine AS extractor
 WORKDIR /app
-COPY --from=builder /workspace/cowork-channel/build/libs/*.jar app.jar
+COPY build/libs/*.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
 
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
-COPY --from=extractor /app/extracted/dependencies ./
-COPY --from=extractor /app/extracted/spring-boot-loader ./
-COPY --from=extractor /app/extracted/snapshot-dependencies ./
-COPY --from=extractor /app/extracted/application ./
+COPY --chown=app:app --from=extractor /app/extracted/dependencies ./
+COPY --chown=app:app --from=extractor /app/extracted/spring-boot-loader ./
+COPY --chown=app:app --from=extractor /app/extracted/snapshot-dependencies ./
+COPY --chown=app:app --from=extractor /app/extracted/application ./
 USER app
 EXPOSE 8083
 ENTRYPOINT ["java", \

--- a/cowork-channel/prod.dockerfile
+++ b/cowork-channel/prod.dockerfile
@@ -1,8 +1,8 @@
-# 빌드 전 build/libs/*.jar (gradle :cowork-channel:bootJar) 산출물이 컨텍스트에 있어야 한다.
+# 빌드 전 build/libs/app.jar (CI가 :cowork-channel:bootJar 산출물을 app.jar로 전달)이 컨텍스트에 있어야 한다.
 # TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine AS extractor
 WORKDIR /app
-COPY build/libs/*.jar app.jar
+COPY build/libs/app.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
 
 FROM eclipse-temurin:21-jre-alpine

--- a/cowork-chat/prod.dockerfile
+++ b/cowork-chat/prod.dockerfile
@@ -4,7 +4,7 @@ FROM node:22-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
 COPY package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev && npm cache clean --force
 COPY --chown=app:app dist ./dist
 USER app
 EXPOSE 8087

--- a/cowork-chat/prod.dockerfile
+++ b/cowork-chat/prod.dockerfile
@@ -1,16 +1,11 @@
-FROM node:22-alpine AS builder
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci
-COPY . .
-RUN npm run build
-
+# 빌드 전 dist/ (npm run build) 산출물이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM node:22-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev
-COPY --from=builder /app/dist ./dist
+COPY --chown=app:app dist ./dist
 USER app
 EXPOSE 8087
 ENV PORT=8087

--- a/cowork-config/build.gradle.kts
+++ b/cowork-config/build.gradle.kts
@@ -42,3 +42,7 @@ kotlin {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+tasks.named("jar") {
+    enabled = false
+}

--- a/cowork-config/prod.dockerfile
+++ b/cowork-config/prod.dockerfile
@@ -1,8 +1,8 @@
-# 빌드 전 build/libs/*.jar (gradle :cowork-config:bootJar) 산출물이 컨텍스트에 있어야 한다.
+# 빌드 전 build/libs/app.jar (CI가 :cowork-config:bootJar 산출물을 app.jar로 전달)이 컨텍스트에 있어야 한다.
 # TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine AS extractor
 WORKDIR /app
-COPY build/libs/*.jar app.jar
+COPY build/libs/app.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
 
 FROM eclipse-temurin:21-jre-alpine

--- a/cowork-config/prod.dockerfile
+++ b/cowork-config/prod.dockerfile
@@ -1,29 +1,17 @@
-FROM eclipse-temurin:21-jdk-alpine AS builder
-WORKDIR /workspace
-COPY gradlew gradlew
-COPY gradle gradle
-COPY settings.gradle.kts build.gradle.kts ./
-COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
-COPY cowork-config/src cowork-config/src
-COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
-COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
-COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
-COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
-RUN chmod +x gradlew && ./gradlew :cowork-config:bootJar -x test --no-daemon
-
+# 빌드 전 build/libs/*.jar (gradle :cowork-config:bootJar) 산출물이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine AS extractor
 WORKDIR /app
-COPY --from=builder /workspace/cowork-config/build/libs/*.jar app.jar
+COPY build/libs/*.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
 
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
-COPY --from=extractor /app/extracted/dependencies ./
-COPY --from=extractor /app/extracted/spring-boot-loader ./
-COPY --from=extractor /app/extracted/snapshot-dependencies ./
-COPY --from=extractor /app/extracted/application ./
+COPY --chown=app:app --from=extractor /app/extracted/dependencies ./
+COPY --chown=app:app --from=extractor /app/extracted/spring-boot-loader ./
+COPY --chown=app:app --from=extractor /app/extracted/snapshot-dependencies ./
+COPY --chown=app:app --from=extractor /app/extracted/application ./
 USER app
 EXPOSE 8761
 ENTRYPOINT ["java", \

--- a/cowork-dm/DOCKERFILE_TODO.md
+++ b/cowork-dm/DOCKERFILE_TODO.md
@@ -1,0 +1,33 @@
+# ⚠️ cowork-dm 도커 배포 설정 미작성 (작업 필요)
+
+이 모듈에는 아직 컨테이너 배포에 필요한 Dockerfile과 문서가 없습니다.
+운영/로컬 배포 대상에 포함되기 전에 아래 항목을 반드시 완료해야 합니다.
+
+## 현재 상태
+
+- `cowork-dm`은 prod CI 매트릭스(`.github/workflows/cowork-prod-ci.yml`)와
+  `docker-compose.yml`의 서비스(`cowork-dm:local`, 포트 `8091`)에 이미 등록돼 있음
+- 그러나 **`prod.dockerfile` / `local.dockerfile`이 존재하지 않아 이미지를 빌드할 수 없음**
+- `docker-compose.override.yml`에도 `cowork-dm`의 `build:` 설정이 빠져 있음
+
+## 해야 할 일
+
+- [ ] **`cowork-dm/local.dockerfile` 작성**
+  - 같은 NestJS(Node 22) 계열인 `cowork-chat/local.dockerfile`을 참고
+- [ ] **`cowork-dm/prod.dockerfile` 작성**
+  - ⚠️ 배포 모델은 **(B) 러너 산출물 → COPY** 방식으로 결정됨
+  - CI가 네이티브로 빌드한 산출물(`dist/`)을 artifact로 전달받아
+    런타임 스테이지에서 `COPY`만 하도록 작성 (소스 재빌드 금지)
+  - 동일 모델로 전환될 다른 모듈들과 구조를 통일할 것
+- [ ] **`docker-compose.override.yml`에 `cowork-dm` `build:` 블록 추가**
+  - context/dockerfile 경로를 다른 Node 모듈(`cowork-chat`)과 동일 패턴으로
+- [ ] **`docker-compose.prod.yml`에 `cowork-dm` 이미지(`${REGISTRY}/cowork-dm:${IMAGE_TAG}`) 추가**
+- [ ] **LOCAL 배포 가이드 갱신: `docs/LOCAL_RUN_GUIDE.md`**
+  - `## 1. 한눈에 보기` 서비스 표에 `cowork-dm`(포트 `8091`) 추가
+  - `## 7. 빌드 구조`의 NestJS 서비스 항목에 `cowork-dm` 반영
+  - 필요 시 `## 6. 서비스 기동 순서` 의존성 갱신
+
+## 참고
+
+- 누락 모듈 전체 점검 결과: `cowork-dm`, `cowork-promotion`(둘 다 prod.dockerfile 없음),
+  `cowork-monitoring`(CI/compose 미등록) — 이번 작업 범위는 **`cowork-dm`만**,두 모듈은 작성 필요 없음

--- a/cowork-gateway/build.gradle.kts
+++ b/cowork-gateway/build.gradle.kts
@@ -50,3 +50,7 @@ kotlin {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+tasks.named("jar") {
+    enabled = false
+}

--- a/cowork-gateway/build.gradle.kts
+++ b/cowork-gateway/build.gradle.kts
@@ -50,7 +50,3 @@ kotlin {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
-
-tasks.named("jar") {
-    enabled = false
-}

--- a/cowork-gateway/prod.dockerfile
+++ b/cowork-gateway/prod.dockerfile
@@ -1,20 +1,12 @@
-# 빌드 전 build/libs/app.jar (CI가 :cowork-gateway:bootJar 산출물을 app.jar로 전달)이 컨텍스트에 있어야 한다.
+# 빌드 전 gateway.jar (Bazel //cowork-gateway:gateway, rules_spring springboot 산출물)이 컨텍스트에 있어야 한다.
 # TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
-FROM eclipse-temurin:21-jre-alpine AS extractor
-WORKDIR /app
-COPY build/libs/app.jar app.jar
-RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
-
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
-COPY --chown=app:app --from=extractor /app/extracted/dependencies ./
-COPY --chown=app:app --from=extractor /app/extracted/spring-boot-loader ./
-COPY --chown=app:app --from=extractor /app/extracted/snapshot-dependencies ./
-COPY --chown=app:app --from=extractor /app/extracted/application ./
+COPY --chown=app:app gateway.jar app.jar
 USER app
 EXPOSE 8080
 ENTRYPOINT ["java", \
   "-XX:+UseContainerSupport", \
   "-XX:MaxRAMPercentage=75.0", \
-  "org.springframework.boot.loader.launch.JarLauncher"]
+  "-jar", "app.jar"]

--- a/cowork-gateway/prod.dockerfile
+++ b/cowork-gateway/prod.dockerfile
@@ -1,8 +1,8 @@
-# 빌드 전 build/libs/*.jar (gradle :cowork-gateway:bootJar) 산출물이 컨텍스트에 있어야 한다.
+# 빌드 전 build/libs/app.jar (CI가 :cowork-gateway:bootJar 산출물을 app.jar로 전달)이 컨텍스트에 있어야 한다.
 # TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine AS extractor
 WORKDIR /app
-COPY build/libs/*.jar app.jar
+COPY build/libs/app.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
 
 FROM eclipse-temurin:21-jre-alpine

--- a/cowork-gateway/prod.dockerfile
+++ b/cowork-gateway/prod.dockerfile
@@ -1,29 +1,17 @@
-FROM eclipse-temurin:21-jdk-alpine AS builder
-WORKDIR /workspace
-COPY gradlew gradlew
-COPY gradle gradle
-COPY settings.gradle.kts build.gradle.kts ./
-COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
-COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-gateway/src cowork-gateway/src
-COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
-COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
-COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
-COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
-RUN chmod +x gradlew && ./gradlew :cowork-gateway:bootJar -x test --no-daemon
-
+# 빌드 전 build/libs/*.jar (gradle :cowork-gateway:bootJar) 산출물이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine AS extractor
 WORKDIR /app
-COPY --from=builder /workspace/cowork-gateway/build/libs/*.jar app.jar
+COPY build/libs/*.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
 
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
-COPY --from=extractor /app/extracted/dependencies ./
-COPY --from=extractor /app/extracted/spring-boot-loader ./
-COPY --from=extractor /app/extracted/snapshot-dependencies ./
-COPY --from=extractor /app/extracted/application ./
+COPY --chown=app:app --from=extractor /app/extracted/dependencies ./
+COPY --chown=app:app --from=extractor /app/extracted/spring-boot-loader ./
+COPY --chown=app:app --from=extractor /app/extracted/snapshot-dependencies ./
+COPY --chown=app:app --from=extractor /app/extracted/application ./
 USER app
 EXPOSE 8080
 ENTRYPOINT ["java", \

--- a/cowork-notification/prod.dockerfile
+++ b/cowork-notification/prod.dockerfile
@@ -1,16 +1,11 @@
-FROM golang:1.25-alpine AS builder
-WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o cowork-notification ./cmd/server
-
+# 빌드 전 cowork-notification (CGO_ENABLED=0 GOOS=linux 정적 바이너리)이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM alpine:3.20
 RUN apk --no-cache add ca-certificates tzdata && \
     addgroup -S app && adduser -S app -G app
-USER app
 WORKDIR /app
-COPY --from=builder /app/cowork-notification /usr/local/bin/cowork-notification
+COPY --chown=app:app cowork-notification /usr/local/bin/cowork-notification
+USER app
 EXPOSE 8086
 ENV PORT=8086
 CMD ["cowork-notification"]

--- a/cowork-preference/prod.dockerfile
+++ b/cowork-preference/prod.dockerfile
@@ -1,28 +1,11 @@
-# Build stage: compile and package with the Kotlin Toolchain (Amper) CLI.
-# A glibc-based image is used because the Kotlin CLI launcher is not musl-compatible.
-FROM eclipse-temurin:21-jdk AS builder
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-# Pinned, checksum-verified Kotlin Toolchain (Amper) CLI wrapper for reproducible builds.
-ARG KOTLIN_CLI_VERSION=0.11.0
-ARG KOTLIN_CLI_WRAPPER_SHA256=f53d26ee0bb6ef3078c33bda3c180d19fbca665408c27b62b7dfce335551c3d7
-RUN curl -fsSL -o /usr/local/bin/kotlin \
-      "https://packages.jetbrains.team/maven/p/amper/amper/org/jetbrains/kotlin/kotlin-cli/${KOTLIN_CLI_VERSION}/kotlin-cli-${KOTLIN_CLI_VERSION}-wrapper" \
-    && echo "${KOTLIN_CLI_WRAPPER_SHA256}  /usr/local/bin/kotlin" | sha256sum -c - \
-    && chmod +x /usr/local/bin/kotlin
-WORKDIR /workspace/cowork-preference
-COPY cowork-preference/module.yaml module.yaml
-COPY cowork-preference/src src
-RUN kotlin package
-
-# Runtime stage: the executable JAR is a plain JVM artifact, so a small alpine JRE is enough.
+# 빌드 전 build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar
+# (kotlin package) 산출물이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
-COPY --chown=app:app --from=builder /workspace/cowork-preference/build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar app.jar
+COPY --chown=app:app build/tasks/_cowork-preference_executableJarJvm/cowork-preference-jvm-executable.jar app.jar
 ENV JAVA_OPTS="-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0"
-# Write logs to a writable, volume-friendly path owned by the non-root user.
 ENV PREFERENCE_LOG_DIR=/var/log/cowork/preference
 RUN mkdir -p /var/log/cowork/preference && chown -R app:app /var/log/cowork
 USER app

--- a/cowork-project/prod.dockerfile
+++ b/cowork-project/prod.dockerfile
@@ -1,18 +1,8 @@
-# Build stage: compile and package with the bundled Maven wrapper.
-FROM eclipse-temurin:21-jdk-alpine AS builder
-WORKDIR /workspace/cowork-project
-# Resolve dependencies first so this layer is cached when only sources change.
-COPY cowork-project/.mvn .mvn
-COPY cowork-project/mvnw mvnw
-COPY cowork-project/pom.xml pom.xml
-RUN chmod +x mvnw && ./mvnw -B dependency:go-offline || true
-COPY cowork-project/src src
-RUN ./mvnw -B clean package -DskipTests
-
-# Extract Spring Boot layers for better runtime image caching.
+# 빌드 전 target/cowork-project-*.jar (mvnw package) 산출물이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine AS extractor
 WORKDIR /app
-COPY --from=builder /workspace/cowork-project/target/cowork-project-*.jar app.jar
+COPY target/cowork-project-*.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
 
 FROM eclipse-temurin:21-jre-alpine

--- a/cowork-project/prod.dockerfile
+++ b/cowork-project/prod.dockerfile
@@ -1,8 +1,8 @@
-# 빌드 전 target/cowork-project-*.jar (mvnw package) 산출물이 컨텍스트에 있어야 한다.
+# 빌드 전 target/app.jar (CI가 mvnw package 산출물 boot jar를 app.jar로 전달)이 컨텍스트에 있어야 한다.
 # TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine AS extractor
 WORKDIR /app
-COPY target/cowork-project-*.jar app.jar
+COPY target/app.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
 
 FROM eclipse-temurin:21-jre-alpine

--- a/cowork-team/build.gradle.kts
+++ b/cowork-team/build.gradle.kts
@@ -63,3 +63,7 @@ kotlin {
 tasks.withType<Test> {
     useJUnitPlatform()
 }
+
+tasks.named("jar") {
+    enabled = false
+}

--- a/cowork-team/prod.dockerfile
+++ b/cowork-team/prod.dockerfile
@@ -1,29 +1,17 @@
-FROM eclipse-temurin:21-jdk-alpine AS builder
-WORKDIR /workspace
-COPY gradlew gradlew
-COPY gradle gradle
-COPY settings.gradle.kts build.gradle.kts ./
-COPY cowork-config/build.gradle.kts cowork-config/build.gradle.kts
-COPY cowork-gateway/build.gradle.kts cowork-gateway/build.gradle.kts
-COPY cowork-channel/build.gradle.kts cowork-channel/build.gradle.kts
-COPY cowork-project/build.gradle.kts cowork-project/build.gradle.kts
-COPY cowork-team/build.gradle.kts cowork-team/build.gradle.kts
-COPY cowork-team/src cowork-team/src
-COPY cowork-preference/build.gradle.kts cowork-preference/build.gradle.kts
-RUN chmod +x gradlew && ./gradlew :cowork-team:bootJar -x test --no-daemon
-
+# 빌드 전 build/libs/*.jar (gradle :cowork-team:bootJar) 산출물이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine AS extractor
 WORKDIR /app
-COPY --from=builder /workspace/cowork-team/build/libs/*.jar app.jar
+COPY build/libs/*.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
 
 FROM eclipse-temurin:21-jre-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
-COPY --from=extractor /app/extracted/dependencies ./
-COPY --from=extractor /app/extracted/spring-boot-loader ./
-COPY --from=extractor /app/extracted/snapshot-dependencies ./
-COPY --from=extractor /app/extracted/application ./
+COPY --chown=app:app --from=extractor /app/extracted/dependencies ./
+COPY --chown=app:app --from=extractor /app/extracted/spring-boot-loader ./
+COPY --chown=app:app --from=extractor /app/extracted/snapshot-dependencies ./
+COPY --chown=app:app --from=extractor /app/extracted/application ./
 USER app
 EXPOSE 8085
 ENTRYPOINT ["java", \

--- a/cowork-team/prod.dockerfile
+++ b/cowork-team/prod.dockerfile
@@ -1,8 +1,8 @@
-# 빌드 전 build/libs/*.jar (gradle :cowork-team:bootJar) 산출물이 컨텍스트에 있어야 한다.
+# 빌드 전 build/libs/app.jar (CI가 :cowork-team:bootJar 산출물을 app.jar로 전달)이 컨텍스트에 있어야 한다.
 # TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM eclipse-temurin:21-jre-alpine AS extractor
 WORKDIR /app
-COPY build/libs/*.jar app.jar
+COPY build/libs/app.jar app.jar
 RUN java -Djarmode=layertools -jar app.jar extract --destination extracted
 
 FROM eclipse-temurin:21-jre-alpine

--- a/cowork-user/prod.dockerfile
+++ b/cowork-user/prod.dockerfile
@@ -1,26 +1,6 @@
-ARG ELIXIR_IMAGE=hexpm/elixir:1.17.3-erlang-27.1.1-debian-bookworm-20240926-slim
-
+# 빌드 전 _build/prod/rel/cowork_user (MIX_ENV=prod mix release) 산출물이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM flyway/flyway:11.8.1 AS flyway
-
-FROM ${ELIXIR_IMAGE} AS builder
-WORKDIR /app
-ENV MIX_ENV=prod
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential cmake git curl ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mix local.hex --force && mix local.rebar --force
-
-COPY cowork-user/mix.exs ./
-COPY cowork-user/config config
-RUN mix deps.get
-RUN mix deps.compile
-
-COPY cowork-user/lib lib
-COPY cowork-user/priv priv
-RUN mix compile
-RUN mix release
 
 FROM debian:bookworm-20240926-slim
 WORKDIR /app
@@ -32,13 +12,13 @@ RUN apt-get update \
     && mkdir -p /var/log/cowork/user && chown -R app:app /var/log/cowork
 
 COPY --from=flyway /flyway /flyway
-COPY cowork-user/src/main/resources/db/migration /flyway/sql
-COPY --from=builder /app/_build/prod/rel/cowork_user ./
-COPY cowork-user/docker-entrypoint.sh /app/docker-entrypoint.sh
+COPY src/main/resources/db/migration /flyway/sql
+COPY --chown=app:app _build/prod/rel/cowork_user ./
+COPY --chown=app:app docker-entrypoint.sh /app/docker-entrypoint.sh
 
 ENV PATH="/flyway:${PATH}"
 ENV ELIXIR_ERL_OPTIONS="+fnu"
-RUN chmod +x /app/docker-entrypoint.sh && chown -R app:app /app
+RUN chmod +x /app/docker-entrypoint.sh
 USER app
 EXPOSE 8082
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/cowork-user/prod.dockerfile
+++ b/cowork-user/prod.dockerfile
@@ -18,7 +18,7 @@ COPY --chown=app:app docker-entrypoint.sh /app/docker-entrypoint.sh
 
 ENV PATH="/flyway:${PATH}"
 ENV ELIXIR_ERL_OPTIONS="+fnu"
-RUN chmod +x /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh && chown app:app /app
 USER app
 EXPOSE 8082
 ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/cowork-voice/prod.dockerfile
+++ b/cowork-voice/prod.dockerfile
@@ -1,16 +1,11 @@
-FROM golang:1.25-alpine AS builder
-WORKDIR /app
-COPY go.mod go.sum ./
-RUN go mod download
-COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o cowork-voice ./cmd/server
-
+# 빌드 전 cowork-voice (CGO_ENABLED=0 GOOS=linux 정적 바이너리)이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
 FROM alpine:3.20
 RUN apk --no-cache add ca-certificates tzdata && \
     addgroup -S app && adduser -S app -G app
-USER app
 WORKDIR /app
-COPY --from=builder /app/cowork-voice /usr/local/bin/cowork-voice
+COPY --chown=app:app cowork-voice /usr/local/bin/cowork-voice
+USER app
 EXPOSE 8084
 ENV PORT=8084
 CMD ["cowork-voice"]


### PR DESCRIPTION
## 개요

각 모듈의 `prod.dockerfile`을 소스 재빌드 방식에서 CI 러너가 생성한 산출물을 받아 `COPY`만 하는 방식으로 전환하였습니다. 이를 통해 컴파일 중복을 제거하고 런타임 이미지 구성을 단순화하였습니다.

## 본문

기존 `prod.dockerfile`은 멀티스테이지 빌더에서 소스를 다시 컴파일하였으나, CI가 이미 네이티브로 빌드·테스트를 수행하므로 컴파일이 이중으로 발생하였습니다. 이를 해소하기 위해 빌더 스테이지를 제거하고, 빌드 산출물을 빌드 컨텍스트로 전달받아 런타임 스테이지에서 복사하도록 변경하였습니다.

- Spring Boot 모듈(`cowork-config`, `cowork-gateway`, `cowork-channel`, `cowork-team`, `cowork-project`): `layertools` 추출 후 레이어를 복사하며, 컴파일 단계는 제거하였습니다.
- `cowork-preference`(Amper): executable jar를 복사하는 단일 런타임 스테이지로 정리하였습니다.
- Go 모듈(`cowork-authorization`, `cowork-voice`, `cowork-notification`): 정적 바이너리를 복사하는 `alpine` 단일 스테이지로 정리하였습니다.
- `cowork-chat`(NestJS): `dist` 산출물을 복사하고 프로덕션 의존성만 설치하도록 변경하였습니다.
- `cowork-user`(Elixir): release 산출물과 마이그레이션을 복사하며 `flyway` 스테이지는 유지하였습니다.

모든 모듈에 `COPY --chown=app:app`을 적용하여 비-root 소유권 처리를 일관화하였습니다. 빌드 컨텍스트는 모듈 디렉터리 기준이며, 산출물 선행 전제는 각 파일 상단 주석에 명시하였고 CI 핸드오프 배선 완료 후 제거하도록 표시하였습니다.

CI 산출물 업로드 및 이미지 빌드·푸시 잡 연결은 후속 작업으로 분리하였습니다. 따라서 현재 단계에서는 산출물이 준비된 상태에서만 단독 `docker build`가 성공합니다.
