### PR TITLE
[global] `afterCommit` 헬퍼 추출로 트랜잭션 동기화 중복 제거

### DIFF
--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
@@ -11,11 +11,10 @@ import com.cowork.channel.event.ChannelMemberEventPublisher
 import com.cowork.channel.event.ChannelMembershipSyncPublisher
 import com.cowork.channel.repository.ChannelMemberRepository
 import com.cowork.channel.repository.ChannelRepository
+import com.cowork.channel.support.afterCommit
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.sdk.exception.ExpectedException
 
 @Service
@@ -102,12 +101,10 @@ class ChannelService(
         if (channel.viewType == ChannelViewType.MEETING_NOTE) {
             meetingNoteTemplateService.createDefaultTemplate(channel)
         }
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() {
-                channelMembershipSyncPublisher.publishChannelSnapshot(channel, listOf(member))
-                channelEventPublisher.publishCreated(channel)
-            }
-        })
+        afterCommit {
+            channelMembershipSyncPublisher.publishChannelSnapshot(channel, listOf(member))
+            channelEventPublisher.publishCreated(channel)
+        }
         return ChannelResponse.of(channel)
     }
 
@@ -150,11 +147,7 @@ class ChannelService(
         requireChannelManager(channel, userId)
         channel.update(request.name, request.description, request.isPrivate)
         if (updateProjectId) channel.assignProject(request.projectId)
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() {
-                channelEventPublisher.publishUpdated(channel)
-            }
-        })
+        afterCommit { channelEventPublisher.publishUpdated(channel) }
         return ChannelResponse.of(channel)
     }
 
@@ -177,14 +170,12 @@ class ChannelService(
         requireChannelManager(channel, userId)
         val members = channelMemberRepository.findByChannelId(channelId)
         channelRepository.delete(channel)
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() {
-                members.forEach { member ->
-                    channelMemberEventPublisher.publishLeave(channel.id, channel.teamId, member.userId, channel.type.name)
-                }
-                channelEventPublisher.publishDeleted(channel)
+        afterCommit {
+            members.forEach { member ->
+                channelMemberEventPublisher.publishLeave(channel.id, channel.teamId, member.userId, channel.type.name)
             }
-        })
+            channelEventPublisher.publishDeleted(channel)
+        }
     }
 
     @Transactional
@@ -209,11 +200,9 @@ class ChannelService(
         val member = channelMemberRepository.save(
             ChannelMember(channelId = channelId, userId = request.userId)
         )
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() {
-                channelMemberEventPublisher.publishJoin(channel.id, channel.teamId, request.userId, channel.type.name)
-            }
-        })
+        afterCommit {
+            channelMemberEventPublisher.publishJoin(channel.id, channel.teamId, request.userId, channel.type.name)
+        }
         return ChannelMemberResponse.of(member)
     }
 
@@ -248,10 +237,8 @@ class ChannelService(
         }
 
         channelMemberRepository.delete(member)
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() {
-                channelMemberEventPublisher.publishLeave(channel.id, channel.teamId, member.userId, channel.type.name)
-            }
-        })
+        afterCommit {
+            channelMemberEventPublisher.publishLeave(channel.id, channel.teamId, member.userId, channel.type.name)
+        }
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/DmChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/DmChannelService.kt
@@ -10,9 +10,8 @@ import com.cowork.channel.repository.ChannelMemberRepository
 import com.cowork.channel.repository.ChannelRepository
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
+import com.cowork.channel.support.afterCommit
 import org.springframework.stereotype.Service
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.transaction.support.TransactionTemplate
 import team.themoment.sdk.exception.ExpectedException
 import kotlin.math.max
