### PR TITLE
[promotion] 기술스택에 빌드 도구 추가

### DIFF
--- a/cowork-promotion/README.md
+++ b/cowork-promotion/README.md
@@ -6,6 +6,10 @@ cowork 프로모션 웹사이트.
 ## 스택
 - Nuxt 3
 - Tailwind CSS
+- Maven
+- Gradle
+- Amper
+- Bazel
 
 ## 포트
 `3000`

--- a/cowork-promotion/package-lock.json
+++ b/cowork-promotion/package-lock.json
@@ -1666,25 +1666,6 @@
         "nuxt": "^3.21.2"
       }
     },
-    "node_modules/@nuxt/schema": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@nuxt/schema/-/schema-4.4.2.tgz",
-      "integrity": "sha512-/q6C7Qhiricgi+PKR7ovBnJlKTL0memCbA1CzRT+itCW/oeYzUfeMdQ35mGntlBoyRPNrMXbzuSUhfDbSCU57w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@vue/shared": "^3.5.30",
-        "defu": "^6.1.4",
-        "pathe": "^2.0.3",
-        "pkg-types": "^2.3.0",
-        "std-env": "^4.0.0"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.10.0"
-      }
-    },
     "node_modules/@nuxt/telemetry": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/@nuxt/telemetry/-/telemetry-2.8.0.tgz",
@@ -5176,18 +5157,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/commondir": {
       "version": "1.0.1",

--- a/cowork-promotion/pages/index.vue
+++ b/cowork-promotion/pages/index.vue
@@ -1,229 +1,283 @@
 <script lang="ts" setup>
-import rawMembers from '~/data/members.json'
+import rawMembers from "~/data/members.json";
 
 interface Member {
-    githubId: string
-    name: string
-    position: string
-    cohort: string
+    githubId: string;
+    name: string;
+    position: string;
+    cohort: string;
 }
 
 interface TechItem {
-    name: string
-    color: string
-    positions: string[]
+    name: string;
+    color: string;
+    positions: string[];
 }
 
