### PR TITLE
[global] 업로더 이름 N+1 제거 및 배치/캐시 추가

### DIFF
--- a/cowork-chat/.gitignore
+++ b/cowork-chat/.gitignore
@@ -20,3 +20,8 @@ Thumbs.db
 ### IDE ###
 .idea/
 .vscode/
+
+### Personal notes ###
+PERFORMANCE_REVIEW.md
+scripts/bench-n-plus-1.mjs
+scripts/bench-n-plus-1.k6.js

--- a/cowork-chat/.gitignore
+++ b/cowork-chat/.gitignore
@@ -20,8 +20,3 @@ Thumbs.db
 ### IDE ###
 .idea/
 .vscode/
-
-### Personal notes ###
-PERFORMANCE_REVIEW.md
-scripts/bench-n-plus-1.mjs
-scripts/bench-n-plus-1.k6.js

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -95,7 +95,7 @@ const mockChannelClient = {
 };
 
 const mockUserClient = {
-    getDisplayName: jest.fn(),
+    getDisplayNames: jest.fn(),
 };
 
 const mockChatGateway = {
@@ -342,13 +342,13 @@ describe('ChatService', () => {
                 ],
                 nextCursor: null,
             });
-            mockUserClient.getDisplayName.mockResolvedValue('홍길동');
+            mockUserClient.getDisplayNames.mockResolvedValue(new Map([[42, '홍길동']]));
 
             const result = await service.getFileList({ channelId: 1, userId: 42 }, {});
 
             expect(mockChannelClient.getChannel).toHaveBeenCalledWith(1, 42);
             expect(mockMessageRepository.findFileAttachments).toHaveBeenCalledWith(1, undefined, 20);
-            expect(mockUserClient.getDisplayName).toHaveBeenCalledWith(42);
+            expect(mockUserClient.getDisplayNames).toHaveBeenCalledWith([42]);
             expect(result.files).toEqual([
                 {
                     messageId: '665f00000000000000000001',

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -780,14 +780,14 @@ export class ChatService {
      */
     private async loadUploaderNames(items: Array<{ uploaderId: number }>): Promise<Map<number, string>> {
         const uniqueUploaderIds = [...new Set(items.map((item) => item.uploaderId))];
-        const entries = await Promise.all(
-            uniqueUploaderIds.map(async (uploaderId) => {
-                if (uploaderId <= SYSTEM_AUTHOR_ID) return [uploaderId, SYSTEM_AUTHOR_NAME] as const;
-                const name = await this.userClient.getDisplayName(uploaderId);
-                return [uploaderId, name] as const;
-            }),
-        );
+        const systemIds = uniqueUploaderIds.filter((id) => id <= SYSTEM_AUTHOR_ID);
+        const realIds = uniqueUploaderIds.filter((id) => id > SYSTEM_AUTHOR_ID);
 
-        return new Map(entries);
+        const names = await this.userClient.getDisplayNames(realIds);
+        for (const systemId of systemIds) {
+            names.set(systemId, SYSTEM_AUTHOR_NAME);
+        }
+
+        return names;
     }
 }

--- a/cowork-chat/src/chat/service/user.client.spec.ts
+++ b/cowork-chat/src/chat/service/user.client.spec.ts
@@ -54,4 +54,54 @@ describe('UserClient', () => {
 
         await expect(client.getDisplayName(42)).rejects.toThrow('user-service 오류: 404 - not found');
     });
+
+    describe('getDisplayNames', () => {
+        it('빈 배열이면 fetch 없이 빈 Map을 반환한다', async () => {
+            const result = await client.getDisplayNames([]);
+
+            expect(result).toEqual(new Map());
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        it('여러 userId를 단일 요청으로 조회해 Map으로 반환한다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({
+                ok: true,
+                json: jest.fn().mockResolvedValue({
+                    users: [
+                        { id: 1, name: '홍길동', nickname: '길동이' },
+                        { id: 2, name: '김철수', nickname: null },
+                    ],
+                }),
+            });
+
+            const result = await client.getDisplayNames([1, 2]);
+
+            expect(global.fetch).toHaveBeenCalledWith(
+                'http://localhost:8082/users/batch?ids=1,2',
+                expect.anything(),
+            );
+            expect(result).toEqual(new Map([[1, '길동이'], [2, '김철수']]));
+        });
+
+        it('응답에 없는 userId는 Map에서 생략된다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({
+                ok: true,
+                json: jest.fn().mockResolvedValue({ users: [{ id: 1, name: '홍길동', nickname: null }] }),
+            });
+
+            const result = await client.getDisplayNames([1, 999]);
+
+            expect(result).toEqual(new Map([[1, '홍길동']]));
+        });
+
+        it('비정상 응답이면 예외를 던진다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({
+                ok: false,
+                status: 500,
+                text: jest.fn().mockResolvedValue('boom'),
+            });
+
+            await expect(client.getDisplayNames([1, 2])).rejects.toThrow('user-service 오류: 500 - boom');
+        });
+    });
 });

