### PR TITLE
[chat] 전역 Guard·Interceptor 추가 및 모니터링 Discord 알림 연동

### DIFF
--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -1,4 +1,7 @@
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { Module } from '@nestjs/common';
+import { AuthGuard } from '../common/guard/auth.guard';
+import { HttpLoggingInterceptor } from '../common/interceptor/http-logging.interceptor';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
@@ -116,6 +119,8 @@ function createLogStream() {
     ],
     controllers: [ChatController, DmController, ProjectMessageController, TeamUnreadController, TeamSearchController, HealthController],
     providers: [
+        { provide: APP_GUARD, useClass: AuthGuard },
+        { provide: APP_INTERCEPTOR, useClass: HttpLoggingInterceptor },
         ChatGateway,
         ChatService,
         MessageRepository,

--- a/cowork-chat/src/common/guard/auth.guard.ts
+++ b/cowork-chat/src/common/guard/auth.guard.ts
@@ -1,0 +1,38 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+import { UserRole } from '../enum/user-role.enum';
+import { IS_PUBLIC_KEY } from './public.decorator';
+import { ROLES_KEY } from './roles.decorator';
+
+@Injectable()
+export class AuthGuard implements CanActivate {
+    constructor(private readonly reflector: Reflector) {}
+
+    canActivate(context: ExecutionContext): boolean {
+        const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+            context.getHandler(),
+            context.getClass(),
+        ]);
+        if (isPublic) return true;
+
+        const request = context.switchToHttp().getRequest<Request>();
+        const path = request.path;
+        if (path === '/metrics') return true;
+
+        const userId = request.headers['x-user-id'];
+        if (!userId) throw new UnauthorizedException('x-user-id 헤더가 없습니다');
+
+        const requiredRoles = this.reflector.getAllAndOverride<UserRole[]>(ROLES_KEY, [
+            context.getHandler(),
+            context.getClass(),
+        ]);
+        if (!requiredRoles || requiredRoles.length === 0) return true;
+
+        const userRole = request.headers['x-user-role'] as string | undefined;
+        if (!requiredRoles.includes(userRole as UserRole)) {
+            throw new ForbiddenException('접근 권한이 없습니다');
+        }
+        return true;
+    }
+}