-const members = rawMembers as Member[]
+const members = rawMembers as Member[];
 
 const techCategories: { label: string; items: TechItem[] }[] = [
     {
-        label: 'Language',
+        label: "Language",
         items: [
-            {name: 'Kotlin', color: '#7F52FF', positions: ['Server', 'Desktop App Client']},
-            {name: 'TypeScript', color: '#3178C6', positions: ['Server', 'Web Client']},
-            {name: 'JavaScript', color: '#F7DF1E', positions: []},
-            {name: 'Go', color: '#00ADD8', positions: ['Server']},
-            {name: 'Elixir', color: '#4B275F', positions: ['Server']},
-            {name: 'Dart', color: '#0175C2', positions: ['Mobile App Client']},
+            {
+                name: "Kotlin",
+                color: "#7F52FF",
+                positions: ["Server", "Desktop App Client"],
+            },
+            {
+                name: "TypeScript",
+                color: "#3178C6",
+                positions: ["Server", "Web Client"],
+            },
+            { name: "JavaScript", color: "#F7DF1E", positions: [] },
+            { name: "Go", color: "#00ADD8", positions: ["Server"] },
+            { name: "Elixir", color: "#4B275F", positions: ["Server"] },
+            {
+                name: "Dart",
+                color: "#0175C2",
+                positions: ["Mobile App Client"],
+            },
         ],
     },
     {
-        label: 'Frontend',
+        label: "Frontend",
         items: [
-            {name: 'React', color: '#61DAFB', positions: ['Web Client']},
-            {name: 'Vue.js', color: '#4FC08D', positions: []},
-            {name: 'Rsbuild', color: '#FF3E00', positions: ['Web Client']},
-            {name: 'Flutter', color: '#02569B', positions: ['Mobile App Client']},
-            {name: 'Kotlin Multiplatform', color: '#7F52FF', positions: ['Desktop App Client']},
+            { name: "React", color: "#61DAFB", positions: ["Web Client"] },
+            { name: "Vue.js", color: "#4FC08D", positions: [] },
+            { name: "Rsbuild", color: "#FF3E00", positions: ["Web Client"] },
+            {
+                name: "Flutter",
+                color: "#02569B",
+                positions: ["Mobile App Client"],
+            },
+            {
+                name: "Kotlin Multiplatform",
+                color: "#7F52FF",
+                positions: ["Desktop App Client"],
+            },
         ],
     },
     {
-        label: 'Backend',
+        label: "Backend",
         items: [
-            {name: 'Spring Boot', color: '#6DB33F', positions: ['Server']},
-            {name: 'Spring Cloud Gateway', color: '#6DB33F', positions: ['Server']},
-            {name: 'Eureka', color: '#6DB33F', positions: ['Server']},
-            {name: 'OpenFeign', color: '#6DB33F', positions: ['Server']},
-            {name: 'Vert.x', color: '#2C3E50', positions: ['Server']},
-            {name: 'Node.js', color: '#339933', positions: ['Server']},
-            {name: 'NestJS', color: '#E0234E', positions: ['Server']},
-            {name: 'Gin', color: '#00ADD8', positions: ['Server']},
-            {name: 'Chi', color: '#00ADD8', positions: ['Server']},
-            {name: 'Phoenix', color: '#FD4F00', positions: ['Server']},
-            {name: 'LiveKit', color: '#FF5C93', positions: ['Server']},
+            { name: "Spring Boot", color: "#6DB33F", positions: ["Server"] },
+            {
+                name: "Spring Cloud Gateway",
+                color: "#6DB33F",
+                positions: ["Server"],
+            },
+            { name: "Eureka", color: "#6DB33F", positions: ["Server"] },
+            { name: "OpenFeign", color: "#6DB33F", positions: ["Server"] },
+            { name: "Vert.x", color: "#2C3E50", positions: ["Server"] },
+            { name: "Node.js", color: "#339933", positions: ["Server"] },
+            { name: "NestJS", color: "#E0234E", positions: ["Server"] },
+            { name: "Gin", color: "#00ADD8", positions: ["Server"] },
+            { name: "Chi", color: "#00ADD8", positions: ["Server"] },
+            { name: "Phoenix", color: "#FD4F00", positions: ["Server"] },
+            { name: "LiveKit", color: "#FF5C93", positions: ["Server"] },
         ],
     },
     {
-        label: 'Database',
+        label: "Database",
         items: [
-            {name: 'MySQL', color: '#4479A1', positions: ['Server']},
-            {name: 'PostgreSQL', color: '#336791', positions: []},
-            {name: 'MongoDB', color: '#47A248', positions: ['Server']},
-            {name: 'Redis', color: '#DC382D', positions: ['Server']},
-            {name: 'Elasticsearch', color: '#005571', positions: ['Server']},
-            {name: 'Flyway', color: '#CC0200', positions: ['Server']},
+            { name: "MySQL", color: "#4479A1", positions: ["Server"] },
+            { name: "PostgreSQL", color: "#336791", positions: [] },
+            { name: "MongoDB", color: "#47A248", positions: ["Server"] },
+            { name: "Redis", color: "#DC382D", positions: ["Server"] },
+            { name: "Elasticsearch", color: "#005571", positions: ["Server"] },
+            { name: "Flyway", color: "#CC0200", positions: ["Server"] },
         ],
     },
     {
-        label: 'Messaging',
-        items: [{name: 'Apache Kafka', color: '#231F20', positions: ['Server']}],
-    },
-    {
-        label: 'Infrastructure',
+        label: "Messaging",
         items: [
-            {name: 'Docker', color: '#2496ED', positions: ['Cloud']},
-            {name: 'Grafana', color: '#F46800', positions: ['Cloud']},
-            {name: 'Prometheus', color: '#E6522C', positions: ['Cloud']},
-            {name: 'Vault', color: '#0FC75E', positions: ['Cloud']},
+            { name: "Apache Kafka", color: "#231F20", positions: ["Server"] },
         ],
     },
     {
-        label: 'Design',
+        label: "Infrastructure",
         items: [
-            {name: 'Figma', color: '#F24E1E', positions: ['Design']},
+            { name: "Docker", color: "#2496ED", positions: ["Cloud"] },
+            { name: "Grafana", color: "#F46800", positions: ["Cloud"] },
+            { name: "Prometheus", color: "#E6522C", positions: ["Cloud"] },
+            { name: "Vault", color: "#0FC75E", positions: ["Cloud"] },
         ],
     },
-]
+    {
+        label: "Design",
+        items: [{ name: "Figma", color: "#F24E1E", positions: ["Design"] }],
+    },
+    {
+        label: "Build Tools",
+        items: [
+            { name: "Maven", color: "#C71C36", positions: [] },
+            { name: "Gradle", color: "#02303A", positions: [] },
+            { name: "Amper", color: "#1F6FEB", positions: [] },
+            { name: "Bazel", color: "#092E20", positions: [] },
+        ],
+    },
+];
 
 const repos = [
     {
-        name: 'cowork-server',
-        description: 'MSA 기반 통합 백엔드 API 서버',
-        badge: 'Backend',
-        url: 'https://github.com/team-cowork/cowork-server',
+        name: "cowork-server",
+        description: "MSA 기반 통합 백엔드 API 서버",
+        badge: "Backend",
+        url: "https://github.com/team-cowork/cowork-server",
     },
     {
-        name: 'cowork-web-client',
-        description: 'MFE 기반 웹 브라우저 환경의 협업 클라이언트',
-        badge: 'Web',
-        url: 'https://github.com/team-cowork/cowork-web-client',
+        name: "cowork-web-client",
+        description: "MFE 기반 웹 브라우저 환경의 협업 클라이언트",
+        badge: "Web",
+        url: "https://github.com/team-cowork/cowork-web-client",
     },
     {
-        name: 'cowork-desktop-app-client',
-        description: '데스크탑 환경의 협업 클라이언트',
-        badge: 'Desktop',
-        url: 'https://github.com/team-cowork/cowork-desktop-app-client',
+        name: "cowork-desktop-app-client",
+        description: "데스크탑 환경의 협업 클라이언트",
+        badge: "Desktop",
+        url: "https://github.com/team-cowork/cowork-desktop-app-client",
     },
     {
-        name: 'cowork-github-app',
-        description: 'GitHub 저장소와의 협업 연동 앱',
-        badge: 'GitHub App',
-        url: 'https://github.com/team-cowork/cowork-github-app',
+        name: "cowork-github-app",
+        description: "GitHub 저장소와의 협업 연동 앱",
+        badge: "GitHub App",
+        url: "https://github.com/team-cowork/cowork-github-app",
     },
     {
-        name: 'cowork-mobile-app-client',
-        description: '모바일 환경의 협업 클라이언트',
-        badge: 'Mobile',
-        url: 'https://github.com/team-cowork/cowork-mobile-app-client',
+        name: "cowork-mobile-app-client",
+        description: "모바일 환경의 협업 클라이언트",
+        badge: "Mobile",
+        url: "https://github.com/team-cowork/cowork-mobile-app-client",
     },
-]
+];
 
