### PR TITLE
[dm] Swagger·모니터링·도커 배포 연동

### DIFF
--- a/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-dev.yml
@@ -254,6 +254,13 @@ spring:
           filters:
             - RewritePath=/v3/api-docs/chat, /api-json
 
+        - id: dm-service-docs
+          uri: lb://cowork-dm
+          predicates:
+            - Path=/v3/api-docs/dm
+          filters:
+            - RewritePath=/v3/api-docs/dm, /api-json
+
         - id: preference-service-docs
           uri: lb://cowork-preference
           predicates:

--- a/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
+++ b/cowork-config/src/main/resources/configs/cowork-gateway-local.yml
@@ -17,6 +17,8 @@ cowork:
         url: /v3/api-docs/voice
       - name: chat
         url: /v3/api-docs/chat
+      - name: dm
+        url: /v3/api-docs/dm
       - name: notification
         url: /v3/api-docs/notification
       - name: preference
@@ -243,6 +245,13 @@ spring:
             - Path=/v3/api-docs/chat
           filters:
             - RewritePath=/v3/api-docs/chat, /api-json
+
+        - id: dm-service-docs
+          uri: lb://cowork-dm
+          predicates:
+            - Path=/v3/api-docs/dm
+          filters:
+            - RewritePath=/v3/api-docs/dm, /api-json
 
         - id: preference-service-docs
           uri: lb://cowork-preference

--- a/cowork-dm/.gitignore
+++ b/cowork-dm/.gitignore
@@ -1,0 +1,22 @@
+### Node.js ###
+node_modules/
+dist/
+build/
+.env
+.env.local
+.env.*.local
+
+### NestJS ###
+.nest/
+
+### Logs ###
+*.log
+logs/
+
+### OS ###
+.DS_Store
+Thumbs.db
+
+### IDE ###
+.idea/
+.vscode/

--- a/cowork-dm/DOCKERFILE_TODO.md
+++ b/cowork-dm/DOCKERFILE_TODO.md
@@ -1,31 +1,32 @@
-# ⚠️ cowork-dm 도커 배포 설정 미작성 (작업 필요)
+# ✅ cowork-dm 도커 배포 설정 (작업 완료)
 
-이 모듈에는 아직 컨테이너 배포에 필요한 Dockerfile과 문서가 없습니다.
-운영/로컬 배포 대상에 포함되기 전에 아래 항목을 반드시 완료해야 합니다.
+> 아래 항목은 모두 완료되었습니다. 기록 보존을 위해 취소선으로 남겨 둡니다.
+
+~~이 모듈에는 아직 컨테이너 배포에 필요한 Dockerfile과 문서가 없습니다.~~
+~~운영/로컬 배포 대상에 포함되기 전에 아래 항목을 반드시 완료해야 합니다.~~
 
 ## 현재 상태
 
 - `cowork-dm`은 prod CI 매트릭스(`.github/workflows/cowork-prod-ci.yml`)와
   `docker-compose.yml`의 서비스(`cowork-dm:local`, 포트 `8091`)에 이미 등록돼 있음
-- 그러나 **`prod.dockerfile` / `local.dockerfile`이 존재하지 않아 이미지를 빌드할 수 없음**
-- `docker-compose.override.yml`에도 `cowork-dm`의 `build:` 설정이 빠져 있음
+- ~~그러나 **`prod.dockerfile` / `local.dockerfile`이 존재하지 않아 이미지를 빌드할 수 없음**~~ → 작성 완료
+- ~~`docker-compose.override.yml`에도 `cowork-dm`의 `build:` 설정이 빠져 있음~~ → 추가 완료
 
 ## 해야 할 일
 
