### PR TITLE
[dm] DM 모듈 README 추가

### DIFF
--- a/cowork-dm/README.md
+++ b/cowork-dm/README.md
@@ -21,7 +21,7 @@
 `8091`
 
 ## 의존성
-- Kafka produce: `dm.block.updated`, DM 알림 이벤트
+- Kafka produce: `dm.block.updated` (사용자 차단 이벤트), `notification.trigger` (DM 알림 이벤트)
 - Redis (차단 상태 저장)
 - MinIO (파일 업로드)
 
@@ -35,6 +35,7 @@
 | `REDIS_HOST` | Redis 호스트 |
 | `REDIS_PORT` | Redis 포트 |
 | `MINIO_INTERNAL_ENDPOINT` | MinIO 내부 엔드포인트 |
+| `MINIO_PUBLIC_BASE_URL` | MinIO 외부 공개 Base URL |
 | `MINIO_ACCESS_KEY` | MinIO 액세스 키 |
 | `MINIO_SECRET_KEY` | MinIO 시크릿 키 |
 | `MINIO_BUCKET` | MinIO 버킷명 |

--- a/cowork-dm/README.md
+++ b/cowork-dm/README.md
@@ -1,0 +1,42 @@
+# cowork-dm
+
+## 역할
+다이렉트 메시지(DM) 서비스.
+- Socket.io 기반 실시간 1:1 메시지 송수신
+- DM 대화방 개설/조회/숨기기
+- 메시지 수정/삭제, 이모지 리액션, 읽음 처리
+- 사용자 차단/해제 (Redis 저장 + Kafka 이벤트)
+- MinIO presigned URL 기반 첨부파일 업로드
+- Outbox 패턴 기반 DM 알림 발행
+
+## 스택
+- NestJS 11 + TypeScript
+- Socket.io
+- MongoDB (Mongoose)
+- Redis (ioredis)
+- KafkaJS
+- MinIO
+
+## 포트
+`8091`
+
+## 의존성
+- Kafka produce: `dm.block.updated`, DM 알림 이벤트
+- Redis (차단 상태 저장)
+- MinIO (파일 업로드)
+
+## 환경변수
+| 변수 | 설명 |
+|---|---|
+| `PORT` | HTTP 리슨 포트 |
+| `MONGODB_URI` | MongoDB 연결 URI |
+| `JWT_SECRET` | WebSocket JWT 검증 시크릿 |
+| `KAFKA_BOOTSTRAP_SERVERS` | Kafka 브로커 주소 |
+| `REDIS_HOST` | Redis 호스트 |
+| `REDIS_PORT` | Redis 포트 |
+| `MINIO_INTERNAL_ENDPOINT` | MinIO 내부 엔드포인트 |
+| `MINIO_ACCESS_KEY` | MinIO 액세스 키 |
+| `MINIO_SECRET_KEY` | MinIO 시크릿 키 |
+| `MINIO_BUCKET` | MinIO 버킷명 |
+| `EUREKA_SERVER_URL` | Eureka 서버 URL |
+| `EUREKA_INSTANCE_HOST` | Eureka 등록 호스트 |


### PR DESCRIPTION
## 개요

`cowork-dm` 모듈의 `README.md`를 추가하였습니다. 기존 `cowork-chat` 등 다른 모듈의 README 형식에 맞춰 `역할` / `스택` / `포트` / `의존성` / `환경변수` 구조로 작성하였습니다.

## 본문

- `역할`: 실시간 1:1 DM 송수신, 대화방 개설/조회/숨기기, 메시지 수정·삭제·리액션·읽음 처리, 사용자 차단, 첨부파일 업로드, Outbox 기반 알림 발행을 정리하였습니다.
- `스택`: `NestJS` + `TypeScript`, `Socket.io`, `MongoDB`, `Redis`, `KafkaJS`, `MinIO`를 명시하였습니다.
- `포트`: `docker-compose.yml` 기준 `8091`로 기재하였습니다.
- `의존성`: Kafka produce 토픽(`dm.block.updated`, DM 알림 이벤트), `Redis`, `MinIO` 의존성을 정리하였습니다.
- `환경변수`: `PORT`, `MONGODB_URI`, `JWT_SECRET`, `KAFKA_BOOTSTRAP_SERVERS`, `REDIS_HOST`, `MINIO_*`, `EUREKA_*` 등 기동에 필요한 항목을 표로 정리하였습니다.