-const positionOrder = ['Server', 'Web Client', 'Desktop App Client', 'Mobile App Client', 'Cloud', 'Design']
+const positionOrder = [
+    "Server",
+    "Web Client",
+    "Desktop App Client",
+    "Mobile App Client",
+    "Cloud",
+    "Design",
+];
 
 const positionConfig: Record<string, { color: string; description: string }> = {
-    'Server': {
-        color: '#8B5CF6',
-        description: '서비스의 핵심 비즈니스 로직과 API를 설계하고 구현합니다. MSA 구조 위에서 각 도메인 서비스를 담당합니다.',
+    Server: {
+        color: "#8B5CF6",
+        description:
+            "서비스의 핵심 비즈니스 로직과 API를 설계하고 구현합니다. MSA 구조 위에서 각 도메인 서비스를 담당합니다.",
     },
-    'Web Client': {
-        color: '#EAB308',
-        description: '웹 브라우저 환경의 사용자 인터페이스를 개발합니다. MFE 아키텍처로 확장 가능한 프론트엔드를 구성합니다.',
+    "Web Client": {
+        color: "#EAB308",
+        description:
+            "웹 브라우저 환경의 사용자 인터페이스를 개발합니다. MFE 아키텍처로 확장 가능한 프론트엔드를 구성합니다.",
     },
-    'Desktop App Client': {
-        color: '#0EA5E9',
-        description: '데스크탑 환경에 최적화된 협업 클라이언트를 개발합니다. 네이티브에 가까운 성능과 경험을 제공합니다.',
+    "Desktop App Client": {
+        color: "#0EA5E9",
+        description:
+            "데스크탑 환경에 최적화된 협업 클라이언트를 개발합니다. 네이티브에 가까운 성능과 경험을 제공합니다.",
     },
-    'Mobile App Client': {
-        color: '#F43F5E',
-        description: '모바일 환경의 협업 클라이언트를 개발합니다. iOS와 Android를 아우르는 크로스 플랫폼 앱을 구현합니다.',
+    "Mobile App Client": {
+        color: "#F43F5E",
+        description:
+            "모바일 환경의 협업 클라이언트를 개발합니다. iOS와 Android를 아우르는 크로스 플랫폼 앱을 구현합니다.",
     },
-    'Cloud': {
-        color: '#F97316',
-        description: '서비스 인프라를 설계하고 운영합니다. 안정적인 배포 파이프라인과 모니터링 체계를 구축합니다.',
+    Cloud: {
+        color: "#F97316",
+        description:
+            "서비스 인프라를 설계하고 운영합니다. 안정적인 배포 파이프라인과 모니터링 체계를 구축합니다.",
     },
-    'Design': {
-        color: '#14B8A6',
-        description: 'cowork의 시각적 아이덴티티를 정의합니다. 사용자 중심의 UI/UX 디자인으로 직관적인 경험을 만듭니다.',
+    Design: {
+        color: "#14B8A6",
+        description:
+            "cowork의 시각적 아이덴티티를 정의합니다. 사용자 중심의 UI/UX 디자인으로 직관적인 경험을 만듭니다.",
     },
-}
+};
 
 const positionTechsMap = computed<Record<string, string[]>>(() => {
-    const map: Record<string, string[]> = {}
+    const map: Record<string, string[]> = {};
     for (const cat of techCategories) {
         for (const tech of cat.items) {
             for (const pos of tech.positions) {
-                if (!map[pos]) map[pos] = []
-                map[pos].push(tech.name)
+                if (!map[pos]) map[pos] = [];
+                map[pos].push(tech.name);
             }
         }
     }
-    return map
-})
+    return map;
+});
 
 interface PositionGroup {
-    name: string
-    color: string
-    description: string
-    techs: string[]
-    members: Member[]
+    name: string;
+    color: string;
+    description: string;
+    techs: string[];
+    members: Member[];
 }
 
 const positionGroups = computed<PositionGroup[]>(() => {
-    const groups = new Map<string, Member[]>(positionOrder.map(p => [p, []]))
+    const groups = new Map<string, Member[]>(positionOrder.map((p) => [p, []]));
     for (const member of members) {
-        for (const part of member.position.split(' | ')) {
-            const key = positionOrder.find(p => part.trim() === p)
+        for (const part of member.position.split(" | ")) {
+            const key = positionOrder.find((p) => part.trim() === p);
             if (key) {
-                const list = groups.get(key)!
-                if (!list.some(m => m.githubId === member.githubId)) list.push(member)
+                const list = groups.get(key)!;
+                if (!list.some((m) => m.githubId === member.githubId))
+                    list.push(member);
             }
         }
     }
     return positionOrder
-        .map(name => ({
+        .map((name) => ({
             name,
             color: positionConfig[name].color,
             description: positionConfig[name].description,
             techs: positionTechsMap.value[name] ?? [],
             members: groups.get(name)!,
         }))
-        .filter(g => g.members.length > 0)
-})
+        .filter((g) => g.members.length > 0);
+});
 
-const sectionRef = ref<HTMLElement | null>(null)
-const activeIndex = ref(0)
+const sectionRef = ref<HTMLElement | null>(null);
+const activeIndex = ref(0);
 
 const scrollToIndex = (i: number) => {
-    if (!sectionRef.value) return
-    const sectionTop = sectionRef.value.getBoundingClientRect().top + window.scrollY
-    const scrollable = sectionRef.value.offsetHeight - window.innerHeight
-    window.scrollTo({top: sectionTop + (i / positionGroups.value.length) * scrollable + 1, behavior: 'smooth'})
-}
+    if (!sectionRef.value) return;
+    const sectionTop =
+        sectionRef.value.getBoundingClientRect().top + window.scrollY;
+    const scrollable = sectionRef.value.offsetHeight - window.innerHeight;
+    window.scrollTo({
+        top: sectionTop + (i / positionGroups.value.length) * scrollable + 1,
+        behavior: "smooth",
+    });
+};
 
 onMounted(() => {
     const handleScroll = () => {
-        if (!sectionRef.value) return
-        const rect = sectionRef.value.getBoundingClientRect()
-        const scrollable = sectionRef.value.offsetHeight - window.innerHeight
-        if (scrollable <= 0) return
-        const progress = Math.max(0, Math.min(1, -rect.top / scrollable))
-        activeIndex.value = Math.min(positionGroups.value.length - 1, Math.floor(progress * positionGroups.value.length))
-    }
-    window.addEventListener('scroll', handleScroll, {passive: true})
-    onUnmounted(() => window.removeEventListener('scroll', handleScroll))
-})
+        if (!sectionRef.value) return;
+        const rect = sectionRef.value.getBoundingClientRect();
+        const scrollable = sectionRef.value.offsetHeight - window.innerHeight;
+        if (scrollable <= 0) return;
+        const progress = Math.max(0, Math.min(1, -rect.top / scrollable));
+        activeIndex.value = Math.min(
+            positionGroups.value.length - 1,
+            Math.floor(progress * positionGroups.value.length),
+        );
+    };
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    onUnmounted(() => window.removeEventListener("scroll", handleScroll));
+});
 
 function fillMarquee(list: Member[], min = 20): Member[] {
-    if (list.length === 0) return []
-    const result: Member[] = []
-    while (result.length < min) result.push(...list)
-    return result
+    if (list.length === 0) return [];
+    const result: Member[] = [];
+    while (result.length < min) result.push(...list);
+    return result;
 }
 
-const marqueeItems = fillMarquee(members)
-const row1 = [...marqueeItems, ...marqueeItems]
-const row2 = [...marqueeItems, ...marqueeItems]
+const marqueeItems = fillMarquee(members);
+const row1 = [...marqueeItems, ...marqueeItems];
+const row2 = [...marqueeItems, ...marqueeItems];
 </script>
 
 <template>
@@ -236,8 +290,10 @@ const row2 = [...marqueeItems, ...marqueeItems]
                 class="max-w-6xl mx-auto px-6 h-16 flex items-center justify-between"
             >
                 <div class="flex items-center gap-2.5">
-                    <CoworkLogo :size="28"/>
-                    <span class="font-bold text-base tracking-tight">cowork</span>
+                    <CoworkLogo :size="28" />
+                    <span class="font-bold text-base tracking-tight"
+                        >cowork</span
+                    >
                 </div>
                 <a
                     class="flex items-center gap-2 text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors duration-150"
@@ -245,9 +301,16 @@ const row2 = [...marqueeItems, ...marqueeItems]
                     rel="noopener noreferrer"
                     target="_blank"
                 >
-                    <svg aria-hidden="true" fill="currentColor" height="18" viewBox="0 0 24 24" width="18">
+                    <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        height="18"
+                        viewBox="0 0 24 24"
+                        width="18"
+                    >
                         <path
-                            d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
+                            d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"
+                        />
                     </svg>
                     GitHub
                 </a>
@@ -258,7 +321,7 @@ const row2 = [...marqueeItems, ...marqueeItems]
         <section class="pt-36 pb-28 px-6 text-center">
             <div class="max-w-3xl mx-auto">
                 <div class="flex justify-center mb-10">
-                    <CoworkLogo :size="160"/>
+                    <CoworkLogo :size="160" />
                 </div>
                 <h1
                     class="text-8xl font-black tracking-tighter mb-5 text-gray-900 leading-none"
@@ -278,9 +341,16 @@ const row2 = [...marqueeItems, ...marqueeItems]
                         rel="noopener noreferrer"
                         target="_blank"
                     >
-                        <svg aria-hidden="true" fill="currentColor" height="18" viewBox="0 0 24 24" width="18">
+                        <svg
+                            aria-hidden="true"
+                            fill="currentColor"
+                            height="18"
+                            viewBox="0 0 24 24"
+                            width="18"
+                        >
                             <path
-                                d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/>
+                                d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"
+                            />
                         </svg>
                         GitHub 조직 바로가기
                     </a>
@@ -296,26 +366,34 @@ const row2 = [...marqueeItems, ...marqueeItems]
 
         <!-- Divider -->
         <div class="max-w-6xl mx-auto px-6">
-            <div class="h-px bg-gradient-to-r from-transparent via-gray-200 to-transparent"/>
+            <div
+                class="h-px bg-gradient-to-r from-transparent via-gray-200 to-transparent"
+            />
         </div>
 
         <!-- Repos Section -->
         <section id="repos" class="py-24 px-6 bg-gray-50/60">
             <div class="max-w-6xl mx-auto">
                 <div class="text-center mb-14">
-                    <h2 class="text-3xl font-bold mb-3 tracking-tight">레포지토리</h2>
-                    <p class="text-gray-500">team-cowork 조직을 구성하는 프로젝트들</p>
+                    <h2 class="text-3xl font-bold mb-3 tracking-tight">
+                        레포지토리
+                    </h2>
+                    <p class="text-gray-500">
+                        team-cowork 조직을 구성하는 프로젝트들
+                    </p>
                 </div>
 
-                <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-5">
+                <div
+                    class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-5"
+                >
                     <a
                         v-for="(repo, index) in repos"
                         :key="repo.name"
                         :class="[
-              'group bg-white rounded-2xl p-6 border border-gray-100 hover:border-red-200 hover:shadow-md transition-all duration-200 flex flex-col',
-              'lg:col-span-2',
-              index === 3 ? 'lg:col-start-2' : '',
-            ]"
+                            'group bg-white rounded-2xl p-6 border border-gray-100 hover:border-red-200 hover:shadow-md transition-all duration-200 flex flex-col',
+                            'lg:col-span-2',
+                            index === 3 ? 'lg:col-start-2' : '',
+                        ]"
                         :href="repo.url"
                         rel="noopener noreferrer"
                         target="_blank"