--- a/cowork-chat/src/common/guard/auth.guard.ts
+++ b/cowork-chat/src/common/guard/auth.guard.ts
@@ -10,6 +10,8 @@ export class AuthGuard implements CanActivate {
     constructor(private readonly reflector: Reflector) {}
 
     canActivate(context: ExecutionContext): boolean {
+        if (context.getType() !== 'http') return true;
+
         const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
             context.getHandler(),
             context.getClass(),

--- a/cowork-chat/src/common/guard/public.decorator.ts
+++ b/cowork-chat/src/common/guard/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/cowork-chat/src/common/guard/roles.decorator.ts
+++ b/cowork-chat/src/common/guard/roles.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { UserRole } from '../enum/user-role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: UserRole[]) => SetMetadata(ROLES_KEY, roles);

--- a/cowork-chat/src/common/interceptor/http-logging.interceptor.ts
+++ b/cowork-chat/src/common/interceptor/http-logging.interceptor.ts
@@ -7,21 +7,34 @@ export class HttpLoggingInterceptor implements NestInterceptor {
     private readonly logger = new Logger('HttpLog');
 
     intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+        if (context.getType() !== 'http') return next.handle();
+
         const request = context.switchToHttp().getRequest<Request>();
         const { method, path } = request;
         const userId = request.headers['x-user-id'] ?? '-';
         const start = Date.now();
 
         return next.handle().pipe(
-            tap(() => {
-                const response = context.switchToHttp().getResponse<Response>();
-                this.logger.log({
-                    method,
-                    path,
-                    userId,
-                    statusCode: response.statusCode,
-                    duration: Date.now() - start,
-                });
+            tap({
+                next: () => {
+                    const response = context.switchToHttp().getResponse<Response>();
+                    this.logger.log({
+                        method,
+                        path,
+                        userId,
+                        statusCode: response.statusCode,
+                        duration: Date.now() - start,
+                    });
+                },
+                error: (err: { status?: number; statusCode?: number }) => {
+                    this.logger.log({
+                        method,
+                        path,
+                        userId,
+                        statusCode: err?.status ?? err?.statusCode ?? 500,
+                        duration: Date.now() - start,
+                    });
+                },
             }),
         );
     }

--- a/cowork-chat/src/common/interceptor/http-logging.interceptor.ts
+++ b/cowork-chat/src/common/interceptor/http-logging.interceptor.ts
@@ -1,0 +1,28 @@
+import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from '@nestjs/common';
+import { Request, Response } from 'express';
+import { Observable, tap } from 'rxjs';
+
+@Injectable()
+export class HttpLoggingInterceptor implements NestInterceptor {
+    private readonly logger = new Logger('HttpLog');
+
+    intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+        const request = context.switchToHttp().getRequest<Request>();
+        const { method, path } = request;
+        const userId = request.headers['x-user-id'] ?? '-';
+        const start = Date.now();
+
+        return next.handle().pipe(
+            tap(() => {
+                const response = context.switchToHttp().getResponse<Response>();
+                this.logger.log({
+                    method,
+                    path,
+                    userId,
+                    statusCode: response.statusCode,
+                    duration: Date.now() - start,
+                });
+            }),
+        );
+    }
+}

--- a/cowork-chat/src/health.controller.ts
+++ b/cowork-chat/src/health.controller.ts
@@ -1,5 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
+import { Public } from './common/guard/public.decorator';
 
+@Public()
 @Controller('health')
 export class HealthController {
     @Get()

--- a/cowork-monitoring/alertmanager/alertmanager.yml
+++ b/cowork-monitoring/alertmanager/alertmanager.yml
@@ -15,7 +15,7 @@ route:
 receivers:
   - name: discord
     discord_configs:
-      - webhook_url: '{{ env "DISCORD_WEBHOOK_URL" }}'
+      - webhook_url: '${DISCORD_WEBHOOK_URL}'
         title: '[{{ .Status | toUpper }}] {{ .GroupLabels.alertname }}'
         message: |-
           {{ range .Alerts }}

--- a/cowork-monitoring/alertmanager/alertmanager.yml
+++ b/cowork-monitoring/alertmanager/alertmanager.yml
@@ -1,0 +1,25 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: discord
+  group_by: [alertname, service]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - matchers:
+        - severity = critical
+      repeat_interval: 1h
+
+receivers:
+  - name: discord
+    discord_configs:
+      - webhook_url: '{{ env "DISCORD_WEBHOOK_URL" }}'
+        title: '[{{ .Status | toUpper }}] {{ .GroupLabels.alertname }}'
+        message: |-
+          {{ range .Alerts }}
+          **Service**: {{ .Labels.service }}
+          **Severity**: {{ .Labels.severity }}
+          {{ .Annotations.description }}
+          {{ end }}

--- a/cowork-monitoring/prometheus/prometheus.yml
+++ b/cowork-monitoring/prometheus/prometheus.yml
@@ -7,6 +7,11 @@ global:
 rule_files:
   - /etc/prometheus/rules/*.yml
 
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+            - alertmanager:9093
 
 scrape_configs:
   # ── 애플리케이션 서비스 (Eureka 자동 감지) ──

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -312,6 +312,20 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: cowork-alertmanager
+    restart: unless-stopped
+    ports:
+      - "9093:9093"
+    volumes:
+      - ./cowork-monitoring/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    environment:
+      - DISCORD_WEBHOOK_URL=${DISCORD_WEBHOOK_URL}
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+      - '--config.expand-env=true'
+
   grafana:
     image: grafana/grafana:12.0.0
     container_name: cowork-grafana


### PR DESCRIPTION
## 개요

`cowork-chat` 모듈에 전역 인증 가드(`AuthGuard`)와 HTTP 로깅 인터셉터(`HttpLoggingInterceptor`)를 추가하였습니다. 또한 모니터링 스택에 Alertmanager를 연동하여 Prometheus 알림을 Discord 웹훅으로 전달할 수 있게 되었습니다.

## 본문

### cowork-chat — Guard / Interceptor

**`AuthGuard`** (`src/common/guard/auth.guard.ts`)

`APP_GUARD`로 전역 등록된 가드입니다. 모든 REST 엔드포인트에 적용됩니다.

- `X-User-Id` 헤더 누락 시 401 반환
- `@Roles(UserRole.ADMIN)` 데코레이터가 붙은 핸들러에서 역할이 `ROLE_ADMIN`이 아니면 403 반환
- `@Public()` 데코레이터가 있거나 경로가 `/metrics`이면 검사 생략

**`HttpLoggingInterceptor`** (`src/common/interceptor/http-logging.interceptor.ts`)

`APP_INTERCEPTOR`로 전역 등록된 인터셉터입니다. 응답 완료 후 다음 5개 필드를 로깅합니다.

| 필드 | 설명 |
|------|------|
| `method` | HTTP 메서드 |
| `path` | 요청 경로 |
| `userId` | `X-User-Id` 헤더 값 |
| `statusCode` | 응답 상태 코드 |
| `duration` | 처리 소요 시간 (ms) |

**지원 데코레이터**
- `@Public()` (`src/common/guard/public.decorator.ts`) — `AuthGuard` 전체 스킵
- `@Roles(...roles)` (`src/common/guard/roles.decorator.ts`) — ADMIN 전용 라우트 선언

`HealthController`에 `@Public()` 추가 완료.

---

### cowork-monitoring — Alertmanager Discord 연동

**`alertmanager.yml`** (`cowork-monitoring/alertmanager/alertmanager.yml`)

Prometheus 알림을 Discord 웹훅으로 라우팅합니다. 웹훅 URL은 `DISCORD_WEBHOOK_URL` 환경변수로 주입합니다.

- `critical` 알림: 1시간 간격 반복
- 일반 알림: 4시간 간격 반복
- `group_by: [alertname, service]`로 서비스별 그룹화

**`prometheus.yml`**

`alerting.alertmanagers` 섹션을 추가하여 `alertmanager:9093`과 연결하였습니다.

**`docker-compose.yml`**

`prom/alertmanager:v0.27.0` 서비스를 추가하였습니다. `DISCORD_WEBHOOK_URL` 환경변수는 `.env`에서 주입합니다.