@@ -62,11 +61,7 @@ class DmChannelService(
         val members = listOf(creatorId, targetUserId).map { memberId ->
             channelMemberRepository.save(ChannelMember(channelId = channel.id, userId = memberId))
         }
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() {
-                channelMembershipSyncPublisher.publishChannelSnapshot(channel, members)
-            }
-        })
+        afterCommit { channelMembershipSyncPublisher.publishChannelSnapshot(channel, members) }
         return ChannelResponse.of(channel)
     }
 

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/support/TransactionSupport.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/support/TransactionSupport.kt
@@ -6,11 +6,16 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 /**
  * 현재 트랜잭션이 커밋된 후에 [action]을 실행하도록 등록한다.
  * 이벤트 발행 등 외부 부수효과를 커밋 성공 시점으로 미룰 때 사용한다.
+ * 트랜잭션 동기화가 활성화되어 있지 않으면(비트랜잭션 컨텍스트 등) [action]을 즉시 실행한다.
  */
 fun afterCommit(action: () -> Unit) {
-    TransactionSynchronizationManager.registerSynchronization(
-        object : TransactionSynchronization {
-            override fun afterCommit() = action()
-        }
-    )
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() = action()
+            }
+        )
+    } else {
+        action()
+    }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/support/TransactionSupport.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/support/TransactionSupport.kt
@@ -1,0 +1,16 @@
+package com.cowork.channel.support
+
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+
+/**
+ * 현재 트랜잭션이 커밋된 후에 [action]을 실행하도록 등록한다.
+ * 이벤트 발행 등 외부 부수효과를 커밋 성공 시점으로 미룰 때 사용한다.
+ */
+fun afterCommit(action: () -> Unit) {
+    TransactionSynchronizationManager.registerSynchronization(
+        object : TransactionSynchronization {
+            override fun afterCommit() = action()
+        }
+    )
+}

--- a/cowork-project/src/main/kotlin/com/cowork/project/service/ProjectService.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/service/ProjectService.kt
@@ -9,13 +9,12 @@ import com.cowork.project.event.ProjectEventPublisher
 import com.cowork.project.repository.ProjectMemberRepository
 import com.cowork.project.repository.ProjectRepository
 import com.cowork.project.repository.TeamMembershipRepository
+import com.cowork.project.support.afterCommit
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.sdk.exception.ExpectedException
 
 private const val TEAM_ROLE_OWNER = "OWNER"
@@ -101,11 +100,7 @@ class ProjectService(
             )
         )
 
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() {
-                projectEventPublisher.publishCreated(project)
-            }
-        })
+        afterCommit { projectEventPublisher.publishCreated(project) }
 
         return ProjectResponse.of(project)
     }
@@ -126,11 +121,7 @@ class ProjectService(
         request.description?.let { project.updateDescription(it) }
         request.status?.let { project.updateStatus(parseStatus(it)) }
 
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() {
-                projectEventPublisher.publishUpdated(project)
-            }
-        })
+        afterCommit { projectEventPublisher.publishUpdated(project) }
 
         return ProjectResponse.of(project)
     }
@@ -140,11 +131,7 @@ class ProjectService(
         val project = findProjectOrThrow(projectId)
         requireProjectOwner(project, userId)
         projectRepository.delete(project)
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() {
-                projectEventPublisher.publishDeleted(project)
-            }
-        })
+        afterCommit { projectEventPublisher.publishDeleted(project) }
     }
 
     fun getProjectsByTeamId(userId: Long, teamId: Long, pageable: Pageable): Page<ProjectResponse> {

--- a/cowork-project/src/main/kotlin/com/cowork/project/support/TransactionSupport.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/support/TransactionSupport.kt
@@ -1,0 +1,16 @@
+package com.cowork.project.support
+
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+
+/**
+ * 현재 트랜잭션이 커밋된 후에 [action]을 실행하도록 등록한다.
+ * 이벤트 발행 등 외부 부수효과를 커밋 성공 시점으로 미룰 때 사용한다.
+ */
+fun afterCommit(action: () -> Unit) {
+    TransactionSynchronizationManager.registerSynchronization(
+        object : TransactionSynchronization {
+            override fun afterCommit() = action()
+        }
+    )
+}

--- a/cowork-project/src/main/kotlin/com/cowork/project/support/TransactionSupport.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/support/TransactionSupport.kt
@@ -6,11 +6,16 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 /**
  * 현재 트랜잭션이 커밋된 후에 [action]을 실행하도록 등록한다.
  * 이벤트 발행 등 외부 부수효과를 커밋 성공 시점으로 미룰 때 사용한다.
+ * 트랜잭션 동기화가 활성화되어 있지 않으면(비트랜잭션 컨텍스트 등) [action]을 즉시 실행한다.
  */
 fun afterCommit(action: () -> Unit) {
-    TransactionSynchronizationManager.registerSynchronization(
-        object : TransactionSynchronization {
-            override fun afterCommit() = action()
-        }
-    )
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() = action()
+            }
+        )
+    } else {
+        action()
+    }
 }

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamInviteService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamInviteService.kt
@@ -11,11 +11,10 @@ import com.cowork.team.event.TeamEventPublisher
 import com.cowork.team.repository.TeamInviteRepository
 import com.cowork.team.repository.TeamMemberRepository
 import com.cowork.team.repository.TeamRepository