@@ -332,14 +410,15 @@ const row2 = [...marqueeItems, ...marqueeItems]
                                     width="18"
                                 >
                                     <path
-                                        d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
+                                        d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"
+                                    />
                                 </svg>
                             </div>
                             <span
                                 class="text-xs font-medium px-2.5 py-1 bg-gray-100 text-gray-500 rounded-full"
                             >
-                {{ repo.badge }}
-              </span>
+                                {{ repo.badge }}
+                            </span>
                         </div>
 
                         <h3
@@ -351,7 +430,9 @@ const row2 = [...marqueeItems, ...marqueeItems]
                             {{ repo.description }}
                         </p>
 
-                        <div class="mt-4 rounded-xl overflow-hidden border border-gray-50">
+                        <div
+                            class="mt-4 rounded-xl overflow-hidden border border-gray-50"
+                        >
                             <img
                                 :alt="`${repo.name} language stats`"
                                 :src="`https://github-repository-language-graph-wi.vercel.app/api?username=team-cowork&repo=${repo.name}&theme=white&langs_count=100`"
@@ -375,11 +456,15 @@ const row2 = [...marqueeItems, ...marqueeItems]
                                 viewBox="0 0 24 24"
                                 width="11"
                             >
-                                <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
-                                <polyline points="15 3 21 3 21 9"/>
-                                <line x1="10" x2="21" y1="14" y2="3"/>
+                                <path
+                                    d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+                                />
+                                <polyline points="15 3 21 3 21 9" />
+                                <line x1="10" x2="21" y1="14" y2="3" />
                             </svg>