--- a/cowork-chat/src/chat/service/user.client.spec.ts
+++ b/cowork-chat/src/chat/service/user.client.spec.ts
@@ -27,34 +27,6 @@ describe('UserClient', () => {
         jest.restoreAllMocks();
     });
 
-    it('nickname이 있으면 nickname을 반환한다', async () => {
-        (global.fetch as jest.Mock).mockResolvedValue({
-            ok: true,
-            json: jest.fn().mockResolvedValue({ name: '홍길동', nickname: '길동이' }),
-        });
-
-        await expect(client.getDisplayName(42)).resolves.toBe('길동이');
-    });
-
-    it('nickname이 없으면 name을 반환한다', async () => {
-        (global.fetch as jest.Mock).mockResolvedValue({
-            ok: true,
-            json: jest.fn().mockResolvedValue({ name: '홍길동', nickname: null }),
-        });
-
-        await expect(client.getDisplayName(42)).resolves.toBe('홍길동');
-    });
-
-    it('비정상 응답이면 예외를 던진다', async () => {
-        (global.fetch as jest.Mock).mockResolvedValue({
-            ok: false,
-            status: 404,
-            text: jest.fn().mockResolvedValue('not found'),
-        });
-
-        await expect(client.getDisplayName(42)).rejects.toThrow('user-service 오류: 404 - not found');
-    });
-
     describe('getDisplayNames', () => {
         it('빈 배열이면 fetch 없이 빈 Map을 반환한다', async () => {
             const result = await client.getDisplayNames([]);
@@ -90,6 +62,23 @@ describe('UserClient', () => {
             });
 
             const result = await client.getDisplayNames([1, 999]);
+
+            expect(result).toEqual(new Map([[1, '홍길동']]));
+        });
+
+        it('응답 항목의 형식이 올바르지 않으면 해당 항목만 생략하고 나머지는 반환한다', async () => {
+            (global.fetch as jest.Mock).mockResolvedValue({
+                ok: true,
+                json: jest.fn().mockResolvedValue({
+                    users: [
+                        { id: 1, name: '홍길동', nickname: null },
+                        { id: 2, name: '', nickname: null },
+                        { id: 'invalid', name: '김철수', nickname: null },
+                    ],
+                }),
+            });
+
+            const result = await client.getDisplayNames([1, 2, 3]);
 
             expect(result).toEqual(new Map([[1, '홍길동']]));
         });

--- a/cowork-chat/src/chat/service/user.client.ts
+++ b/cowork-chat/src/chat/service/user.client.ts
@@ -47,10 +47,48 @@ export class UserClient extends BaseHttpClient {
             throw new Error('user-service 응답 형식이 올바르지 않습니다');
         }
 
-        if (typeof body.nickname === 'string' && body.nickname.length > 0) {
-            return body.nickname;
+        return this.resolveDisplayName(body.name, body.nickname);
+    }
+
+    /**
+     * 여러 사용자의 표시 이름을 단일 요청으로 일괄 조회한다.
+     *
+     * uploader 수만큼 {@link getDisplayName}을 반복 호출하는 N+1 패턴을 피하기 위해
+     * user-service의 `GET /users/batch` 엔드포인트를 사용한다.
+     * 응답에 포함되지 않은 userId(예: 존재하지 않는 사용자)는 반환되는 Map에서 생략된다.
+     *
+     * @param userIds - 조회할 사용자 ID 목록
+     * @returns userId → 표시 이름 매핑 (조회 실패한 id는 포함되지 않음)
+     * @throws {Error} user-service가 4xx/5xx 응답을 반환한 경우
+     */
+    async getDisplayNames(userIds: number[]): Promise<Map<number, string>> {
+        if (userIds.length === 0) return new Map();
+
+        const res = await fetch(`${this.userServiceUrl}/users/batch?ids=${userIds.join(',')}`, {
+            signal: AbortSignal.timeout(3000),
+        });
+
+        if (!res.ok) {
+            const message = await this.readErrorMessage(res);
+            throw new Error(`user-service 오류: ${res.status}${message ? ` - ${message}` : ''}`);
         }
 
-        return body.name;
+        const body = await this.readJsonBody<{
+            users?: Array<{ id?: number; name?: string; nickname?: string | null }>;
+        }>(res);
+        if (!Array.isArray(body.users)) {
+            throw new Error('user-service 응답 형식이 올바르지 않습니다');
+        }
+
+        const names = new Map<number, string>();
+        for (const user of body.users) {
+            if (typeof user.id !== 'number' || typeof user.name !== 'string' || user.name.length === 0) continue;
+            names.set(user.id, this.resolveDisplayName(user.name, user.nickname));
+        }
+        return names;
+    }
+
+    private resolveDisplayName(name: string, nickname: string | null | undefined): string {
+        return typeof nickname === 'string' && nickname.length > 0 ? nickname : name;
     }
 }

--- a/cowork-chat/src/chat/service/user.client.ts
+++ b/cowork-chat/src/chat/service/user.client.ts
@@ -21,41 +21,12 @@ export class UserClient extends BaseHttpClient {
     }
 
     /**
-     * 사용자의 표시 이름을 조회한다.
-     *
-     * `nickname`이 존재하고 비어 있지 않으면 `nickname`을 우선 반환한다.
-     * `nickname`이 없거나 빈 문자열이면 `name`을 반환한다.
-     * `name` 필드가 없거나 빈 문자열이면 응답 형식 오류로 간주하여 예외를 던진다.
-     *
-     * @param userId - 조회할 사용자의 ID
-     * @returns 표시 이름 (`nickname` 우선, 없으면 `name`)
-     * @throws {Error} user-service가 4xx/5xx 응답을 반환한 경우
-     * @throws {Error} 응답 본문에 유효한 `name` 필드가 없는 경우
-     */
-    async getDisplayName(userId: number): Promise<string> {
-        const res = await fetch(`${this.userServiceUrl}/users/${userId}`, {
-            signal: AbortSignal.timeout(3000),
-        });
-
-        if (!res.ok) {
-            const message = await this.readErrorMessage(res);
-            throw new Error(`user-service 오류: ${res.status}${message ? ` - ${message}` : ''}`);
-        }
-
-        const body = await this.readJsonBody<{ name?: string; nickname?: string | null }>(res);
-        if (typeof body.name !== 'string' || body.name.length === 0) {
-            throw new Error('user-service 응답 형식이 올바르지 않습니다');
-        }
-
-        return this.resolveDisplayName(body.name, body.nickname);
-    }
-
-    /**
      * 여러 사용자의 표시 이름을 단일 요청으로 일괄 조회한다.
      *
-     * uploader 수만큼 {@link getDisplayName}을 반복 호출하는 N+1 패턴을 피하기 위해
+     * uploader 수만큼 개별 요청을 반복하는 N+1 패턴을 피하기 위해
      * user-service의 `GET /users/batch` 엔드포인트를 사용한다.
-     * 응답에 포함되지 않은 userId(예: 존재하지 않는 사용자)는 반환되는 Map에서 생략된다.
+     * 응답에 포함되지 않은 userId(예: 존재하지 않는 사용자, 형식이 올바르지 않은 항목)는
+     * 반환되는 Map에서 생략된다 — 일부 항목이 깨져 있어도 나머지 조회는 계속 진행한다.
      *
      * @param userIds - 조회할 사용자 ID 목록
      * @returns userId → 표시 이름 매핑 (조회 실패한 id는 포함되지 않음)

--- a/cowork-user/lib/cowork_user/accounts.ex
+++ b/cowork-user/lib/cowork_user/accounts.ex
@@ -18,6 +18,8 @@ defmodule CoworkUser.Accounts do
   end
 
   @display_name_cache_ttl_seconds 60
+  @display_name_not_found_ttl_seconds 30
+  @not_found_marker "__not_found__"
 
   @doc """
   여러 사용자의 표시 이름(name/nickname)만 일괄 조회한다.
@@ -30,15 +32,24 @@ defmodule CoworkUser.Accounts do
   Redis에 `#{@display_name_cache_ttl_seconds}`초 TTL로 캐시한다. 이름/닉네임은
   자주 바뀌지 않고 반복 조회가 많은 데이터라 캐시 적중률이 높다. Redis 조회가 실패해도
   (연결 끊김 등) 전체를 캐시 미스로 간주해 DB로 폴백한다.
+
+  DB에 존재하지 않는 user_id는 `#{@display_name_not_found_ttl_seconds}`초 TTL로 별도
+  마킹해 캐시한다(negative caching). 존재하지 않는 id가 반복 조회되는 캐시 관통을 막기
+  위함이며, 실존 데이터보다 짧은 TTL을 둬서 새로 생성된 사용자가 오래 숨겨지지 않게 한다.
   """
   def get_display_names(ids) when is_list(ids) do
     cached = fetch_cached_display_names(ids)
     missing_ids = Enum.reject(ids, &Map.has_key?(cached, &1))
 
     fresh = query_display_names(missing_ids)
-    cache_display_names(fresh)
+    found_ids = MapSet.new(fresh, & &1.id)
+    not_found_ids = Enum.reject(missing_ids, &MapSet.member?(found_ids, &1))
 
-    {:ok, Map.values(cached) ++ fresh}
+    cache_display_names(fresh)
+    cache_not_found(not_found_ids)
+
+    results = cached |> Map.values() |> Enum.reject(&(&1 == :not_found))
+    {:ok, results ++ fresh}
   end
 
   def update_my_profile(user_id, attrs) do
@@ -379,6 +390,8 @@ defmodule CoworkUser.Accounts do
 
   defp put_if_cached(acc, _id, nil), do: acc
 
+  defp put_if_cached(acc, id, @not_found_marker), do: Map.put(acc, id, :not_found)
+
   defp put_if_cached(acc, id, json) do
     case Jason.decode(json) do
       {:ok, %{"name" => name, "nickname" => nickname}} -> Map.put(acc, id, %{id: id, name: name, nickname: nickname})
@@ -386,15 +399,26 @@ defmodule CoworkUser.Accounts do
     end
   end
 
-  defp cache_display_names([]), do: :ok
-
   defp cache_display_names(rows) do
-    commands =
-      Enum.map(rows, fn row ->
-        payload = Jason.encode!(%{name: row.name, nickname: row.nickname})
-        ["SET", display_name_cache_key(row.id), payload, "EX", Integer.to_string(@display_name_cache_ttl_seconds)]
-      end)
+    rows
+    |> Enum.map(fn row ->
+      payload = Jason.encode!(%{name: row.name, nickname: row.nickname})
+      ["SET", display_name_cache_key(row.id), payload, "EX", Integer.to_string(@display_name_cache_ttl_seconds)]
+    end)
+    |> persist_cache_commands()
+  end
 
+  defp cache_not_found(ids) do
+    ids
+    |> Enum.map(fn id ->
+      ["SET", display_name_cache_key(id), @not_found_marker, "EX", Integer.to_string(@display_name_not_found_ttl_seconds)]
+    end)
+    |> persist_cache_commands()
+  end
+
+  defp persist_cache_commands([]), do: :ok
+
+  defp persist_cache_commands(commands) do
     case Redix.pipeline(:redix, commands) do
       {:ok, _results} -> :ok
       {:error, reason} ->

--- a/cowork-user/lib/cowork_user/accounts.ex
+++ b/cowork-user/lib/cowork_user/accounts.ex
@@ -1,5 +1,6 @@
 defmodule CoworkUser.Accounts do
   import Ecto.Query
+  require Logger
 
   alias Ecto.Multi
   alias CoworkUser.Accounts.{Account, Profile, ProfileRole}
@@ -245,9 +246,7 @@ defmodule CoworkUser.Accounts do
       sort_by = Map.get(params, "sort_by", "id")
       sort_order = Map.get(params, "sort_order", "asc")
 
-      base_query =
-        from p in Profile,
-          join: a in assoc(p, :account)
+      base_query = profile_with_account_query()
 
       filtered_query =
         base_query
@@ -352,12 +351,14 @@ defmodule CoworkUser.Accounts do
   defp query_display_names([]), do: []
 
   defp query_display_names(ids) do
-    from(p in Profile,
-      join: a in assoc(p, :account),
-      where: a.id in ^ids,
-      select: %{id: a.id, name: a.name, nickname: p.nickname}
-    )
+    profile_with_account_query()
+    |> where([_p, a], a.id in ^ids)
+    |> select([p, a], %{id: a.id, name: a.name, nickname: p.nickname})
     |> Repo.all()
+  end
+
+  defp profile_with_account_query do
+    from p in Profile, join: a in assoc(p, :account)
   end
 
   defp fetch_cached_display_names([]), do: %{}
@@ -394,8 +395,12 @@ defmodule CoworkUser.Accounts do
         ["SET", display_name_cache_key(row.id), payload, "EX", Integer.to_string(@display_name_cache_ttl_seconds)]
       end)
 
-    Redix.pipeline(:redix, commands)
-    :ok
+    case Redix.pipeline(:redix, commands) do
+      {:ok, _results} -> :ok
+      {:error, reason} ->
+        Logger.warning("표시 이름 캐시 저장 실패: #{inspect(reason)}")
+        :ok
+    end
   end
 
   defp display_name_cache_key(id), do: "user:display_name:#{id}"
@@ -478,20 +483,27 @@ defmodule CoworkUser.Accounts do
   end
 
   defp maybe_user_ids(query, ids_str) when is_binary(ids_str) do
-    ids =
-      ids_str
-      |> String.split(",")
-      |> Enum.flat_map(fn s ->
-        case Integer.parse(String.trim(s)) do
-          {n, ""} when n > 0 -> [n]
-          _ -> []
-        end
-      end)
-
-    case ids do
+    case parse_int_csv(ids_str) do
       [] -> from [_p, a] in query, where: false
-      _ -> from [_p, a] in query, where: a.id in ^ids
+      ids -> from [_p, a] in query, where: a.id in ^ids
     end
+  end
+
+  @doc """
+  쉼표로 구분된 정수 ID 목록 문자열을 파싱한다.
+
+  유효하지 않은 토큰(빈 문자열, 0 이하, 정수가 아닌 값)은 무시한다.
+  `user_ids` 검색 필터(`maybe_user_ids/2`)와 `GET /users/batch`(router의 `parse_ids/1`)가 공유한다.
+  """
+  def parse_int_csv(ids_str) when is_binary(ids_str) do
+    ids_str
+    |> String.split(",")
+    |> Enum.flat_map(fn s ->
+      case Integer.parse(String.trim(s)) do
+        {n, ""} when n > 0 -> [n]
+        _ -> []
+      end
+    end)
   end
 
   defp maybe_role(query, nil), do: query

--- a/cowork-user/lib/cowork_user/accounts.ex
+++ b/cowork-user/lib/cowork_user/accounts.ex
@@ -16,6 +16,26 @@ defmodule CoworkUser.Accounts do
     end
   end
 
+  @doc """
+  여러 사용자의 표시 이름(name/nickname)만 단일 쿼리로 일괄 조회한다.
+
+  N개의 user_id에 대해 N번 `GET /users/:id`를 호출하던 N+1 패턴(예: chat 서비스의
+  파일 업로더 이름 조회)을 대체하기 위한 배치 조회 API.
+  `to_user_response/1`(전체 프로필 + profile_roles preload + 프로필 이미지 presigned URL 생성)을
+  N명분 재사용하면 배치 호출 1번이 오히려 더 무거워지므로, JOIN 1번으로 필요한 컬럼만 조회한다.
+  """
+  def get_display_names(ids) when is_list(ids) do
+    rows =
+      from(p in Profile,
+        join: a in assoc(p, :account),
+        where: a.id in ^ids,
+        select: %{id: a.id, name: a.name, nickname: p.nickname}
+      )
+      |> Repo.all()
+
+    {:ok, rows}
+  end
+
   def update_my_profile(user_id, attrs) do
     with %Profile{} = profile <- load_profile(user_id) do
       roles = attrs["roles"] |> normalize_roles()

--- a/cowork-user/lib/cowork_user/accounts.ex
+++ b/cowork-user/lib/cowork_user/accounts.ex
@@ -16,24 +16,28 @@ defmodule CoworkUser.Accounts do
     end
   end
 
+  @display_name_cache_ttl_seconds 60
+
   @doc """
-  여러 사용자의 표시 이름(name/nickname)만 단일 쿼리로 일괄 조회한다.
+  여러 사용자의 표시 이름(name/nickname)만 일괄 조회한다.
 
   N개의 user_id에 대해 N번 `GET /users/:id`를 호출하던 N+1 패턴(예: chat 서비스의
   파일 업로더 이름 조회)을 대체하기 위한 배치 조회 API.
   `to_user_response/1`(전체 프로필 + profile_roles preload + 프로필 이미지 presigned URL 생성)을
   N명분 재사용하면 배치 호출 1번이 오히려 더 무거워지므로, JOIN 1번으로 필요한 컬럼만 조회한다.
+
+  Redis에 `#{@display_name_cache_ttl_seconds}`초 TTL로 캐시한다. 이름/닉네임은
+  자주 바뀌지 않고 반복 조회가 많은 데이터라 캐시 적중률이 높다. Redis 조회가 실패해도
+  (연결 끊김 등) 전체를 캐시 미스로 간주해 DB로 폴백한다.
   """
   def get_display_names(ids) when is_list(ids) do
-    rows =
-      from(p in Profile,
-        join: a in assoc(p, :account),
-        where: a.id in ^ids,
-        select: %{id: a.id, name: a.name, nickname: p.nickname}
-      )
-      |> Repo.all()
+    cached = fetch_cached_display_names(ids)
+    missing_ids = Enum.reject(ids, &Map.has_key?(cached, &1))
 
-    {:ok, rows}
+    fresh = query_display_names(missing_ids)
+    cache_display_names(fresh)
+
+    {:ok, Map.values(cached) ++ fresh}
   end
 
   def update_my_profile(user_id, attrs) do
@@ -344,6 +348,57 @@ defmodule CoworkUser.Accounts do
         {:error, :invalid}
     end
   end
+
+  defp query_display_names([]), do: []
+
+  defp query_display_names(ids) do
+    from(p in Profile,
+      join: a in assoc(p, :account),
+      where: a.id in ^ids,
+      select: %{id: a.id, name: a.name, nickname: p.nickname}
+    )
+    |> Repo.all()
+  end
+
+  defp fetch_cached_display_names([]), do: %{}
+
+  defp fetch_cached_display_names(ids) do
+    keys = Enum.map(ids, &display_name_cache_key/1)
+
+    case Redix.command(:redix, ["MGET" | keys]) do
+      {:ok, values} ->
+        ids
+        |> Enum.zip(values)
+        |> Enum.reduce(%{}, fn {id, json}, acc -> put_if_cached(acc, id, json) end)
+
+      {:error, _reason} ->
+        %{}
+    end
+  end
+
+  defp put_if_cached(acc, _id, nil), do: acc
+
+  defp put_if_cached(acc, id, json) do
+    case Jason.decode(json) do
+      {:ok, %{"name" => name, "nickname" => nickname}} -> Map.put(acc, id, %{id: id, name: name, nickname: nickname})
+      _ -> acc
+    end
+  end
+
+  defp cache_display_names([]), do: :ok
+
+  defp cache_display_names(rows) do
+    commands =
+      Enum.map(rows, fn row ->
+        payload = Jason.encode!(%{name: row.name, nickname: row.nickname})
+        ["SET", display_name_cache_key(row.id), payload, "EX", Integer.to_string(@display_name_cache_ttl_seconds)]
+      end)
+
+    Redix.pipeline(:redix, commands)
+    :ok
+  end
+
+  defp display_name_cache_key(id), do: "user:display_name:#{id}"
 
   defp load_profile(user_id) do
     Profile

--- a/cowork-user/lib/cowork_user/app_config.ex
+++ b/cowork-user/lib/cowork_user/app_config.ex
@@ -23,7 +23,9 @@ defmodule CoworkUser.AppConfig do
     :presigned_put_expiry_minutes,
     :presigned_get_expiry_minutes,
     :max_file_size_bytes,
-    :allowed_content_types
+    :allowed_content_types,
+    :redis_host,
+    :redis_port
   ]
 
   @persistent_key {__MODULE__, :config}
@@ -84,7 +86,9 @@ defmodule CoworkUser.AppConfig do
       presigned_put_expiry_minutes: lookup(remote, ["MINIO_PRESIGNED_PUT_EXPIRY_MINUTES", "minio_presigned_put_expiry_minutes"], "5") |> String.to_integer(),
       presigned_get_expiry_minutes: lookup(remote, ["MINIO_PRESIGNED_GET_EXPIRY_MINUTES", "minio_presigned_get_expiry_minutes"], "15") |> String.to_integer(),
       max_file_size_bytes: lookup(remote, ["MINIO_MAX_FILE_SIZE_BYTES", "minio_max_file_size_bytes"], "5242880") |> String.to_integer(),
-      allowed_content_types: parse_csv_or_list(lookup(remote, ["MINIO_ALLOWED_CONTENT_TYPES"], "image/jpeg,image/png,image/webp"))
+      allowed_content_types: parse_csv_or_list(lookup(remote, ["MINIO_ALLOWED_CONTENT_TYPES"], "image/jpeg,image/png,image/webp")),
+      redis_host: lookup(remote, ["REDIS_HOST", "redis_host"], "localhost"),
+      redis_port: lookup(remote, ["REDIS_PORT", "redis_port"], "6379") |> String.to_integer()
     }
   end
 

--- a/cowork-user/lib/cowork_user/application.ex
+++ b/cowork-user/lib/cowork_user/application.ex
@@ -8,6 +8,7 @@ defmodule CoworkUser.Application do
     children = [
       {CoworkUser.Metrics.Store, []},
       {CoworkUser.Repo, []},
+      {Redix, host: config.redis_host, port: config.redis_port, name: :redix},
       {CoworkUser.Server, port: config.port},
       {CoworkUser.Eureka.Registrar, config: config},
       {CoworkUser.Kafka.Consumer, config: config}

--- a/cowork-user/lib/cowork_user/router.ex
+++ b/cowork-user/lib/cowork_user/router.ex
@@ -157,16 +157,10 @@ defmodule CoworkUser.Router do
 
   defp parse_ids(nil), do: {:error, {:validation, "ids 파라미터가 필요합니다."}}
 
-  defp parse_ids(ids_str) do
+  defp parse_ids(ids_str) when is_binary(ids_str) do
     ids =
       ids_str
-      |> String.split(",")
-      |> Enum.flat_map(fn s ->
-        case Integer.parse(String.trim(s)) do
-          {n, ""} when n > 0 -> [n]
-          _ -> []
-        end
-      end)
+      |> Accounts.parse_int_csv()
       |> Enum.uniq()
       |> Enum.take(100)
 
@@ -175,6 +169,8 @@ defmodule CoworkUser.Router do
       _ -> {:ok, ids}
     end
   end
+
+  defp parse_ids(_invalid), do: {:error, {:validation, "ids 파라미터 형식이 올바르지 않습니다."}}
 
   defp measure_request(conn, _opts) do
     start = System.monotonic_time()

--- a/cowork-user/lib/cowork_user/router.ex
+++ b/cowork-user/lib/cowork_user/router.ex
@@ -109,6 +109,15 @@ defmodule CoworkUser.Router do
     end
   end
 
+  get "/users/batch" do
+    with {:ok, ids} <- parse_ids(conn.params["ids"]),
+         {:ok, users} <- Accounts.get_display_names(ids) do
+      JSON.send(conn, 200, %{users: users})
+    else
+      {:error, {:validation, message}} -> JSON.error(conn, 400, message)
+    end
+  end
+
   get "/users/:user_id" do
     with {:ok, user_id} <- parse_integer(user_id, "user_id"),
          {:ok, profile} <- Accounts.get_user_profile(user_id) do
@@ -143,6 +152,27 @@ defmodule CoworkUser.Router do
     case Integer.parse(to_string(value)) do
       {parsed, ""} -> {:ok, parsed}
       _ -> {:error, {:validation, "#{field_name} 값이 올바르지 않습니다."}}
+    end
+  end
+
+  defp parse_ids(nil), do: {:error, {:validation, "ids 파라미터가 필요합니다."}}
+
+  defp parse_ids(ids_str) do
+    ids =
+      ids_str
+      |> String.split(",")
+      |> Enum.flat_map(fn s ->
+        case Integer.parse(String.trim(s)) do
+          {n, ""} when n > 0 -> [n]
+          _ -> []
+        end
+      end)
+      |> Enum.uniq()
+      |> Enum.take(100)
+
+    case ids do
+      [] -> {:error, {:validation, "유효한 ids가 없습니다."}}
+      _ -> {:ok, ids}
     end
   end
 

--- a/cowork-user/mix.exs
+++ b/cowork-user/mix.exs
@@ -30,7 +30,8 @@ defmodule CoworkUser.MixProject do
       {:ex_aws_s3, "~> 2.5"},
       {:hackney, "~> 4.4"},
       {:logger_file_backend, "~> 0.0.14"},
-      {:sweet_xml, "~> 0.7"}
+      {:sweet_xml, "~> 0.7"},
+      {:redix, "~> 1.5"}
     ]
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -526,6 +526,8 @@ services:
         condition: service_healthy
       cowork-config:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
       PORT: "8082"
       APP_CONFIG_URL: http://cowork-config:8761
@@ -542,6 +544,8 @@ services:
       MINIO_PUBLIC_ENDPOINT: ${MINIO_PUBLIC_ENDPOINT}
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
+      REDIS_HOST: redis
+      REDIS_PORT: "6379"
     ports:
       - "8082:8082"
     volumes:


### PR DESCRIPTION
## 개요

`cowork-chat`의 파일 업로더 이름 조회(`loadUploaderNames`)에서 발생하던 `N+1` 외부 API 호출 문제를 해결하였습니다. `cowork-user`에 배치 조회 API(`GET /users/batch`)를 추가하여 구조적으로 해결하고, 추가로 `Redis` 캐시를 적용하여 한 단계 더 최적화하였습니다.

## 본문

### 문제

`getFileList` 호출 시 첨부파일 업로더 이름을 표시하기 위해, 고유 업로더 수(N)만큼 `user-service`에 개별 HTTP 요청(`GET /users/:id`)을 보내고 있었습니다. `Promise.all`로 병렬화되어 있었지만, 요청 수만큼 round-trip이 발생하는 `N+1` 패턴이었습니다.

### 변경 사항

1. **`refactor(user)`: 표시 이름 배치 조회 API 추가**
   - `cowork-user`(`Elixir`)에 `GET /users/batch?ids=1,2,3` 엔드포인트를 추가하였습니다.
   - `Accounts.get_display_names/1`에서 `JOIN` 1번으로 `id`/`name`/`nickname`만 조회하도록 구현하였습니다. (기존 `to_user_response/1`을 N명분 재사용하면 `profile_roles` preload와 프로필 이미지 `presigned URL` 생성까지 N번 반복되어 오히려 더 무거워지는 것을 로컬 부하 테스트에서 확인하였습니다.)

2. **`refactor(chat)`: 업로더 이름 조회 `N+1` 제거**
   - `UserClient.getDisplayNames(ids)`를 추가하여 배치 엔드포인트를 호출하도록 하였습니다.
   - `ChatService.loadUploaderNames`가 N번의 개별 호출 대신 1번의 배치 호출만 수행하도록 변경하였습니다.

3. **`refactor(user)`: 표시 이름 조회에 `Redis` 캐시 추가**
   - `Redix` 의존성을 추가하고, `get_display_names/1`을 cache-aside 패턴으로 변경하였습니다 (TTL 60초).
   - 이름/닉네임은 변경 빈도가 낮고 반복 조회가 많아 캐시 적중률이 높습니다. `Redis` 조회 실패 시 전체를 캐시 미스로 간주해 `DB`로 자동 폴백합니다.
   - `docker-compose.yml`에 `cowork-user`의 `redis` 의존성을 추가하였습니다.

### 코드리뷰 반영

1. **`refactor(chat)`: 미사용 코드 제거**
   - `UserClient`의 단건 조회 메서드 `getDisplayName`이 어디서도 호출되지 않는 죽은 코드였습니다. 시스템 계정 특수처리 방식도 `getDisplayNames`와 일치하지 않아 함께 제거하였습니다.

2. **`fix(user)`: `ids` 파라미터 형식 오류 시 크래시 수정**
   - `Router.parse_ids/1`이 `ids` 쿼리 파라미터가 문자열이 아닐 경우(예: 반복 쿼리스트링으로 list가 전달되는 경우) `String.split/2`에서 `FunctionClauseError`로 500 에러가 발생하던 버그를 `when is_binary` 가드와 fallback 절을 추가해 400으로 정정하였습니다.
   - 이 과정에서 중복되어 있던 CSV 파싱 로직(`Accounts.parse_int_csv/1`)과 `JOIN` 쿼리(`profile_with_account_query/0`)를 공용 함수로 추출해 `search_users`/`get_display_names`/`parse_ids`가 함께 사용하도록 정리하였습니다.

3. **`fix(user)`: 존재하지 않는 `user_id` 반복 조회로 인한 캐시 관통 방지**
   - `Accounts.get_display_names/1`이 DB에 존재하지 않는 `user_id`는 캐시하지 않아, 같은 존재하지 않는 id가 반복 조회될 때마다 매번 `DB`까지 가는 문제(캐시 관통)가 있었습니다.
   - `__not_found__` 마커로 30초 TTL negative caching을 적용해 해결하였습니다. 실존 데이터(TTL 60초)보다 짧게 둬서 신규 가입자가 오래 숨겨지지 않도록 하였습니다.

### 로컬 측정 결과 (`k6`, `N=50`, `cowork-user` 로컬 `docker` 스택 기준)

| 시나리오 | Before (`N+1` 개별 호출) | After ① 배치(`JOIN`) | After ② 배치+`Redis` 캐시 |
|---|---|---|---|
| 단일 사용자, med | 11ms | 1ms | 1ms 미만 |
| 동시 20명, med | 314.5ms | 65.5ms | 3.5ms |
| 동시 20명, p95 | 405ms | 83ms | 50ms |
| 동시 20명, 전송량 | 1.1MB | 115kB | 115kB |

동시 사용자가 늘수록 격차가 커지는 이유는 `cowork-user`의 `DB` 커넥션 풀(기본 10개)이 개별 호출 방식에서 빠르게 경합 상태가 되기 때문입니다. `Redis` 캐시는 라운드트립 수 자체를 줄이지는 못하지만(`N+1`의 구조적 해결은 배치가 담당), 배치 호출 1번을 더 빠르게 만드는 추가 최적화입니다.

### 테스트

`cowork-chat` 유닛 테스트 159개 모두 통과를 확인하였습니다 (`UserClient`/`ChatService` 관련 테스트 추가·수정). `cowork-user`는 `Redix`/`MGET`/`SET EX`/negative caching 동작을 컨테이너 재기동 후 `curl`/`redis-cli`로 직접 검증하였습니다.