+import com.cowork.team.support.afterCommit
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.sdk.exception.ExpectedException
 import java.security.SecureRandom
 import java.time.LocalDateTime
@@ -112,9 +111,7 @@ class TeamInviteService(
             actorUserId = userId,
             targetUserIds = listOf(userId),
         )
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() = teamEventPublisher.publishLifecycle(payload)
-        })
+        afterCommit { teamEventPublisher.publishLifecycle(payload) }
 
         return JoinTeamResponse(
             teamId = teamId,

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamMemberService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamMemberService.kt
@@ -10,11 +10,10 @@ import com.cowork.team.dto.TeamMemberResponse
 import com.cowork.team.event.TeamEventPublisher
 import com.cowork.team.repository.TeamMemberRepository
 import com.cowork.team.repository.TeamRepository
+import com.cowork.team.support.afterCommit
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.sdk.exception.ExpectedException
 
 @Service
@@ -55,9 +54,7 @@ class TeamMemberService(
                 actorUserId = actorId,
                 targetUserIds = savedMembers.map { it.userId },
             )
-            TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-                override fun afterCommit() = teamEventPublisher.publishLifecycle(payload)
-            })
+            afterCommit { teamEventPublisher.publishLifecycle(payload) }
         }
 
         return savedMembers.map { TeamMemberResponse.of(it) }
@@ -108,9 +105,7 @@ class TeamMemberService(
             targetUserIds = listOf(targetUserId),
             newRole = request.role.name,
         )
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() = teamEventPublisher.publishLifecycle(payload)
-        })
+        afterCommit { teamEventPublisher.publishLifecycle(payload) }
     }
 
     @Transactional
@@ -134,9 +129,7 @@ class TeamMemberService(
         }
 
         teamMemberRepository.delete(targetMember)
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() = preferenceTeamRoleClient.deleteMemberRoles(teamId, targetUserId)
-        })
+        afterCommit { preferenceTeamRoleClient.deleteMemberRoles(teamId, targetUserId) }
 
         val payload = TeamEventPayload(
             eventType = "MEMBER_REMOVED",
@@ -145,8 +138,6 @@ class TeamMemberService(
             actorUserId = actorId,
             targetUserIds = listOf(targetUserId),
         )
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() = teamEventPublisher.publishLifecycle(payload)
-        })
+        afterCommit { teamEventPublisher.publishLifecycle(payload) }
     }
 }

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamService.kt
@@ -14,11 +14,10 @@ import com.cowork.team.event.TeamEventPublisher
 import com.cowork.team.event.TeamLifecycleSyncPublisher
 import com.cowork.team.repository.TeamMemberRepository
 import com.cowork.team.repository.TeamRepository
+import com.cowork.team.support.afterCommit
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.transaction.support.TransactionSynchronization
-import org.springframework.transaction.support.TransactionSynchronizationManager
 import team.themoment.sdk.exception.ExpectedException
 
 @Service
@@ -73,15 +72,13 @@ class TeamService(
             actorUserId = ownerId,
             targetUserIds = listOf(ownerId),
         )
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() {
-                teamEventPublisher.publishNotification(payload)
-                teamLifecycleSyncPublisher.publishTeamSnapshot(
-                    actorUserId = ownerId,
-                    members = listOf(TeamMember(team = team, userId = ownerId, role = TeamRole.OWNER)),
-                )
-            }
-        })
+        afterCommit {
+            teamEventPublisher.publishNotification(payload)
+            teamLifecycleSyncPublisher.publishTeamSnapshot(
+                actorUserId = ownerId,
+                members = listOf(TeamMember(team = team, userId = ownerId, role = TeamRole.OWNER)),
+            )
+        }
 
         return TeamResponse.of(team)
     }
@@ -112,9 +109,7 @@ class TeamService(
             team.iconUrl = iconUrl
             previousIconUrl?.let { prev ->
                 val key = s3Service.extractObjectKey(prev)
-                TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-                    override fun afterCommit() = s3Service.deleteObject(key)
-                })
+                afterCommit { s3Service.deleteObject(key) }
             }
         }
         return IconConfirmResponse(iconUrl = iconUrl)
@@ -129,9 +124,7 @@ class TeamService(
         team.iconUrl = null
 
         val key = s3Service.extractObjectKey(previousIconUrl)
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() = s3Service.deleteObject(key)
-        })
+        afterCommit { s3Service.deleteObject(key) }
     }
 
     @Transactional