-                            <span class="truncate">github.com/team-cowork/{{ repo.name }}</span>
+                            <span class="truncate"
+                                >github.com/team-cowork/{{ repo.name }}</span
+                            >
                         </div>
                     </a>
                 </div>
@@ -388,14 +473,18 @@ const row2 = [...marqueeItems, ...marqueeItems]
 
         <!-- Divider -->
         <div class="max-w-6xl mx-auto px-6">
-            <div class="h-px bg-gradient-to-r from-transparent via-gray-200 to-transparent"/>
+            <div
+                class="h-px bg-gradient-to-r from-transparent via-gray-200 to-transparent"
+            />
         </div>
 
         <!-- Tech Stack Section -->
         <section class="py-24 px-6">
             <div class="max-w-4xl mx-auto">
                 <div class="text-center mb-14">
-                    <h2 class="text-3xl font-bold mb-3 tracking-tight">기술 스택</h2>
+                    <h2 class="text-3xl font-bold mb-3 tracking-tight">
+                        기술 스택
+                    </h2>
                     <p class="text-gray-500">cowork을 만드는 기술들</p>
                 </div>
 
@@ -405,23 +494,23 @@ const row2 = [...marqueeItems, ...marqueeItems]
                         :key="cat.label"
                         class="flex items-start gap-6"
                     >