-- [ ] **`cowork-dm/local.dockerfile` 작성**
-  - 같은 NestJS(Node 22) 계열인 `cowork-chat/local.dockerfile`을 참고
-- [ ] **`cowork-dm/prod.dockerfile` 작성**
-  - ⚠️ 배포 모델은 **(B) 러너 산출물 → COPY** 방식으로 결정됨
-  - CI가 네이티브로 빌드한 산출물(`dist/`)을 artifact로 전달받아
-    런타임 스테이지에서 `COPY`만 하도록 작성 (소스 재빌드 금지)
-  - 동일 모델로 전환될 다른 모듈들과 구조를 통일할 것
-- [ ] **`docker-compose.override.yml`에 `cowork-dm` `build:` 블록 추가**
-  - context/dockerfile 경로를 다른 Node 모듈(`cowork-chat`)과 동일 패턴으로
-- [ ] **`docker-compose.prod.yml`에 `cowork-dm` 이미지(`${REGISTRY}/cowork-dm:${IMAGE_TAG}`) 추가**
-- [ ] **LOCAL 배포 가이드 갱신: `docs/LOCAL_RUN_GUIDE.md`**
-  - `## 1. 한눈에 보기` 서비스 표에 `cowork-dm`(포트 `8091`) 추가
-  - `## 7. 빌드 구조`의 NestJS 서비스 항목에 `cowork-dm` 반영
-  - 필요 시 `## 6. 서비스 기동 순서` 의존성 갱신
+- [x] ~~**`cowork-dm/local.dockerfile` 작성**~~
+  - ~~같은 NestJS(Node 22) 계열인 `cowork-chat/local.dockerfile`을 참고~~
+- [x] ~~**`cowork-dm/prod.dockerfile` 작성**~~
+  - ~~⚠️ 배포 모델은 **(B) 러너 산출물 → COPY** 방식으로 결정됨~~
+  - ~~CI가 네이티브로 빌드한 산출물(`dist/`)을 artifact로 전달받아 런타임 스테이지에서 `COPY`만 하도록 작성 (소스 재빌드 금지)~~
+  - ~~동일 모델로 전환될 다른 모듈들과 구조를 통일할 것~~
+- [x] ~~**`docker-compose.override.yml`에 `cowork-dm` `build:` 블록 추가**~~
+  - ~~context/dockerfile 경로를 다른 Node 모듈(`cowork-chat`)과 동일 패턴으로~~
+- [x] ~~**`docker-compose.prod.yml`에 `cowork-dm` 이미지(`${REGISTRY}/cowork-dm:${IMAGE_TAG}`) 추가**~~
+- [x] ~~**LOCAL 배포 가이드 갱신: `docs/LOCAL_RUN_GUIDE.md`**~~
+  - ~~`## 1. 한눈에 보기` 서비스 표에 `cowork-dm`(포트 `8091`) 추가~~
+  - ~~`## 7. 빌드 구조`의 NestJS 서비스 항목에 `cowork-dm` 반영~~
+  - `## 6. 서비스 기동 순서`는 DM이 일반 비즈니스 서비스와 동급이라 갱신 불필요
 
 ## 참고
 

--- a/cowork-dm/local.dockerfile
+++ b/cowork-dm/local.dockerfile
@@ -1,0 +1,15 @@
+FROM node:22-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY --from=builder /app/dist ./dist
+EXPOSE 8091
+ENV PORT=8091
+CMD ["node", "dist/main.js"]

--- a/cowork-dm/prod.dockerfile
+++ b/cowork-dm/prod.dockerfile
@@ -3,7 +3,7 @@
 FROM node:22-alpine
 RUN addgroup -S app && adduser -S app -G app
 WORKDIR /app
-COPY package*.json ./
+COPY --chown=app:app package*.json ./
 RUN npm ci --omit=dev && npm cache clean --force
 COPY --chown=app:app dist ./dist
 USER app

--- a/cowork-dm/prod.dockerfile
+++ b/cowork-dm/prod.dockerfile
@@ -1,0 +1,13 @@
+# 빌드 전 dist/ (npm run build) 산출물이 컨텍스트에 있어야 한다.
+# TODO: CI 산출물 핸드오프 배선 후 이 주석 삭제
+FROM node:22-alpine
+RUN addgroup -S app && adduser -S app -G app
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+COPY --chown=app:app dist ./dist
+USER app
+EXPOSE 8091
+ENV PORT=8091
+ENV NODE_ENV=production
+CMD ["node", "dist/main.js"]