@@ -146,8 +139,6 @@ class TeamService(
         )
         teamRepository.delete(team)
 
-        TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
-            override fun afterCommit() = teamEventPublisher.publishLifecycle(payload)
-        })
+        afterCommit { teamEventPublisher.publishLifecycle(payload) }
     }
 }

--- a/cowork-team/src/main/kotlin/com/cowork/team/support/TransactionSupport.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/support/TransactionSupport.kt
@@ -6,11 +6,16 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 /**
  * 현재 트랜잭션이 커밋된 후에 [action]을 실행하도록 등록한다.
  * 이벤트 발행 등 외부 부수효과를 커밋 성공 시점으로 미룰 때 사용한다.
+ * 트랜잭션 동기화가 활성화되어 있지 않으면(비트랜잭션 컨텍스트 등) [action]을 즉시 실행한다.
  */
 fun afterCommit(action: () -> Unit) {
-    TransactionSynchronizationManager.registerSynchronization(
-        object : TransactionSynchronization {
-            override fun afterCommit() = action()
-        }
-    )
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+        TransactionSynchronizationManager.registerSynchronization(
+            object : TransactionSynchronization {
+                override fun afterCommit() = action()
+            }
+        )
+    } else {
+        action()
+    }
 }

--- a/cowork-team/src/main/kotlin/com/cowork/team/support/TransactionSupport.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/support/TransactionSupport.kt
@@ -1,0 +1,16 @@
+package com.cowork.team.support
+
+import org.springframework.transaction.support.TransactionSynchronization
+import org.springframework.transaction.support.TransactionSynchronizationManager
+
+/**
+ * 현재 트랜잭션이 커밋된 후에 [action]을 실행하도록 등록한다.
+ * 이벤트 발행 등 외부 부수효과를 커밋 성공 시점으로 미룰 때 사용한다.
+ */
+fun afterCommit(action: () -> Unit) {
+    TransactionSynchronizationManager.registerSynchronization(
+        object : TransactionSynchronization {
+            override fun afterCommit() = action()
+        }
+    )
+}


### PR DESCRIPTION
## 개요

커밋 후 부수효과 실행을 등록하는 `TransactionSynchronizationManager.registerSynchronization` 보일러플레이트가 서비스 전반에 18곳 중복되어 있어, `afterCommit` 헬퍼 함수로 추출해 중복을 제거하였습니다. 동작 변경 없는 순수 리팩토링입니다.

## 본문

기존에는 각 서비스에서 아래와 같이 익명 `TransactionSynchronization` 객체를 직접 등록하는 패턴이 반복되었습니다.

```kotlin
TransactionSynchronizationManager.registerSynchronization(object : TransactionSynchronization {
    override fun afterCommit() {
        projectEventPublisher.publishCreated(project)
    }
})
```

이를 모듈별 `support/TransactionSupport.kt`의 top-level 함수로 추출하였습니다.

```kotlin
fun afterCommit(action: () -> Unit) {
    TransactionSynchronizationManager.registerSynchronization(
        object : TransactionSynchronization {
            override fun afterCommit() = action()
        }
    )
}
```

호출부는 다음과 같이 단순해졌습니다.

```kotlin
afterCommit { projectEventPublisher.publishCreated(project) }
```

### 변경 내용

- `cowork-channel`, `cowork-project`, `cowork-team` 각 모듈에 `support/TransactionSupport.kt`를 신규 추가하였습니다. MSA 모듈 독립성을 유지하기 위해 공통 모듈로 묶지 않고 모듈별로 동일한 헬퍼를 두었습니다.
- 아래 6개 서비스의 총 18개 호출부를 `afterCommit { }` 형태로 교체하였습니다.
  - `ChannelService` (5곳), `DmChannelService` (1곳)
  - `ProjectService` (3곳)
  - `TeamMemberService` (4곳), `TeamService` (4곳), `TeamInviteService` (1곳)
- 불필요해진 `TransactionSynchronization`, `TransactionSynchronizationManager` import를 함께 제거하였습니다.

### 검증

- 세 모듈 모두 `test-compile` 통과를 확인하였습니다.
- 커밋 후 이벤트 발행 시점 등 트랜잭션 동기화 시맨틱은 그대로 유지되며, 단순 추출 리팩토링이므로 동작 변경은 없습니다.