-            <span
-                class="text-xs font-semibold text-gray-400 uppercase tracking-wider w-24 shrink-0 pt-2"
-            >
-              {{ cat.label }}
-            </span>
+                        <span
+                            class="text-xs font-semibold text-gray-400 uppercase tracking-wider w-24 shrink-0 pt-2"
+                        >
+                            {{ cat.label }}
+                        </span>
                         <div class="flex flex-wrap gap-2">
-              <span
-                  v-for="tech in cat.items"
-                  :key="tech.name"
-                  class="inline-flex items-center gap-2 px-3.5 py-1.5 bg-gray-50 border border-gray-100 rounded-full text-sm text-gray-700 font-medium"
-              >
-                <span
-                    :style="{ backgroundColor: tech.color }"
-                    class="w-2 h-2 rounded-full shrink-0"
-                />
-                {{ tech.name }}
-              </span>
+                            <span
+                                v-for="tech in cat.items"
+                                :key="tech.name"
+                                class="inline-flex items-center gap-2 px-3.5 py-1.5 bg-gray-50 border border-gray-100 rounded-full text-sm text-gray-700 font-medium"
+                            >
+                                <span
+                                    :style="{ backgroundColor: tech.color }"
+                                    class="w-2 h-2 rounded-full shrink-0"
+                                />
+                                {{ tech.name }}
+                            </span>
                         </div>
                     </div>
                 </div>
@@ -430,7 +519,9 @@ const row2 = [...marqueeItems, ...marqueeItems]
 
         <!-- Divider -->
         <div class="max-w-6xl mx-auto px-6">
-            <div class="h-px bg-gradient-to-r from-transparent via-gray-200 to-transparent"/>
+            <div
+                class="h-px bg-gradient-to-r from-transparent via-gray-200 to-transparent"
+            />
         </div>
 
         <!-- Position Section -->