--- a/cowork-dm/src/message/message.service.spec.ts
+++ b/cowork-dm/src/message/message.service.spec.ts
@@ -262,14 +262,14 @@ describe('MessageService', () => {
         it('대화방이 없으면 NotFoundException', async () => {
             convRepo.findById.mockResolvedValue(null);
 
-            await expect(service.reactMessage('conv1', 'msg1', 1, '👍', 'ADD')).rejects.toThrow(NotFoundException);
+            await expect(service.reactMessage('conv1', makeObjectId().toString(), 1, '👍', 'ADD')).rejects.toThrow(NotFoundException);
         });
 
         it('참여자가 아니면 ForbiddenException', async () => {
             const conv = makeConversation(2, 3);
             convRepo.findById.mockResolvedValue(conv);
 
-            await expect(service.reactMessage(conv._id.toString(), 'msg1', 1, '👍', 'ADD')).rejects.toThrow(ForbiddenException);
+            await expect(service.reactMessage(conv._id.toString(), makeObjectId().toString(), 1, '👍', 'ADD')).rejects.toThrow(ForbiddenException);
         });
 
         it('메시지가 없으면 NotFoundException (addReaction null)', async () => {
@@ -277,7 +277,7 @@ describe('MessageService', () => {
             convRepo.findById.mockResolvedValue(conv);
             messageRepo.addReaction.mockResolvedValue(null);
 
-            await expect(service.reactMessage(conv._id.toString(), 'msg1', 1, '👍', 'ADD')).rejects.toThrow(NotFoundException);
+            await expect(service.reactMessage(conv._id.toString(), makeObjectId().toString(), 1, '👍', 'ADD')).rejects.toThrow(NotFoundException);
         });
 
         it('ADD 리액션 후 WebSocket 브로드캐스트', async () => {
@@ -321,14 +321,14 @@ describe('MessageService', () => {
         it('대화방이 없으면 NotFoundException', async () => {
             convRepo.findById.mockResolvedValue(null);
 
-            await expect(service.markRead('conv1', 1, 'msg1')).rejects.toThrow(NotFoundException);
+            await expect(service.markRead('conv1', 1, makeObjectId().toString())).rejects.toThrow(NotFoundException);
         });
 
         it('참여자가 아니면 ForbiddenException', async () => {
             const conv = makeConversation(2, 3);
             convRepo.findById.mockResolvedValue(conv);
 
-            await expect(service.markRead(conv._id.toString(), 1, 'msg1')).rejects.toThrow(ForbiddenException);
+            await expect(service.markRead(conv._id.toString(), 1, makeObjectId().toString())).rejects.toThrow(ForbiddenException);
         });
 
         it('읽음 처리 후 WebSocket 브로드캐스트', async () => {

--- a/cowork-monitoring/prometheus/prometheus.yml
+++ b/cowork-monitoring/prometheus/prometheus.yml
@@ -54,6 +54,7 @@ scrape_configs:
           - http://host.docker.internal:8085/actuator/health
           - http://host.docker.internal:8086/health
           - http://host.docker.internal:8087/health
+          - http://host.docker.internal:8091/health
           - http://host.docker.internal:9001/health
     relabel_configs:
       - source_labels: [__address__]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -51,6 +51,11 @@ services:
       context: cowork-chat
       dockerfile: local.dockerfile
 
+  cowork-dm:
+    build:
+      context: cowork-dm
+      dockerfile: local.dockerfile
+
   cowork-voice:
     build:
       context: cowork-voice

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,6 +33,9 @@ services:
   cowork-chat:
     image: ${REGISTRY}/cowork-chat:${IMAGE_TAG}
 
+  cowork-dm:
+    image: ${REGISTRY}/cowork-dm:${IMAGE_TAG}
+
   cowork-voice:
     image: ${REGISTRY}/cowork-voice:${IMAGE_TAG}
     environment:

--- a/docs/LOCAL_RUN_GUIDE.md
+++ b/docs/LOCAL_RUN_GUIDE.md
@@ -30,6 +30,7 @@
 | `cowork-channel`       | `8083` | Spring Boot                          | 정상 |
 | `cowork-notification`  | `8086` | Go                                   | 정상 |
 | `cowork-chat`          | `8087` | NestJS                               | 정상 |
+| `cowork-dm`            | `8091` | NestJS                               | 정상 |
 | `cowork-voice`         | `8084` | Go                                   | 정상 |
 | `cowork-project`       | `8089` | Spring Boot                          | 정상 |
 
@@ -159,9 +160,9 @@ infra (MySQL, Kafka, Redis, Mongo, Postgres, ...)
 - 빌드 컨텍스트: 각 서비스 디렉터리
 - 베이스 이미지: `golang:1.25-alpine` (빌드) → `alpine:3.20` (런타임)
 
-### NestJS 서비스 (chat)
+### NestJS 서비스 (chat, dm)
 
-- 빌드 컨텍스트: `cowork-chat/`
+- 빌드 컨텍스트: 각 서비스 디렉터리 (`cowork-chat/`, `cowork-dm/`)
 - `npm run build` (tsc) → `node dist/main.js`
 - 베이스 이미지: `node:22-alpine`
 


### PR DESCRIPTION
## 개요

`cowork-dm` 모듈을 Gateway 통합 Swagger, 모니터링, 도커 배포 파이프라인에 연동하였습니다. 또한 `#151`에서 추가된 `DOCKERFILE_TODO.md`의 잔여 작업을 모두 완료하였습니다.

## 본문

### Swagger 통합 (`gateway`)
- `cowork-gateway-local.yml`의 `cowork.swagger-ui.urls`에 `dm` 항목을 추가하였습니다.
- `cowork-gateway-local.yml` / `cowork-gateway-dev.yml`에 `dm-service-docs` 라우트를 추가하여 `/v3/api-docs/dm` 요청을 `lb://cowork-dm`의 `/api-json`으로 전달하도록 하였습니다. 동일 `NestJS` 모듈인 `cowork-chat`과 같은 패턴입니다.

### 모니터링 (`monitoring`)
- 메트릭 스크랩은 `EurekaClient`가 이미 `prometheus.scrape`, `prometheus.path` 메타데이터를 등록하므로 Eureka 자동 감지로 동작합니다.
- `prometheus.yml`의 Blackbox probe 대상에 DM 헬스체크(`8091/health`)를 추가하였습니다.

### 도커 배포 설정 (`dm`)
- `cowork-dm/local.dockerfile`을 추가하였습니다(`node:22-alpine`, 포트 `8091`).
- `cowork-dm/prod.dockerfile`을 추가하였습니다. CI가 빌드한 산출물(`dist/`)을 `COPY`만 하는 방식으로, `#151`에서 결정된 다른 모듈과 동일한 구조입니다.
- `docker-compose.override.yml`에 `cowork-dm` `build:` 블록을, `docker-compose.prod.yml`에 `cowork-dm` 이미지를 추가하였습니다.
- `cowork-dm/.gitignore`를 추가하여 `dist/` 등 빌드 산출물이 추적되지 않도록 하였습니다(`cowork-chat`과 동일).
- `docs/LOCAL_RUN_GUIDE.md`의 서비스 표와 빌드 구조 항목에 `cowork-dm`을 반영하였습니다.
- 완료된 `DOCKERFILE_TODO.md`는 기록 보존을 위해 항목에 취소선으로 표시하였습니다.

### 테스트 정정 (`dm`)
- `message.service.spec.ts`의 `reactMessage`/`markRead` 테스트가 `MessageService`의 `Types.ObjectId.isValid` 검증과 충돌하여 `BadRequestException`이 먼저 발생하던 문제를 수정하였습니다. 비정상 문자열 대신 유효한 `ObjectId`를 사용하도록 정정하였으며, 서비스 코드는 변경하지 않았습니다.
- 전체 단위 테스트 40건이 통과합니다.
