### PR TITLE
[chat] 첨부파일 URL 소유권 미검증 취약점 및 Outbox stuck 수정

### DIFF
--- a/cowork-chat/package-lock.json
+++ b/cowork-chat/package-lock.json
@@ -24,7 +24,7 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "dotenv": "^17.4.2",
-        "ioredis": "^5.6.1",
+        "ioredis": "^5.11.1",
         "kafkajs": "^2.2.4",
         "mime-types": "^3.0.2",
         "minio": "^8.0.7",

--- a/cowork-chat/package.json
+++ b/cowork-chat/package.json
@@ -31,7 +31,7 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "dotenv": "^17.4.2",
-    "ioredis": "^5.6.1",
+    "ioredis": "^5.11.1",
     "kafkajs": "^2.2.4",
     "mime-types": "^3.0.2",
     "minio": "^8.0.7",

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import { Types } from 'mongoose';
 import { ChatService } from './chat.service';
 import { ChatGateway } from './chat.gateway';
@@ -74,6 +74,7 @@ const mockElasticsearchService = {
 const mockMinioService = {
     createPresignedUpload: jest.fn(),
     confirmUpload: jest.fn(),
+    assertOwnedAttachmentUrl: jest.fn(),
 };
 
 const mockChatMessageProducer = {
@@ -181,6 +182,32 @@ describe('ChatService', () => {
             mockChannelMemberRepository.findMembership.mockResolvedValue(null);
 
             await expect(service.sendMessage(ctx, { content: 'hi' } as any)).rejects.toThrow(ForbiddenException);
+            expect(mockChatMessageProducer.sendMessage).not.toHaveBeenCalled();
+        });
+
+        it('첨부파일이 있으면 각 url의 소유권을 검증한다', async () => {
+            mockChannelMemberRepository.findMembership.mockResolvedValue({ teamId: 100, channelType: 'TEXT' });
+            mockMinioService.assertOwnedAttachmentUrl.mockReturnValue(undefined);
+            const attachments = [
+                { name: 'a.png', url: 'http://minio/chat-files/1/42/uuid.png', size: 1, mimeType: 'image/png' },
+            ];
+
+            await service.sendMessage(ctx, { content: 'hi', attachments } as any);
+
+            expect(mockMinioService.assertOwnedAttachmentUrl).toHaveBeenCalledWith(attachments[0].url, 1, 42);
+            expect(mockChatMessageProducer.sendMessage).toHaveBeenCalled();
+        });
+
+        it('소유하지 않은 첨부파일 url이면 검증에서 던진 예외가 전파되고 발행되지 않는다', async () => {
+            mockChannelMemberRepository.findMembership.mockResolvedValue({ teamId: 100, channelType: 'TEXT' });
+            mockMinioService.assertOwnedAttachmentUrl.mockImplementation(() => {
+                throw new BadRequestException('첨부파일 URL이 유효하지 않습니다');
+            });
+            const attachments = [
+                { name: 'a.png', url: 'http://minio/chat-files/999/7/uuid.png', size: 1, mimeType: 'image/png' },
+            ];
+
+            await expect(service.sendMessage(ctx, { content: 'hi', attachments } as any)).rejects.toThrow(BadRequestException);
             expect(mockChatMessageProducer.sendMessage).not.toHaveBeenCalled();
         });
 

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -221,6 +221,10 @@ export class ChatService {
             message.attachments.map(async (attachment) => {
                 try {
                     const objectKey = this.minioService.extractObjectKey(attachment.url);
+                    if (!objectKey.startsWith(`chat-files/${ctx.channelId}/`)) {
+                        this.logger.warn(`채널 범위를 벗어난 objectKey 삭제를 건너뜁니다 [key=${objectKey}]`);
+                        return;
+                    }
                     await this.minioService.removeObject(objectKey);
                 } catch (error) {
                     this.logger.warn(`MinIO 파일 삭제 실패 [url=${attachment.url}]`, error);
@@ -250,6 +254,12 @@ export class ChatService {
     async sendMessage(ctx: ChannelUserRoleContext, dto: SendMessageDto): Promise<void> {
         const membership = await this.channelMemberRepository.findMembership(ctx.channelId, ctx.userId);
         if (!membership) throw new ForbiddenException('채널 접근 권한이 없습니다');
+
+        if (dto.attachments?.length) {
+            for (const attachment of dto.attachments) {
+                this.minioService.assertOwnedAttachmentUrl(attachment.url, ctx.channelId, ctx.userId);
+            }
+        }
 
         if (membership.channelType === DM_CHANNEL_TYPE) {
             await this.verifyDmSendable(ctx.channelId, ctx.userId);

--- a/cowork-chat/src/chat/dto/send-message.dto.ts
+++ b/cowork-chat/src/chat/dto/send-message.dto.ts
@@ -1,4 +1,5 @@
-import { IsNumber, IsOptional, IsString, MaxLength, IsEnum, IsArray, IsMongoId } from 'class-validator';
+import { IsNumber, IsOptional, IsString, MaxLength, IsEnum, IsArray, IsMongoId, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class AttachmentDto {
@@ -29,7 +30,7 @@ export class SendMessageDto {
     @IsEnum(['TEXT', 'FILE']) @IsOptional() type?: string;
 
     @ApiPropertyOptional({ type: [AttachmentDto], description: 'S3 첨부파일 목록' })
-    @IsArray() @IsOptional() attachments?: AttachmentDto[];
+    @IsArray() @IsOptional() @ValidateNested({ each: true }) @Type(() => AttachmentDto) attachments?: AttachmentDto[];
 
     @ApiPropertyOptional({ description: '답장 대상 메시지 ID (MongoDB ObjectId)' })
     @IsMongoId() @IsOptional() parentMessageId?: string;

--- a/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
+++ b/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
@@ -11,6 +11,8 @@ const BATCH_SIZE = 10;
 const MAX_RETRY = 3;
 /** 이 시간(2분) 이상 PROCESSING에 머문 메시지를 PENDING으로 회수한다 */
 const PROCESSING_STALE_THRESHOLD_MS = 2 * 60 * 1_000;
+/** reclaimStaleProcessing 실행 최소 간격 — 5초마다 updateMany를 보내지 않도록 스로틀 */
+const RECLAIM_INTERVAL_MS = 60_000;
 
 /**
  * 알림 발송 대기 중인 메시지를 주기적으로 조회하여 알림 트리거를 발행하는 폴러.
@@ -25,6 +27,7 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
     private readonly logger = new Logger(NotificationOutboxPoller.name);
     private timer?: ReturnType<typeof setInterval>;
     private isPolling = false;
+    private lastReclaimTime = 0;
 
     constructor(
         private readonly messageRepository: MessageRepository,
@@ -67,10 +70,14 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
      * 4. 처리 실패 시 재시도 횟수에 따라 PENDING 또는 FAILED로 전환한다.
      */
     private async poll(): Promise<void> {
-        // 0단계: 크래시 등으로 stuck된 stale PROCESSING 메시지를 PENDING으로 회수
-        const reclaimed = await this.messageRepository.reclaimStaleProcessing(PROCESSING_STALE_THRESHOLD_MS);
-        if (reclaimed > 0) {
-            this.logger.warn(`stale PROCESSING 메시지 ${reclaimed}개를 PENDING으로 회수했습니다`);
+        // 0단계: 크래시 등으로 stuck된 stale PROCESSING 메시지를 PENDING으로 회수 (1분 간격 스로틀)
+        const now = Date.now();
+        if (now - this.lastReclaimTime > RECLAIM_INTERVAL_MS) {
+            this.lastReclaimTime = now;
+            const reclaimed = await this.messageRepository.reclaimStaleProcessing(PROCESSING_STALE_THRESHOLD_MS);
+            if (reclaimed > 0) {
+                this.logger.warn(`stale PROCESSING 메시지 ${reclaimed}개를 PENDING으로 회수했습니다`);
+            }
         }
 
         // 1단계: 배치 내 메시지 수집 (PENDING → PROCESSING 원자적 전환)

--- a/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
+++ b/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
@@ -9,6 +9,8 @@ import { ChannelMemberRepository } from '../repository/channel-member.repository
 const POLL_INTERVAL_MS = 5_000;
 const BATCH_SIZE = 10;
 const MAX_RETRY = 3;
+/** 이 시간(2분) 이상 PROCESSING에 머문 메시지를 PENDING으로 회수한다 */
+const PROCESSING_STALE_THRESHOLD_MS = 2 * 60 * 1_000;
 
 /**
  * 알림 발송 대기 중인 메시지를 주기적으로 조회하여 알림 트리거를 발행하는 폴러.
@@ -65,6 +67,12 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
      * 4. 처리 실패 시 재시도 횟수에 따라 PENDING 또는 FAILED로 전환한다.
      */
     private async poll(): Promise<void> {
+        // 0단계: 크래시 등으로 stuck된 stale PROCESSING 메시지를 PENDING으로 회수
+        const reclaimed = await this.messageRepository.reclaimStaleProcessing(PROCESSING_STALE_THRESHOLD_MS);
+        if (reclaimed > 0) {
+            this.logger.warn(`stale PROCESSING 메시지 ${reclaimed}개를 PENDING으로 회수했습니다`);
+        }
+
         // 1단계: 배치 내 메시지 수집 (PENDING → PROCESSING 원자적 전환)
         const msgs: NotificationMessage[] = [];
         for (let i = 0; i < BATCH_SIZE; i++) {

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -350,7 +350,7 @@ export class MessageRepository {
         return this.messageModel.findOneAndUpdate(
             { notificationStatus: 'PENDING' },
             { $set: { notificationStatus: 'PROCESSING', notificationProcessingStartedAt: new Date() } },
-            { new: true },
+            { sort: { createdAt: 1 }, new: true },
         ).lean() as Promise<NotificationMessage | null>;
     }
 

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -349,9 +349,30 @@ export class MessageRepository {
     findOnePendingAndMarkProcessing(): Promise<NotificationMessage | null> {
         return this.messageModel.findOneAndUpdate(
             { notificationStatus: 'PENDING' },
-            { $set: { notificationStatus: 'PROCESSING' } },
+            { $set: { notificationStatus: 'PROCESSING', notificationProcessingStartedAt: new Date() } },
             { new: true },
         ).lean() as Promise<NotificationMessage | null>;
+    }
+
+    /**
+     * PROCESSING 상태로 전환된 지 `staleThresholdMs` 이상 경과한 메시지를 PENDING으로 되돌립니다.
+     *
+     * 폴러 프로세스가 크래시하면 메시지가 PROCESSING에 영구 stuck될 수 있습니다.
+     * 폴러는 PENDING만 조회하므로 이 회수 없이는 해당 메시지의 알림이 영구 유실됩니다.
+     *
+     * @param staleThresholdMs - PROCESSING을 stale로 판단하는 경과 시간 (밀리초)
+     * @returns 회수된 메시지 수
+     */
+    async reclaimStaleProcessing(staleThresholdMs: number): Promise<number> {
+        const staleBeforeDate = new Date(Date.now() - staleThresholdMs);
+        const result = await this.messageModel.updateMany(
+            {
+                notificationStatus: 'PROCESSING',
+                notificationProcessingStartedAt: { $lt: staleBeforeDate },
+            },
+            { $set: { notificationStatus: 'PENDING', notificationProcessingStartedAt: null } },
+        );
+        return result.modifiedCount;
     }
 
     /**

--- a/cowork-chat/src/chat/schema/message.schema.ts
+++ b/cowork-chat/src/chat/schema/message.schema.ts
@@ -160,6 +160,13 @@ export class Message {
      * 한도 초과 시 `notificationStatus`가 `FAILED`로 전환됩니다.
      */
     @Prop({ default: 0 }) notificationRetryCount!: number;
+
+    /**
+     * PROCESSING 상태로 전환된 시각.
+     * 폴러 프로세스가 크래시하여 PROCESSING에 영구 stuck되는 상황을 방지하기 위해
+     * 이 값이 일정 시간 이상 경과하면 PENDING으로 회수한다.
+     */
+    @Prop({ type: Date, default: null }) notificationProcessingStartedAt!: Date | null;
 }
 
 /** {@link Message} 클래스로부터 생성된 Mongoose 스키마 인스턴스 */

--- a/cowork-chat/src/main.ts
+++ b/cowork-chat/src/main.ts
@@ -27,7 +27,7 @@ async function bootstrap() {
     debugStartup('Nest application created');
     app.useLogger(app.get(PinoLogger));
     app.setGlobalPrefix('chat', { exclude: ['health'] });
-    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
     app.useStaticAssets(join(__dirname, '..', 'public'));
 
     const config = new DocumentBuilder()

--- a/cowork-chat/src/storage/minio.service.ts
+++ b/cowork-chat/src/storage/minio.service.ts
@@ -141,6 +141,24 @@ export class MinioService implements OnModuleInit, OnModuleDestroy {
         return fileUrl.slice(prefix.length);
     }
 
+    /**
+     * 첨부파일 URL이 해당 채널·사용자가 실제로 업로드한 오브젝트를 가리키는지 검증한다.
+     * presigned/confirm 단계를 우회해 임의의 objectKey(타 채널·타 사용자 파일)를
+     * 메시지 attachments에 삽입하는 것을 차단한다.
+     *
+     * @param fileUrl - 검증할 첨부파일 URL
+     * @param channelId - 메시지가 속한 채널 ID
+     * @param userId - 업로더(메시지 작성자) ID
+     * @throws BadRequestException URL이 `chat-files/{channelId}/{userId}/` prefix를 벗어난 경우
+     */
+    assertOwnedAttachmentUrl(fileUrl: string, channelId: number, userId: number): void {
+        const objectKey = this.extractObjectKey(fileUrl);
+        const expectedPrefix = `chat-files/${channelId}/${userId}/`;
+        if (!objectKey.startsWith(expectedPrefix)) {
+            throw new BadRequestException('첨부파일 URL이 유효하지 않습니다');
+        }
+    }
+
     private validateCredentials(): void {
         if (!this.config.accessKey || !this.config.secretKey) {
             throw new Error('MinIO 접근 키 설정이 필요합니다 (MINIO_ACCESS_KEY, MINIO_SECRET_KEY)');


### PR DESCRIPTION
## 개요

`cowork-chat` 서비스에서 발견된 보안 취약점 2건과 안정성 버그 1건을 수정하였습니다. 첨부파일 URL 소유권 미검증으로 인한 타 사용자 파일 삭제 가능 문제, `ValidationPipe` 설정 누락으로 인한 숫자 파라미터 변환 오류, 그리고 Outbox 폴러 크래시 시 알림 메시지가 `PROCESSING` 상태에 영구적으로 stuck되는 문제를 수정하였습니다.

## 본문

### 1. 첨부파일 URL 소유권 미검증 취약점 수정 (보안)

`sendMessage` 경로에서 `attachments[].url`에 대한 소유권 검증이 없었습니다. 클라이언트가 `presigned URL → confirmUpload` 흐름을 우회하여 타 채널·타 사용자의 MinIO objectKey를 가리키는 URL을 메시지에 직접 삽입할 수 있었으며, 이후 `deleteFile` 호출 시 `extractObjectKey`가 해당 키를 그대로 `removeObject`에 전달하여 **권한 없는 파일을 삭제**할 수 있었습니다.

- `MinioService`에 `assertOwnedAttachmentUrl()` 헬퍼를 추가하였습니다. objectKey가 `chat-files/{channelId}/{userId}/` prefix를 벗어나면 `BadRequestException`을 던집니다.
- `ChatService.sendMessage`에서 멤버십 확인 직후 모든 attachment URL의 소유권을 검증합니다.
- `ChatService.deleteFile`의 `removeObject` 호출 전에 objectKey가 해당 채널 prefix 범위 내인지 확인하는 방어 로직을 추가하였습니다.
- `SendMessageDto.attachments`에 `@ValidateNested({ each: true })`와 `@Type(() => AttachmentDto)`를 추가하여 중첩 필드를 검증합니다.

### 2. `ValidationPipe` `transform` 옵션 누락 수정

`main.ts`의 전역 `ValidationPipe`에 `transform: true`가 없어 `class-transformer`의 `@Type(() => Number)` 변환이 동작하지 않았습니다. 검색·파일목록 DTO의 숫자 쿼리 파라미터가 문자열로 남아 `@IsInt()` 검증이 오작동하고, `searchProjectMessages`의 `accessibleChannelIds.includes(dto.channelId)` 권한 필터가 항상 `false`를 반환하는 문제가 있었습니다.

- `new ValidationPipe({ whitelist: true, transform: true })`로 수정하였습니다.

### 3. Outbox `PROCESSING` 영구 stuck 방지

알림 Outbox 폴러가 메시지를 `PENDING → PROCESSING`으로 전환한 직후 크래시(OOM·재배포·`process.exit`)하면, 해당 메시지는 `PROCESSING` 상태에 영구적으로 남습니다. 폴러는 `PENDING` 상태만 조회하므로 이 메시지의 알림은 영구 유실되었습니다.

- `Message` 스키마에 `notificationProcessingStartedAt: Date | null` 필드를 추가하였습니다.
- `MessageRepository.findOnePendingAndMarkProcessing`이 `PROCESSING` 전환 시 타임스탬프를 함께 기록합니다.
- `MessageRepository.reclaimStaleProcessing(thresholdMs)`을 추가하였습니다. `PROCESSING` 상태로 지정 시간(2분) 이상 경과한 메시지를 `PENDING`으로 일괄 회수합니다.
- `NotificationOutboxPoller`의 각 폴링 사이클 시작 시 `reclaimStaleProcessing`을 호출하며, 회수가 발생하면 경고 로그를 남깁니다.