@@ -439,7 +530,9 @@ const row2 = [...marqueeItems, ...marqueeItems]
             :style="{ height: `calc(${positionGroups.length} * 50vh + 100vh)` }"
             class="relative"
         >
-            <div class="sticky top-0 h-screen overflow-hidden bg-white flex flex-col justify-center">
+            <div
+                class="sticky top-0 h-screen overflow-hidden bg-white flex flex-col justify-center"
+            >
                 <!-- Background index number -->
                 <div
                     class="absolute inset-0 flex items-center pointer-events-none select-none overflow-hidden"
@@ -447,58 +540,96 @@ const row2 = [...marqueeItems, ...marqueeItems]
                 >
                     <span
                         class="font-black leading-none transition-all duration-700"
-                        style="font-size: clamp(160px, 28vw, 380px); opacity: 0.04; line-height: 1; padding-left: 4vw;"
+                        style="
+                            font-size: clamp(160px, 28vw, 380px);
+                            opacity: 0.04;
+                            line-height: 1;
+                            padding-left: 4vw;
+                        "
                         :style="{ color: positionGroups[activeIndex]?.color }"
                     >
-                        {{ String(activeIndex + 1).padStart(2, '0') }}
+                        {{ String(activeIndex + 1).padStart(2, "0") }}
                     </span>
                 </div>
 
                 <div class="max-w-6xl mx-auto px-6 w-full relative z-10">
                     <!-- Top bar -->
                     <div class="flex items-center justify-between mb-8">
-                        <span class="text-xs font-semibold text-gray-400 uppercase tracking-widest">Position</span>
-                        <span class="text-xs text-gray-400 font-medium tabular-nums">
-                            {{ String(activeIndex + 1).padStart(2, '0') }} / {{ String(positionGroups.length).padStart(2, '0') }}
+                        <span
+                            class="text-xs font-semibold text-gray-400 uppercase tracking-widest"
+                            >Position</span
+                        >
+                        <span
+                            class="text-xs text-gray-400 font-medium tabular-nums"
+                        >
+                            {{ String(activeIndex + 1).padStart(2, "0") }} /
+                            {{ String(positionGroups.length).padStart(2, "0") }}
                         </span>
                     </div>
 
                     <!-- Panel content: fixed-height container prevents layout shift -->
-                    <div class="relative" style="height: 46vh; min-height: 300px;">
+                    <div
+                        class="relative"
+                        style="height: 46vh; min-height: 300px"
+                    >
                         <Transition name="pos-panel" mode="out-in">
-                            <div :key="activeIndex" class="absolute inset-0 grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
+                            <div
+                                :key="activeIndex"
+                                class="absolute inset-0 grid grid-cols-1 lg:grid-cols-2 gap-10 items-center"
+                            >
                                 <!-- Left: text + techs -->
                                 <div>
                                     <div
                                         class="w-2 h-2 rounded-full mb-5"
-                                        :style="{ backgroundColor: positionGroups[activeIndex]?.color }"
+                                        :style="{
+                                            backgroundColor:
+                                                positionGroups[activeIndex]
+                                                    ?.color,
+                                        }"
                                     />
                                     <h2
                                         class="text-5xl lg:text-6xl font-black tracking-tight leading-tight mb-5"
-                                        :style="{ color: positionGroups[activeIndex]?.color }"
+                                        :style="{
+                                            color: positionGroups[activeIndex]
+                                                ?.color,
+                                        }"
                                     >
                                         {{ positionGroups[activeIndex]?.name }}
                                     </h2>
-                                    <p class="text-gray-500 text-base leading-relaxed mb-5">
-                                        {{ positionGroups[activeIndex]?.description }}
+                                    <p
+                                        class="text-gray-500 text-base leading-relaxed mb-5"
+                                    >
+                                        {{
+                                            positionGroups[activeIndex]
+                                                ?.description
+                                        }}
                                     </p>
                                     <div class="flex flex-wrap gap-2">
                                         <span
-                                            v-for="tech in positionGroups[activeIndex]?.techs"
+                                            v-for="tech in positionGroups[
+                                                activeIndex
+                                            ]?.techs"
                                             :key="tech"
                                             class="text-xs font-semibold px-2.5 py-1 rounded-full"
                                             :style="{
                                                 backgroundColor: `${positionGroups[activeIndex]?.color}15`,
-                                                color: positionGroups[activeIndex]?.color,
+                                                color: positionGroups[
+                                                    activeIndex
+                                                ]?.color,
                                             }"
-                                        >{{ tech }}</span>
+                                            >{{ tech }}</span
+                                        >
                                     </div>
                                 </div>
 
                                 <!-- Right: members -->
-                                <div class="flex flex-wrap gap-3 content-start pb-1">
+                                <div
+                                    class="flex flex-wrap gap-3 content-start pb-1"
+                                >
                                     <a
-                                        v-for="member in positionGroups[activeIndex]?.members"
+                                        v-for="member in positionGroups[
+                                            activeIndex
+                                        ]?.members"
                                         :key="member.githubId"
                                         :href="`https://github.com/${member.githubId}`"
                                         target="_blank"
@@ -519,8 +650,14 @@ const row2 = [...marqueeItems, ...marqueeItems]
                                             decoding="async"
                                         />
                                         <div>
-                                            <p class="text-sm font-semibold text-gray-900 leading-tight">{{ member.name }}</p>
-                                            <p class="text-xs text-gray-400">{{ member.cohort }}</p>
+                                            <p
+                                                class="text-sm font-semibold text-gray-900 leading-tight"
+                                            >
+                                                {{ member.name }}
+                                            </p>
+                                            <p class="text-xs text-gray-400">
+                                                {{ member.cohort }}
+                                            </p>
                                         </div>
                                     </a>
                                 </div>
@@ -536,7 +673,10 @@ const row2 = [...marqueeItems, ...marqueeItems]
                             class="h-1 rounded-full transition-all duration-500 cursor-pointer"
                             :style="{
                                 width: activeIndex === i ? '32px' : '8px',
-                                backgroundColor: activeIndex === i ? positionGroups[activeIndex]?.color : '#E5E7EB',
+                                backgroundColor:
+                                    activeIndex === i
+                                        ? positionGroups[activeIndex]?.color
+                                        : '#E5E7EB',
                             }"
                             @click="scrollToIndex(i)"
                         />
@@ -547,7 +687,9 @@ const row2 = [...marqueeItems, ...marqueeItems]
 
         <!-- Divider -->
         <div class="max-w-6xl mx-auto px-6">
-            <div class="h-px bg-gradient-to-r from-transparent via-gray-200 to-transparent"/>
+            <div
+                class="h-px bg-gradient-to-r from-transparent via-gray-200 to-transparent"
+            />
         </div>
 
         <!-- Team Section -->
@@ -588,7 +730,7 @@ const row2 = [...marqueeItems, ...marqueeItems]
                 class="max-w-6xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4"
             >
                 <div class="flex items-center gap-2.5">
-                    <CoworkLogo :size="22"/>
+                    <CoworkLogo :size="22" />
                     <span class="font-bold text-sm text-gray-900">cowork</span>
                 </div>
                 <p class="text-sm text-gray-400">

--- a/cowork-promotion/pages/index.vue
+++ b/cowork-promotion/pages/index.vue
@@ -111,10 +111,10 @@ const techCategories: { label: string; items: TechItem[] }[] = [
     {
         label: "Build Tools",
         items: [
-            { name: "Maven", color: "#C71C36", positions: [] },
-            { name: "Gradle", color: "#02303A", positions: [] },
-            { name: "Amper", color: "#1F6FEB", positions: [] },
-            { name: "Bazel", color: "#092E20", positions: [] },
+            { name: "Maven", color: "#C71C36", positions: ["Server"] },
+            { name: "Gradle", color: "#02303A", positions: ["Server"] },
+            { name: "Amper", color: "#1F6FEB", positions: ["Server"] },
+            { name: "Bazel", color: "#092E20", positions: ["Server"] },
         ],
     },
 ];


### PR DESCRIPTION
## 개요

`cowork-promotion` 프로젝트의 기술 스택에 빌드 도구를 추가하였습니다. README와 프로모션 웹사이트에 `Maven`, `Gradle`, `Amper`, `Bazel`을 기술스택으로 표시하였습니다.

## 본문

cowork 팀의 다양한 빌드 시스템 활용을 반영하기 위해 프로모션 페이지의 기술 스택 섹션에 "Build Tools" 카테고리를 추가하였습니다. 각 빌드 도구는 다음과 같이 구성되었습니다.

### 변경 사항

- **`cowork-promotion/README.md`**: 스택 섹션에 `Maven`, `Gradle`, `Amper`, `Bazel` 항목 추가
- **`cowork-promotion/pages/index.vue`**: `techCategories` 배열에 "Build Tools" 카테고리 추가
  - `Maven` (색상: `#C71C36`)
  - `Gradle` (색상: `#02303A`)
  - `Amper` (색상: `#1F6FEB`)
  - `Bazel` (색상: `#092E20`)

### 영향 범위

- 프로모션 웹사이트의 기술 스택 섹션에서 빌드 도구 항목이 새로 표시됩니다.
- 별도의 기능적 변경 사항은 없습니다.
