### PR TITLE
[global] 스타일 가이드 위반 일괄 정리

### DIFF
--- a/cowork-channel/src/main/kotlin/com/cowork/channel/consumer/ChannelLifecycleHandler.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/consumer/ChannelLifecycleHandler.kt
@@ -26,14 +26,14 @@ class ChannelLifecycleHandler(
         if (newMemberships.isNotEmpty()) {
             teamMembershipRepository.saveAll(newMemberships)
         }
-        log.info("MEMBER_INVITED 처리 완료 [teamId={}, userIds={}]", teamId, userIds)
+        log.info("Processed MEMBER_INVITED event [teamId={}, userIds={}]", teamId, userIds)
     }
 
     @Transactional
     fun onRoleChanged(teamId: Long, userId: Long, newRole: String) {
         val membership = teamMembershipRepository.findByTeamIdAndUserId(teamId, userId) ?: return
         membership.role = newRole
-        log.info("ROLE_CHANGED 처리 완료 [teamId={}, userId={}, newRole={}]", teamId, userId, newRole)
+        log.info("Processed ROLE_CHANGED event [teamId={}, userId={}, newRole={}]", teamId, userId, newRole)
     }
 
     @Transactional
@@ -42,11 +42,11 @@ class ChannelLifecycleHandler(
 
         val channels = channelRepository.findAllByTeamIdOrderByPositionAscIdAsc(teamId)
         if (channels.isEmpty()) {
-            log.info("TEAM_DELETED 처리: 대상 채널 없음 [teamId={}]", teamId)
+            log.info("Skipped TEAM_DELETED event: no channels to delete [teamId={}]", teamId)
             return
         }
         channelRepository.deleteAll(channels)
-        log.info("TEAM_DELETED 처리 완료 [teamId={}, deletedChannels={}]", teamId, channels.size)
+        log.info("Processed TEAM_DELETED event [teamId={}, deletedChannels={}]", teamId, channels.size)
     }
 
     @Transactional
@@ -79,6 +79,6 @@ class ChannelLifecycleHandler(
             channelRepository.deleteAll(ownedChannels)
         }
         channelMemberRepository.deleteAllByUserId(userId)
-        log.info("USER_DELETED 처리 [userId={}, channelsDeleted={}]", userId, ownedChannels.size)
+        log.info("Processed USER_DELETED event [userId={}, channelsDeleted={}]", userId, ownedChannels.size)
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/consumer/TeamLifecycleConsumer.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/consumer/TeamLifecycleConsumer.kt
@@ -22,7 +22,7 @@ class TeamLifecycleConsumer(private val handler: ChannelLifecycleHandler) {
             }
             "MEMBER_REMOVED" -> payload.targetUserIds.forEach { handler.onMemberRemovedFromTeam(payload.teamId, it) }
             "TEAM_DELETED" -> handler.onTeamDeleted(payload.teamId)
-            else -> log.warn("알 수 없는 team.lifecycle 이벤트 [eventType={}]", payload.eventType)
+            else -> log.warn("Received unknown team.lifecycle event [eventType={}]", payload.eventType)
         }
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/consumer/UserLifecycleConsumer.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/consumer/UserLifecycleConsumer.kt
@@ -16,7 +16,7 @@ class UserLifecycleConsumer(private val handler: ChannelLifecycleHandler) {
     fun consume(payload: UserLifecyclePayload) {
         when (payload.eventType) {
             "USER_DELETED" -> handler.onUserDeleted(payload.userId)
-            else -> log.warn("알 수 없는 user.lifecycle 이벤트 [eventType={}]", payload.eventType)
+            else -> log.warn("Received unknown user.lifecycle event [eventType={}]", payload.eventType)
         }
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/ChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/ChannelController.kt
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.http.ResponseEntity
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.ObjectMapper
@@ -27,10 +27,11 @@ class ChannelController(private val channelService: ChannelService, private val 
         ApiResponse(responseCode = "403", description = "팀 멤버가 아님"),
     )
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     fun createChannel(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @RequestBody request: CreateChannelRequest,
-    ): ResponseEntity<ChannelResponse> = ResponseEntity.status(201).body(channelService.createChannel(userId, request))
+    ): ChannelResponse = channelService.createChannel(userId, request)
 
     @Operation(summary = "채널 상세 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -41,7 +42,7 @@ class ChannelController(private val channelService: ChannelService, private val 
     fun getChannel(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
-    ): ResponseEntity<ChannelResponse> = ResponseEntity.ok(channelService.getChannel(userId, channelId))
+    ): ChannelResponse = channelService.getChannel(userId, channelId)
 
     @Operation(summary = "채널 수정", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -54,10 +55,10 @@ class ChannelController(private val channelService: ChannelService, private val 
         @PathVariable channelId: Long,
         @SwaggerRequestBody(content = [Content(schema = Schema(implementation = UpdateChannelRequest::class))])
         @RequestBody body: JsonNode,
-    ): ResponseEntity<ChannelResponse> {
+    ): ChannelResponse {
         val request = objectMapper.convertValue(body, UpdateChannelRequest::class.java)
         val updateProjectId = body.has("projectId")
-        return ResponseEntity.ok(channelService.updateChannel(userId, channelId, request, updateProjectId))
+        return channelService.updateChannel(userId, channelId, request, updateProjectId)
     }
 
     @Operation(summary = "채널 삭제", security = [SecurityRequirement(name = "BearerAuth")])
@@ -66,12 +67,12 @@ class ChannelController(private val channelService: ChannelService, private val 
         ApiResponse(responseCode = "403", description = "권한 없음"),
     )
     @DeleteMapping("/{channelId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteChannel(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
-    ): ResponseEntity<Void> {
+    ) {
         channelService.deleteChannel(userId, channelId)
-        return ResponseEntity.noContent().build()
     }
 
     @Operation(summary = "채널 멤버 추가", security = [SecurityRequirement(name = "BearerAuth")])
@@ -80,12 +81,12 @@ class ChannelController(private val channelService: ChannelService, private val 
         ApiResponse(responseCode = "403", description = "권한 없음"),
     )
     @PostMapping("/{channelId}/members")
+    @ResponseStatus(HttpStatus.CREATED)
     fun addMember(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @RequestBody request: AddMemberRequest,
-    ): ResponseEntity<ChannelMemberResponse> =
-        ResponseEntity.status(201).body(channelService.addMember(userId, channelId, request))
+    ): ChannelMemberResponse = channelService.addMember(userId, channelId, request)
 
     @Operation(summary = "채널 멤버 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -96,7 +97,7 @@ class ChannelController(private val channelService: ChannelService, private val 
     fun getMembers(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
-    ): ResponseEntity<List<ChannelMemberResponse>> = ResponseEntity.ok(channelService.getMembers(userId, channelId))
+    ): List<ChannelMemberResponse> = channelService.getMembers(userId, channelId)
 
     @Operation(summary = "채널 멤버 제거", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -104,12 +105,12 @@ class ChannelController(private val channelService: ChannelService, private val 
         ApiResponse(responseCode = "403", description = "권한 없음"),
     )
     @DeleteMapping("/{channelId}/members/{memberId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun removeMember(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable memberId: Long,
-    ): ResponseEntity<Void> {
+    ) {
         channelService.removeMember(userId, channelId, memberId)
-        return ResponseEntity.noContent().build()
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/DmChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/DmChannelController.kt
@@ -9,11 +9,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.http.ResponseEntity
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "DM", description = "1:1 DM 채널 열기 API")
@@ -27,9 +28,9 @@ class DmChannelController(private val dmChannelService: DmChannelService) {
         ApiResponse(responseCode = "400", description = "자기 자신과의 DM 생성 시도"),
     )
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     fun openDm(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @RequestBody request: OpenDmRequest,
-    ): ResponseEntity<ChannelResponse> =
-        ResponseEntity.status(201).body(dmChannelService.openDm(userId, request.targetUserId))
+    ): ChannelResponse = dmChannelService.openDm(userId, request.targetUserId)
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/GlobalExceptionHandler.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/GlobalExceptionHandler.kt
@@ -33,7 +33,7 @@ class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception::class)
     fun handleInternal(e: Exception): ResponseEntity<ErrorResponse> {
-        log.error("처리되지 않은 예외 발생", e)
+        log.error("Caught unhandled exception", e)
         return ResponseEntity.internalServerError().body(ErrorResponse("서버 오류가 발생했습니다."))
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/MeetingNoteController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/MeetingNoteController.kt
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.http.ResponseEntity
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "회의록", description = "회의록 작성 및 조회 API")
@@ -27,7 +27,7 @@ class MeetingNoteController(private val meetingNoteService: MeetingNoteService) 
     fun listNotes(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
-    ): ResponseEntity<List<MeetingNoteResponse>> = ResponseEntity.ok(meetingNoteService.listNotes(userId, channelId))
+    ): List<MeetingNoteResponse> = meetingNoteService.listNotes(userId, channelId)
 
     @Operation(summary = "회의록 상세 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -40,7 +40,7 @@ class MeetingNoteController(private val meetingNoteService: MeetingNoteService) 
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable noteId: Long,
-    ): ResponseEntity<MeetingNoteResponse> = ResponseEntity.ok(meetingNoteService.getNote(userId, channelId, noteId))
+    ): MeetingNoteResponse = meetingNoteService.getNote(userId, channelId, noteId)
 
     @Operation(summary = "회의록 작성", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -50,12 +50,12 @@ class MeetingNoteController(private val meetingNoteService: MeetingNoteService) 
         ApiResponse(responseCode = "404", description = "템플릿 없음"),
     )
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     fun createNote(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @RequestBody request: CreateMeetingNoteRequest,
-    ): ResponseEntity<MeetingNoteResponse> =
-        ResponseEntity.status(201).body(meetingNoteService.createNote(userId, channelId, request))
+    ): MeetingNoteResponse = meetingNoteService.createNote(userId, channelId, request)
 
     @Operation(summary = "회의록 수정", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -69,8 +69,7 @@ class MeetingNoteController(private val meetingNoteService: MeetingNoteService) 
         @PathVariable channelId: Long,
         @PathVariable noteId: Long,
         @RequestBody request: UpdateMeetingNoteRequest,
-    ): ResponseEntity<MeetingNoteResponse> =
-        ResponseEntity.ok(meetingNoteService.updateNote(userId, channelId, noteId, request))
+    ): MeetingNoteResponse = meetingNoteService.updateNote(userId, channelId, noteId, request)
 
     @Operation(summary = "회의록 삭제", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -79,12 +78,12 @@ class MeetingNoteController(private val meetingNoteService: MeetingNoteService) 
         ApiResponse(responseCode = "404", description = "회의록 없음"),
     )
     @DeleteMapping("/{noteId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteNote(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable noteId: Long,
-    ): ResponseEntity<Unit> {
+    ) {
         meetingNoteService.deleteNote(userId, channelId, noteId)
-        return ResponseEntity.noContent().build()
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/MeetingNoteTemplateController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/MeetingNoteTemplateController.kt
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.http.ResponseEntity
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "회의록 템플릿", description = "회의록 템플릿 및 섹션 CRUD API")
@@ -25,8 +25,7 @@ class MeetingNoteTemplateController(private val meetingNoteTemplateService: Meet
     fun listTemplates(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
-    ): ResponseEntity<List<MeetingNoteTemplateResponse>> =
-        ResponseEntity.ok(meetingNoteTemplateService.listTemplates(userId, channelId))
+    ): List<MeetingNoteTemplateResponse> = meetingNoteTemplateService.listTemplates(userId, channelId)
 
     @Operation(summary = "템플릿 생성", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -34,12 +33,12 @@ class MeetingNoteTemplateController(private val meetingNoteTemplateService: Meet
         ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
     )
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     fun createTemplate(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @RequestBody request: CreateMeetingNoteTemplateRequest,
-    ): ResponseEntity<MeetingNoteTemplateResponse> =
-        ResponseEntity.status(201).body(meetingNoteTemplateService.createTemplate(userId, channelId, request))
+    ): MeetingNoteTemplateResponse = meetingNoteTemplateService.createTemplate(userId, channelId, request)
 
     @Operation(summary = "템플릿 상세 조회 (섹션 포함)", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -51,8 +50,7 @@ class MeetingNoteTemplateController(private val meetingNoteTemplateService: Meet
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable templateId: Long,
-    ): ResponseEntity<MeetingNoteTemplateResponse> =
-        ResponseEntity.ok(meetingNoteTemplateService.getTemplate(userId, channelId, templateId))
+    ): MeetingNoteTemplateResponse = meetingNoteTemplateService.getTemplate(userId, channelId, templateId)
 
     @Operation(summary = "템플릿 이름 수정", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -65,8 +63,7 @@ class MeetingNoteTemplateController(private val meetingNoteTemplateService: Meet
         @PathVariable channelId: Long,
         @PathVariable templateId: Long,
         @RequestBody request: UpdateMeetingNoteTemplateRequest,
-    ): ResponseEntity<MeetingNoteTemplateResponse> =
-        ResponseEntity.ok(meetingNoteTemplateService.updateTemplate(userId, channelId, templateId, request))
+    ): MeetingNoteTemplateResponse = meetingNoteTemplateService.updateTemplate(userId, channelId, templateId, request)
 
     @Operation(summary = "템플릿 삭제 (활성 템플릿 삭제 불가)", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -75,13 +72,13 @@ class MeetingNoteTemplateController(private val meetingNoteTemplateService: Meet
         ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
     )
     @DeleteMapping("/{templateId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteTemplate(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable templateId: Long,
-    ): ResponseEntity<Void> {
+    ) {
         meetingNoteTemplateService.deleteTemplate(userId, channelId, templateId)
-        return ResponseEntity.noContent().build()
     }
 
     @Operation(summary = "템플릿 활성화 (기존 활성 자동 해제)", security = [SecurityRequirement(name = "BearerAuth")])
@@ -94,8 +91,7 @@ class MeetingNoteTemplateController(private val meetingNoteTemplateService: Meet
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable templateId: Long,
-    ): ResponseEntity<MeetingNoteTemplateResponse> =
-        ResponseEntity.ok(meetingNoteTemplateService.activateTemplate(userId, channelId, templateId))
+    ): MeetingNoteTemplateResponse = meetingNoteTemplateService.activateTemplate(userId, channelId, templateId)
 
     @Operation(summary = "섹션 추가", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -103,13 +99,13 @@ class MeetingNoteTemplateController(private val meetingNoteTemplateService: Meet
         ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
     )
     @PostMapping("/{templateId}/sections")
+    @ResponseStatus(HttpStatus.CREATED)
     fun addSection(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable templateId: Long,
         @RequestBody request: CreateTemplateSectionRequest,
-    ): ResponseEntity<TemplateSectionResponse> =
-        ResponseEntity.status(201).body(meetingNoteTemplateService.addSection(userId, channelId, templateId, request))
+    ): TemplateSectionResponse = meetingNoteTemplateService.addSection(userId, channelId, templateId, request)
 
     @Operation(summary = "섹션 수정", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -123,8 +119,8 @@ class MeetingNoteTemplateController(private val meetingNoteTemplateService: Meet
         @PathVariable templateId: Long,
         @PathVariable sectionId: Long,
         @RequestBody request: UpdateTemplateSectionRequest,
-    ): ResponseEntity<TemplateSectionResponse> =
-        ResponseEntity.ok(meetingNoteTemplateService.updateSection(userId, channelId, templateId, sectionId, request))
+    ): TemplateSectionResponse =
+        meetingNoteTemplateService.updateSection(userId, channelId, templateId, sectionId, request)
 
     @Operation(summary = "섹션 삭제", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -132,13 +128,13 @@ class MeetingNoteTemplateController(private val meetingNoteTemplateService: Meet
         ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
     )
     @DeleteMapping("/{templateId}/sections/{sectionId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteSection(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable templateId: Long,
         @PathVariable sectionId: Long,
-    ): ResponseEntity<Void> {
+    ) {
         meetingNoteTemplateService.deleteSection(userId, channelId, templateId, sectionId)
-        return ResponseEntity.noContent().build()
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/ProjectChannelController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/ProjectChannelController.kt
@@ -8,7 +8,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestHeader
@@ -29,5 +28,5 @@ class ProjectChannelController(private val channelService: ChannelService) {
     fun listProjectChannels(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable projectId: Long,
-    ): ResponseEntity<List<ChannelResponse>> = ResponseEntity.ok(channelService.listProjectChannels(userId, projectId))
+    ): List<ChannelResponse> = channelService.listProjectChannels(userId, projectId)
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/SharedAccountController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/SharedAccountController.kt
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.http.ResponseEntity
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "계정 공유", description = "ACCOUNT_SHARE 채널의 공유 계정 관리 API")
@@ -29,8 +29,7 @@ class SharedAccountController(private val sharedAccountService: SharedAccountSer
     fun listAccounts(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
-    ): ResponseEntity<List<SharedAccountResponse>> =
-        ResponseEntity.ok(sharedAccountService.listAccounts(userId, channelId))
+    ): List<SharedAccountResponse> = sharedAccountService.listAccounts(userId, channelId)
 
     @Operation(summary = "공유 계정 상세 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -43,8 +42,7 @@ class SharedAccountController(private val sharedAccountService: SharedAccountSer
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable accountId: Long,
-    ): ResponseEntity<SharedAccountResponse> =
-        ResponseEntity.ok(sharedAccountService.getAccount(userId, channelId, accountId))
+    ): SharedAccountResponse = sharedAccountService.getAccount(userId, channelId, accountId)
 
     @Operation(summary = "공유 계정 등록 (수동)", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -53,12 +51,12 @@ class SharedAccountController(private val sharedAccountService: SharedAccountSer
         ApiResponse(responseCode = "403", description = "팀 멤버가 아님"),
     )
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     fun createAccount(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @RequestBody request: CreateSharedAccountRequest,
-    ): ResponseEntity<SharedAccountResponse> =
-        ResponseEntity.status(201).body(sharedAccountService.createAccount(userId, channelId, request))
+    ): SharedAccountResponse = sharedAccountService.createAccount(userId, channelId, request)
 
     @Operation(summary = "공유 계정 수정", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -72,8 +70,7 @@ class SharedAccountController(private val sharedAccountService: SharedAccountSer
         @PathVariable channelId: Long,
         @PathVariable accountId: Long,
         @RequestBody request: UpdateSharedAccountRequest,
-    ): ResponseEntity<SharedAccountResponse> =
-        ResponseEntity.ok(sharedAccountService.updateAccount(userId, channelId, accountId, request))
+    ): SharedAccountResponse = sharedAccountService.updateAccount(userId, channelId, accountId, request)
 
     @Operation(summary = "공유 계정 삭제", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -82,13 +79,13 @@ class SharedAccountController(private val sharedAccountService: SharedAccountSer
         ApiResponse(responseCode = "404", description = "채널 또는 계정 없음"),
     )
     @DeleteMapping("/{accountId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteAccount(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable accountId: Long,
-    ): ResponseEntity<Void> {
+    ) {
         sharedAccountService.deleteAccount(userId, channelId, accountId)
-        return ResponseEntity.noContent().build()
     }
 
     @Operation(
@@ -105,8 +102,8 @@ class SharedAccountController(private val sharedAccountService: SharedAccountSer
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable accountId: Long,
-    ): ResponseEntity<Map<String, String>> {
+    ): Map<String, String> {
         val credential = sharedAccountService.copyCredential(userId, channelId, accountId)
-        return ResponseEntity.ok(mapOf("credential" to credential))
+        return mapOf("credential" to credential)
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/ThreadController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/ThreadController.kt
@@ -13,7 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.web.PageableDefault
-import org.springframework.http.ResponseEntity
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "스레드", description = "채널 스레드 생성/수정/조회 API")
@@ -27,12 +27,12 @@ class ThreadController(private val threadService: ThreadService) {
         ApiResponse(responseCode = "403", description = "채널 멤버가 아님"),
     )
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     fun createThread(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @RequestBody request: CreateThreadRequest,
-    ): ResponseEntity<ThreadResponse> =
-        ResponseEntity.status(201).body(threadService.createThread(userId, channelId, request))
+    ): ThreadResponse = threadService.createThread(userId, channelId, request)
 
     @Operation(summary = "스레드 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -45,8 +45,7 @@ class ThreadController(private val threadService: ThreadService) {
         @PathVariable channelId: Long,
         @RequestParam(defaultValue = "false") includeArchived: Boolean,
         @PageableDefault(size = 20) pageable: Pageable,
-    ): ResponseEntity<Page<ThreadResponse>> =
-        ResponseEntity.ok(threadService.getThreads(userId, channelId, includeArchived, pageable))
+    ): Page<ThreadResponse> = threadService.getThreads(userId, channelId, includeArchived, pageable)
 
     @Operation(summary = "스레드 수정", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -59,6 +58,5 @@ class ThreadController(private val threadService: ThreadService) {
         @PathVariable channelId: Long,
         @PathVariable threadId: Long,
         @RequestBody request: UpdateThreadRequest,
-    ): ResponseEntity<ThreadResponse> =
-        ResponseEntity.ok(threadService.updateThread(userId, channelId, threadId, request))
+    ): ThreadResponse = threadService.updateThread(userId, channelId, threadId, request)
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/controller/WebhookController.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/controller/WebhookController.kt
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.http.ResponseEntity
+import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "웹훅", description = "채널 웹훅 CRUD API (TEXT 타입 채널 전용)")
@@ -25,12 +25,12 @@ class WebhookController(private val webhookService: WebhookService) {
         ApiResponse(responseCode = "403", description = "권한 없음"),
     )
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     fun createWebhook(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @RequestBody request: CreateWebhookRequest,
-    ): ResponseEntity<WebhookResponse> =
-        ResponseEntity.status(201).body(webhookService.createWebhook(userId, channelId, request))
+    ): WebhookResponse = webhookService.createWebhook(userId, channelId, request)
 
     @Operation(summary = "웹훅 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -41,7 +41,7 @@ class WebhookController(private val webhookService: WebhookService) {
     fun getWebhooks(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
-    ): ResponseEntity<List<WebhookResponse>> = ResponseEntity.ok(webhookService.getWebhooks(userId, channelId))
+    ): List<WebhookResponse> = webhookService.getWebhooks(userId, channelId)
 
     @Operation(summary = "웹훅 수정", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -54,8 +54,7 @@ class WebhookController(private val webhookService: WebhookService) {
         @PathVariable channelId: Long,
         @PathVariable webhookId: Long,
         @RequestBody request: UpdateWebhookRequest,
-    ): ResponseEntity<WebhookResponse> =
-        ResponseEntity.ok(webhookService.updateWebhook(userId, channelId, webhookId, request))
+    ): WebhookResponse = webhookService.updateWebhook(userId, channelId, webhookId, request)
 
     @Operation(summary = "웹훅 삭제", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -63,12 +62,12 @@ class WebhookController(private val webhookService: WebhookService) {
         ApiResponse(responseCode = "403", description = "권한 없음"),
     )
     @DeleteMapping("/{webhookId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteWebhook(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable channelId: Long,
         @PathVariable webhookId: Long,
-    ): ResponseEntity<Void> {
+    ) {
         webhookService.deleteWebhook(userId, channelId, webhookId)
-        return ResponseEntity.noContent().build()
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/CreateMeetingNoteRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/CreateMeetingNoteRequest.kt
@@ -3,10 +3,10 @@ package com.cowork.channel.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class CreateMeetingNoteRequest(
-    @Schema(description = "사용할 템플릿 ID", example = "1")
+    @param:Schema(description = "사용할 템플릿 ID", example = "1")
     val templateId: Long,
-    @Schema(description = "회의록 제목", example = "2024-01-01 팀 주간 회의")
+    @param:Schema(description = "회의록 제목", example = "2024-01-01 팀 주간 회의")
     val title: String,
-    @Schema(description = "섹션별 작성 내용 JSON 블록", example = "{\"회의 제목\": \"API 설계 논의\", \"참석자\": \"홍길동, 김철수\"}")
+    @param:Schema(description = "섹션별 작성 내용 JSON 블록", example = "{\"회의 제목\": \"API 설계 논의\", \"참석자\": \"홍길동, 김철수\"}")
     val content: String,
 )

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/CreateSharedAccountRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/CreateSharedAccountRequest.kt
@@ -4,15 +4,15 @@ import com.cowork.channel.domain.AccountProvider
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class CreateSharedAccountRequest(
-    @Schema(description = "서비스 종류 (OAuth 미지원 서비스는 CUSTOM 사용)", example = "GITHUB")
+    @param:Schema(description = "서비스 종류 (OAuth 미지원 서비스는 CUSTOM 사용)", example = "GITHUB")
     val provider: AccountProvider,
 
-    @Schema(description = "CUSTOM 서비스일 때 사용자 정의 서비스 이름", example = "사내 Jenkins")
+    @param:Schema(description = "CUSTOM 서비스일 때 사용자 정의 서비스 이름", example = "사내 Jenkins")
     val providerLabel: String?,
 
-    @Schema(description = "로그인 식별자 (이메일 또는 username)", example = "team@company.com")
+    @param:Schema(description = "로그인 식별자 (이메일 또는 username)", example = "team@company.com")
     val accountIdentifier: String?,
 
-    @Schema(description = "비밀번호 또는 API 키 (서버에서 암호화 저장)", example = "MyP@ssw0rd!")
+    @param:Schema(description = "비밀번호 또는 API 키 (서버에서 암호화 저장)", example = "MyP@ssw0rd!")
     val credential: String?,
 )

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/MeetingNoteResponse.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/MeetingNoteResponse.kt
@@ -5,21 +5,21 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class MeetingNoteResponse(
-    @Schema(description = "회의록 ID", example = "1")
+    @field:Schema(description = "회의록 ID", example = "1")
     val id: Long,
-    @Schema(description = "채널 ID", example = "1")
+    @field:Schema(description = "채널 ID", example = "1")
     val channelId: Long,
-    @Schema(description = "사용된 템플릿 ID", example = "1")
+    @field:Schema(description = "사용된 템플릿 ID", example = "1")
     val templateId: Long,
-    @Schema(description = "회의록 제목", example = "2024-01-01 팀 주간 회의")
+    @field:Schema(description = "회의록 제목", example = "2024-01-01 팀 주간 회의")
     val title: String,
-    @Schema(description = "섹션별 작성 내용 JSON 블록", example = "{\"회의 제목\": \"API 설계 논의\", \"참석자\": \"홍길동, 김철수\"}")
+    @field:Schema(description = "섹션별 작성 내용 JSON 블록", example = "{\"회의 제목\": \"API 설계 논의\", \"참석자\": \"홍길동, 김철수\"}")
     val content: String,
-    @Schema(description = "작성자 ID", example = "1")
+    @field:Schema(description = "작성자 ID", example = "1")
     val createdBy: Long,
-    @Schema(description = "작성 일시")
+    @field:Schema(description = "작성 일시")
     val createdAt: LocalDateTime,
-    @Schema(description = "수정 일시")
+    @field:Schema(description = "수정 일시")
     val updatedAt: LocalDateTime,
 ) {
     companion object {

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/SharedAccountResponse.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/SharedAccountResponse.kt
@@ -5,40 +5,40 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class SharedAccountResponse(
-    @Schema(description = "공유 계정 ID", example = "1")
+    @field:Schema(description = "공유 계정 ID", example = "1")
     val id: Long,
 
-    @Schema(description = "채널 ID", example = "10")
+    @field:Schema(description = "채널 ID", example = "10")
     val channelId: Long,
 
-    @Schema(description = "서비스 종류 enum 값", example = "GITHUB")
+    @field:Schema(description = "서비스 종류 enum 값", example = "GITHUB")
     val provider: String,
 
-    @Schema(description = "CUSTOM 서비스일 때 사용자 정의 이름", example = "사내 Jenkins")
+    @field:Schema(description = "CUSTOM 서비스일 때 사용자 정의 이름", example = "사내 Jenkins")
     val providerLabel: String?,
 
-    @Schema(description = "화면에 표시할 서비스 이름", example = "GitHub")
+    @field:Schema(description = "화면에 표시할 서비스 이름", example = "GitHub")
     val displayName: String?,
 
-    @Schema(description = "해당 서비스 로그인 페이지 URL", example = "https://github.com/login")
+    @field:Schema(description = "해당 서비스 로그인 페이지 URL", example = "https://github.com/login")
     val loginUrl: String?,
 
-    @Schema(description = "로그인 식별자 (이메일 또는 username)", example = "team@company.com")
+    @field:Schema(description = "로그인 식별자 (이메일 또는 username)", example = "team@company.com")
     val accountIdentifier: String?,
 
-    @Schema(description = "마스킹된 credential (길이에 따라 마지막 2~4자리 노출)", example = "••••w0rd!")
+    @field:Schema(description = "마스킹된 credential (길이에 따라 마지막 2~4자리 노출)", example = "••••w0rd!")
     val maskedCredential: String?,
 
-    @Schema(description = "OAuth 연동으로 등록된 계정 여부")
+    @field:Schema(description = "OAuth 연동으로 등록된 계정 여부")
     val connectedViaOAuth: Boolean,
 
-    @Schema(description = "등록한 사용자 ID", example = "42")
+    @field:Schema(description = "등록한 사용자 ID", example = "42")
     val createdBy: Long,
 
-    @Schema(description = "등록 일시")
+    @field:Schema(description = "등록 일시")
     val createdAt: LocalDateTime,
 
-    @Schema(description = "최종 수정 일시")
+    @field:Schema(description = "최종 수정 일시")
     val updatedAt: LocalDateTime,
 ) {
     companion object {

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateMeetingNoteRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateMeetingNoteRequest.kt
@@ -3,8 +3,8 @@ package com.cowork.channel.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class UpdateMeetingNoteRequest(
-    @Schema(description = "회의록 제목", example = "2024-01-01 팀 주간 회의")
+    @param:Schema(description = "회의록 제목", example = "2024-01-01 팀 주간 회의")
     val title: String?,
-    @Schema(description = "섹션별 작성 내용 JSON 블록", example = "{\"회의 제목\": \"API 설계 논의\", \"참석자\": \"홍길동, 김철수\"}")
+    @param:Schema(description = "섹션별 작성 내용 JSON 블록", example = "{\"회의 제목\": \"API 설계 논의\", \"참석자\": \"홍길동, 김철수\"}")
     val content: String?,
 )

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateSharedAccountRequest.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/dto/UpdateSharedAccountRequest.kt
@@ -3,12 +3,12 @@ package com.cowork.channel.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class UpdateSharedAccountRequest(
-    @Schema(description = "로그인 식별자 (이메일 또는 username)", example = "team@company.com")
+    @param:Schema(description = "로그인 식별자 (이메일 또는 username)", example = "team@company.com")
     val accountIdentifier: String?,
 
-    @Schema(description = "변경할 비밀번호 또는 API 키", example = "NewP@ssw0rd!")
+    @param:Schema(description = "변경할 비밀번호 또는 API 키", example = "NewP@ssw0rd!")
     val credential: String?,
 
-    @Schema(description = "CUSTOM 서비스 이름 변경", example = "사내 Jenkins (신규)")
+    @param:Schema(description = "CUSTOM 서비스 이름 변경", example = "사내 Jenkins (신규)")
     val providerLabel: String?,
 )

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ChannelService.kt
@@ -31,7 +31,7 @@ class ChannelService(
 ) {
 
     fun findChannelOrThrow(channelId: Long): Channel = channelRepository.findById(channelId).orElseThrow {
-        ExpectedException("채널을 찾을 수 없습니다. id=$channelId", HttpStatus.NOT_FOUND)
+        ExpectedException("채널을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
     }
 
     /** DM 채널이면 거부하고, 팀 채널이면 non-null teamId를 반환한다. */
@@ -59,7 +59,7 @@ class ChannelService(
         val type = try {
             ChannelType.valueOf(value.uppercase())
         } catch (e: IllegalArgumentException) {
-            throw ExpectedException("유효하지 않은 채널 타입입니다. type=$value", HttpStatus.BAD_REQUEST)
+            throw ExpectedException("유효하지 않은 채널 타입입니다.", HttpStatus.BAD_REQUEST)
         }
         if (type == ChannelType.DM) {
             throw ExpectedException("DM 채널은 DM 전용 API로만 생성할 수 있습니다.", HttpStatus.BAD_REQUEST)
@@ -70,7 +70,7 @@ class ChannelService(
     private fun parseViewType(value: String): ChannelViewType = try {
         ChannelViewType.valueOf(value.uppercase())
     } catch (e: IllegalArgumentException) {
-        throw ExpectedException("유효하지 않은 view_type 입니다. value=$value", HttpStatus.BAD_REQUEST)
+        throw ExpectedException("유효하지 않은 view_type 입니다.", HttpStatus.BAD_REQUEST)
     }
 
     private fun requireChannelManager(channel: Channel, userId: Long) {
@@ -221,7 +221,7 @@ class ChannelService(
         val channel = findChannelOrThrow(channelId)
         val teamId = requireTeamChannel(channel)
         val member = channelMemberRepository.findById(memberId).orElseThrow {
-            ExpectedException("멤버를 찾을 수 없습니다. id=$memberId", HttpStatus.NOT_FOUND)
+            ExpectedException("멤버를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         }
 
         if (member.channelId != channelId) {

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteService.kt
@@ -53,7 +53,7 @@ class MeetingNoteService(
     fun createNote(userId: Long, channelId: Long, request: CreateMeetingNoteRequest): MeetingNoteResponse {
         requireChannelMember(channelId, userId)
         val template = templateRepository.findById(request.templateId).orElseThrow {
-            ExpectedException("템플릿을 찾을 수 없습니다. id=${request.templateId}", HttpStatus.NOT_FOUND)
+            ExpectedException("템플릿을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         }
         if (template.channelId != channelId) {
             throw ExpectedException("템플릿을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
@@ -103,7 +103,7 @@ class MeetingNoteService(
 
     private fun findNoteOrThrow(noteId: Long, channelId: Long): MeetingNote {
         val note = meetingNoteRepository.findById(noteId).orElseThrow {
-            ExpectedException("회의록을 찾을 수 없습니다. id=$noteId", HttpStatus.NOT_FOUND)
+            ExpectedException("회의록을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         }
         if (note.channelId != channelId) {
             throw ExpectedException("회의록을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteTemplateService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/MeetingNoteTemplateService.kt
@@ -42,12 +42,12 @@ class MeetingNoteTemplateService(
 
     private fun findTemplateOrThrow(templateId: Long): MeetingNoteTemplate =
         templateRepository.findById(templateId).orElseThrow {
-            ExpectedException("템플릿을 찾을 수 없습니다. id=$templateId", HttpStatus.NOT_FOUND)
+            ExpectedException("템플릿을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         }
 
     private fun findSectionOrThrow(sectionId: Long): TemplateSection =
         sectionRepository.findById(sectionId).orElseThrow {
-            ExpectedException("섹션을 찾을 수 없습니다. id=$sectionId", HttpStatus.NOT_FOUND)
+            ExpectedException("섹션을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         }
 
     private fun requireChannelMember(channelId: Long, userId: Long) {
@@ -74,7 +74,7 @@ class MeetingNoteTemplateService(
     private fun parseSectionType(value: String): SectionType = try {
         SectionType.valueOf(value.uppercase())
     } catch (e: IllegalArgumentException) {
-        throw ExpectedException("유효하지 않은 섹션 타입입니다. type=$value", HttpStatus.BAD_REQUEST)
+        throw ExpectedException("유효하지 않은 섹션 타입입니다.", HttpStatus.BAD_REQUEST)
     }
 
     @Transactional(readOnly = true)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/OAuthAccountService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/OAuthAccountService.kt
@@ -103,14 +103,14 @@ class OAuthAccountService(
                     .queryParam("state", state)
                     .build().toUriString()
 
-            else -> throw ExpectedException("OAuth를 지원하지 않는 서비스입니다. provider=${provider.name}", HttpStatus.BAD_REQUEST)
+            else -> throw ExpectedException("OAuth를 지원하지 않는 서비스입니다.", HttpStatus.BAD_REQUEST)
         }
     }
 
     @Transactional
     fun handleCallback(providerName: String, code: String, state: String): SharedAccount {
         val provider = runCatching { AccountProvider.valueOf(providerName.uppercase()) }.getOrElse {
-            throw ExpectedException("지원하지 않는 OAuth provider입니다. provider=$providerName", HttpStatus.BAD_REQUEST)
+            throw ExpectedException("지원하지 않는 OAuth provider입니다.", HttpStatus.BAD_REQUEST)
         }
 
         val (channelId, userId) = verifyState(state, provider)
@@ -214,9 +214,9 @@ class OAuthAccountService(
                 .body(body)
                 .retrieve()
                 .body(Map::class.java)
-                ?: throw ExpectedException("${provider.displayName} 토큰 교환 실패", HttpStatus.BAD_GATEWAY)
+                ?: throw ExpectedException("OAuth 토큰 교환에 실패했습니다.", HttpStatus.BAD_GATEWAY)
             response["access_token"] as? String
-                ?: throw ExpectedException("${provider.displayName} access_token 없음", HttpStatus.BAD_GATEWAY)
+                ?: throw ExpectedException("OAuth 토큰 교환에 실패했습니다.", HttpStatus.BAD_GATEWAY)
         }
 
         else -> throw ExpectedException("OAuth를 지원하지 않는 서비스입니다.", HttpStatus.BAD_REQUEST)
@@ -305,6 +305,6 @@ class OAuthAccountService(
         AccountProvider.JIRA -> oAuthProperties.jira
         AccountProvider.GOOGLE -> oAuthProperties.google
         AccountProvider.FACEBOOK -> oAuthProperties.facebook
-        else -> throw ExpectedException("OAuth를 지원하지 않는 서비스입니다. provider=${provider.name}", HttpStatus.BAD_REQUEST)
+        else -> throw ExpectedException("OAuth를 지원하지 않는 서비스입니다.", HttpStatus.BAD_REQUEST)
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/SharedAccountService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/SharedAccountService.kt
@@ -27,7 +27,7 @@ class SharedAccountService(
 
     private fun findAccountOrThrow(accountId: Long, channelId: Long): SharedAccount =
         sharedAccountRepository.findByIdAndChannelId(accountId, channelId)
-            ?: throw ExpectedException("공유 계정을 찾을 수 없습니다. id=$accountId", HttpStatus.NOT_FOUND)
+            ?: throw ExpectedException("공유 계정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
 
     private fun requireAccountShareChannel(channel: Channel) {
         if (channel.viewType != ChannelViewType.ACCOUNT_SHARE) {

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/ThreadService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/ThreadService.kt
@@ -23,7 +23,7 @@ class ThreadService(
 ) {
 
     private fun findThreadOrThrow(id: Long): Thread = threadRepository.findById(id).orElseThrow {
-        ExpectedException("스레드를 찾을 수 없습니다. id=$id", HttpStatus.NOT_FOUND)
+        ExpectedException("스레드를 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
     }
 
     @Transactional

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/service/WebhookService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/service/WebhookService.kt
@@ -22,7 +22,7 @@ class WebhookService(
 ) {
 
     private fun findWebhookOrThrow(id: Long): Webhook = webhookRepository.findById(id).orElseThrow {
-        ExpectedException("웹훅을 찾을 수 없습니다. id=$id", HttpStatus.NOT_FOUND)
+        ExpectedException("웹훅을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
     }
 
     private fun requireWebhookManager(channelId: Long, userId: Long, expectedTextChannel: Boolean = true): Channel {

--- a/cowork-team/src/main/kotlin/com/cowork/team/controller/AdditionalExceptionHandler.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/controller/AdditionalExceptionHandler.kt
@@ -27,7 +27,7 @@ class AdditionalExceptionHandler {
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handleHttpMessageNotReadable(e: HttpMessageNotReadableException): ResponseEntity<CommonApiResponse<Nothing>> {
-        log.warn("읽을 수 없는 요청 본문", e)
+        log.warn("Failed to read request body", e)
         return ResponseEntity.status(
             HttpStatus.BAD_REQUEST,
         ).body(CommonApiResponse.error("요청 본문을 읽을 수 없습니다.", HttpStatus.BAD_REQUEST))
@@ -60,7 +60,7 @@ class AdditionalExceptionHandler {
 
     @ExceptionHandler(Exception::class)
     fun handleInternal(e: Exception): ResponseEntity<CommonApiResponse<Nothing>> {
-        log.error("처리되지 않은 예외 발생", e)
+        log.error("Caught unhandled exception", e)
         return ResponseEntity.internalServerError().body(
             CommonApiResponse.error("서버 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
         )

--- a/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamController.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamController.kt
@@ -17,7 +17,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "팀", description = "팀 생성/수정/삭제 API")
@@ -31,10 +30,8 @@ class TeamController(private val teamService: TeamService) {
         ApiResponse(responseCode = "400", description = "허용되지 않는 파일 형식"),
     )
     @PostMapping("/icon/presigned")
-    fun generateIconPresignedUrl(
-        @RequestBody request: IconPresignedUrlRequest,
-    ): ResponseEntity<IconPresignedUrlResponse> =
-        ResponseEntity.ok(teamService.generateIconPresignedUrl(request.contentType))
+    fun generateIconPresignedUrl(@RequestBody request: IconPresignedUrlRequest): IconPresignedUrlResponse =
+        teamService.generateIconPresignedUrl(request.contentType)
 
     @Operation(summary = "팀 아이콘 업로드 확인", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -44,8 +41,8 @@ class TeamController(private val teamService: TeamService) {
         ApiResponse(responseCode = "413", description = "파일 크기 초과"),
     )
     @PostMapping("/icon/confirm")
-    fun confirmIconUpload(@RequestBody request: IconConfirmRequest): ResponseEntity<IconConfirmResponse> =
-        ResponseEntity.ok(teamService.confirmIconUpload(request.objectKey))
+    fun confirmIconUpload(@RequestBody request: IconConfirmRequest): IconConfirmResponse =
+        teamService.confirmIconUpload(request.objectKey)
 
     @Operation(summary = "팀 생성", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -53,18 +50,17 @@ class TeamController(private val teamService: TeamService) {
         ApiResponse(responseCode = "400", description = "잘못된 요청"),
     )
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     fun createTeam(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @RequestBody request: CreateTeamRequest,
-    ): ResponseEntity<TeamResponse> =
-        ResponseEntity.status(HttpStatus.CREATED).body(teamService.createTeam(userId, request))
+    ): TeamResponse = teamService.createTeam(userId, request)
 
     @Operation(summary = "내 팀 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping
-    fun getMyTeams(
-        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
-    ): ResponseEntity<List<TeamSummaryResponse>> = ResponseEntity.ok(teamService.getMyTeams(userId))
+    fun getMyTeams(@Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long): List<TeamSummaryResponse> =
+        teamService.getMyTeams(userId)
 
     @Operation(summary = "팀 상세 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -72,8 +68,7 @@ class TeamController(private val teamService: TeamService) {
         ApiResponse(responseCode = "404", description = "팀 없음"),
     )
     @GetMapping("/{teamId}")
-    fun getTeam(@PathVariable teamId: Long): ResponseEntity<TeamResponse> =
-        ResponseEntity.ok(teamService.getTeam(teamId))
+    fun getTeam(@PathVariable teamId: Long): TeamResponse = teamService.getTeam(teamId)
 
     @Operation(summary = "팀 정보 수정", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -86,7 +81,7 @@ class TeamController(private val teamService: TeamService) {
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @RequestBody request: UpdateTeamRequest,
-    ): ResponseEntity<TeamResponse> = ResponseEntity.ok(teamService.updateTeam(userId, teamId, request))
+    ): TeamResponse = teamService.updateTeam(userId, teamId, request)
 
     @Operation(summary = "팀 아이콘 교체", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -99,7 +94,7 @@ class TeamController(private val teamService: TeamService) {
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @RequestBody request: UpdateIconRequest,
-    ): ResponseEntity<IconConfirmResponse> = ResponseEntity.ok(teamService.updateIcon(userId, teamId, request.iconUrl))
+    ): IconConfirmResponse = teamService.updateIcon(userId, teamId, request.iconUrl)
 
     @Operation(summary = "팀 아이콘 제거", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -108,12 +103,9 @@ class TeamController(private val teamService: TeamService) {
         ApiResponse(responseCode = "404", description = "팀 없음 또는 아이콘 없음"),
     )
     @DeleteMapping("/{teamId}/icon")
-    fun deleteIcon(
-        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
-        @PathVariable teamId: Long,
-    ): ResponseEntity<Void> {
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteIcon(@Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long, @PathVariable teamId: Long) {
         teamService.deleteIcon(userId, teamId)
-        return ResponseEntity.noContent().build()
     }
 
     @Operation(summary = "팀 삭제", security = [SecurityRequirement(name = "BearerAuth")])
@@ -123,11 +115,8 @@ class TeamController(private val teamService: TeamService) {
         ApiResponse(responseCode = "404", description = "팀 없음"),
     )
     @DeleteMapping("/{teamId}")
-    fun deleteTeam(
-        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
-        @PathVariable teamId: Long,
-    ): ResponseEntity<Void> {
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deleteTeam(@Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long, @PathVariable teamId: Long) {
         teamService.deleteTeam(userId, teamId)
-        return ResponseEntity.noContent().build()
     }
 }

--- a/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamInviteController.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamInviteController.kt
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "팀 초대", description = "팀 초대 링크 생성·조회·삭제 및 코드로 팀 가입 API")
@@ -26,12 +25,12 @@ class TeamInviteController(private val teamInviteService: TeamInviteService) {
         ApiResponse(responseCode = "404", description = "팀 없음"),
     )
     @PostMapping("/{teamId}/invites")
+    @ResponseStatus(HttpStatus.CREATED)
     fun createInvite(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @RequestBody request: CreateInviteRequest,
-    ): ResponseEntity<InviteResponse> = ResponseEntity.status(HttpStatus.CREATED)
-        .body(teamInviteService.createInvite(userId, teamId, request))
+    ): InviteResponse = teamInviteService.createInvite(userId, teamId, request)
 
     @Operation(summary = "초대 링크 목록 조회 (만료 포함)", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -42,7 +41,7 @@ class TeamInviteController(private val teamInviteService: TeamInviteService) {
     fun getInvites(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
-    ): ResponseEntity<List<InviteResponse>> = ResponseEntity.ok(teamInviteService.getInvites(userId, teamId))
+    ): List<InviteResponse> = teamInviteService.getInvites(userId, teamId)
 
     @Operation(summary = "초대 링크 무효화", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -51,13 +50,13 @@ class TeamInviteController(private val teamInviteService: TeamInviteService) {
         ApiResponse(responseCode = "404", description = "초대 링크 없음"),
     )
     @DeleteMapping("/{teamId}/invites/{inviteCode}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteInvite(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @PathVariable inviteCode: String,
-    ): ResponseEntity<Void> {
+    ) {
         teamInviteService.deleteInvite(userId, teamId, inviteCode)
-        return ResponseEntity.noContent().build()
     }
 
     @Operation(summary = "초대 코드로 팀 가입", security = [SecurityRequirement(name = "BearerAuth")])
@@ -71,5 +70,5 @@ class TeamInviteController(private val teamInviteService: TeamInviteService) {
     fun joinTeam(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable inviteCode: String,
-    ): ResponseEntity<JoinTeamResponse> = ResponseEntity.ok(teamInviteService.joinTeam(userId, inviteCode))
+    ): JoinTeamResponse = teamInviteService.joinTeam(userId, inviteCode)
 }

--- a/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamMemberController.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamMemberController.kt
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
 @Tag(name = "팀 멤버", description = "팀 멤버 초대/조회/역할 변경/추방 API")
@@ -26,26 +25,25 @@ class TeamMemberController(private val teamMemberService: TeamMemberService) {
         ApiResponse(responseCode = "404", description = "팀 없음"),
     )
     @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
     fun inviteMembers(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @RequestBody request: InviteMembersRequest,
-    ): ResponseEntity<List<TeamMemberResponse>> = ResponseEntity.status(HttpStatus.CREATED)
-        .body(teamMemberService.inviteMembers(userId, teamId, request))
+    ): List<TeamMemberResponse> = teamMemberService.inviteMembers(userId, teamId, request)
 
     @Operation(summary = "멤버 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping
-    fun getMembers(@PathVariable teamId: Long): ResponseEntity<List<TeamMemberResponse>> =
-        ResponseEntity.ok(teamMemberService.getMembers(teamId))
+    fun getMembers(@PathVariable teamId: Long): List<TeamMemberResponse> = teamMemberService.getMembers(teamId)
 
     @Operation(summary = "멤버 여부 확인", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
         ApiResponse(responseCode = "200", description = "멤버 여부 반환"),
     )
     @GetMapping("/{userId}/exists")
-    fun isMember(@PathVariable teamId: Long, @PathVariable userId: Long): ResponseEntity<Map<String, Boolean>> =
-        ResponseEntity.ok(mapOf("isMember" to teamMemberService.isMember(teamId, userId)))
+    fun isMember(@PathVariable teamId: Long, @PathVariable userId: Long): Map<String, Boolean> =
+        mapOf("isMember" to teamMemberService.isMember(teamId, userId))
 
     @Operation(summary = "멤버 역할 변경", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -59,9 +57,8 @@ class TeamMemberController(private val teamMemberService: TeamMemberService) {
         @PathVariable teamId: Long,
         @PathVariable targetUserId: Long,
         @RequestBody request: ChangeRoleRequest,
-    ): ResponseEntity<Void> {
+    ) {
         teamMemberService.changeRole(userId, teamId, targetUserId, request)
-        return ResponseEntity.ok().build()
     }
 
     @Operation(summary = "멤버 추방 / 탈퇴", security = [SecurityRequirement(name = "BearerAuth")])
@@ -71,12 +68,12 @@ class TeamMemberController(private val teamMemberService: TeamMemberService) {
         ApiResponse(responseCode = "404", description = "멤버 없음"),
     )
     @DeleteMapping("/{targetUserId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun removeMember(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @PathVariable targetUserId: Long,
-    ): ResponseEntity<Void> {
+    ) {
         teamMemberService.removeMember(userId, teamId, targetUserId)
-        return ResponseEntity.noContent().build()
     }
 }

--- a/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamRoleController.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/controller/TeamRoleController.kt
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.HttpStatus
-import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -21,6 +20,7 @@ import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 
 @Tag(name = "팀 역할", description = "팀 커스텀 역할/권한/색상/우선순위/멘션 설정 API")
@@ -31,16 +31,13 @@ class TeamRoleController(private val teamRoleService: TeamRoleService) {
     @Operation(summary = "역할 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/roles")
-    fun getRoles(@PathVariable teamId: Long): ResponseEntity<List<TeamRoleResponse>> =
-        ResponseEntity.ok(teamRoleService.getRoles(teamId))
+    fun getRoles(@PathVariable teamId: Long): List<TeamRoleResponse> = teamRoleService.getRoles(teamId)
 
     @Operation(summary = "멤버 역할 목록 조회", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponse(responseCode = "200", description = "조회 성공")
     @GetMapping("/members/{userId}/roles")
-    fun getMemberRoles(
-        @PathVariable teamId: Long,
-        @PathVariable userId: Long,
-    ): ResponseEntity<List<TeamRoleResponse>> = ResponseEntity.ok(teamRoleService.getMemberRoles(teamId, userId))
+    fun getMemberRoles(@PathVariable teamId: Long, @PathVariable userId: Long): List<TeamRoleResponse> =
+        teamRoleService.getMemberRoles(teamId, userId)
 
     @Operation(summary = "역할 생성", security = [SecurityRequirement(name = "BearerAuth")])
     @ApiResponses(
@@ -49,12 +46,12 @@ class TeamRoleController(private val teamRoleService: TeamRoleService) {
         ApiResponse(responseCode = "409", description = "역할 이름 중복"),
     )
     @PostMapping("/roles")
+    @ResponseStatus(HttpStatus.CREATED)
     fun createRole(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @RequestBody request: CreateTeamRoleRequest,
-    ): ResponseEntity<TeamRoleResponse> =
-        ResponseEntity.status(HttpStatus.CREATED).body(teamRoleService.createRole(userId, teamId, request))
+    ): TeamRoleResponse = teamRoleService.createRole(userId, teamId, request)
 
     @Operation(summary = "역할 수정", security = [SecurityRequirement(name = "BearerAuth")])
     @PatchMapping("/roles/{roleId}")
@@ -63,17 +60,17 @@ class TeamRoleController(private val teamRoleService: TeamRoleService) {
         @PathVariable teamId: Long,
         @PathVariable roleId: Long,
         @RequestBody request: UpdateTeamRoleRequest,
-    ): ResponseEntity<TeamRoleResponse> = ResponseEntity.ok(teamRoleService.updateRole(userId, teamId, roleId, request))
+    ): TeamRoleResponse = teamRoleService.updateRole(userId, teamId, roleId, request)
 
     @Operation(summary = "역할 삭제", security = [SecurityRequirement(name = "BearerAuth")])
     @DeleteMapping("/roles/{roleId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deleteRole(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @PathVariable roleId: Long,
-    ): ResponseEntity<Void> {
+    ) {
         teamRoleService.deleteRole(userId, teamId, roleId)
-        return ResponseEntity.noContent().build()
     }
 
     @Operation(summary = "멤버에게 역할 부여", security = [SecurityRequirement(name = "BearerAuth")])
@@ -83,18 +80,17 @@ class TeamRoleController(private val teamRoleService: TeamRoleService) {
         @PathVariable teamId: Long,
         @PathVariable targetUserId: Long,
         @PathVariable roleId: Long,
-    ): ResponseEntity<TeamRoleResponse> =
-        ResponseEntity.ok(teamRoleService.assignRole(userId, teamId, targetUserId, roleId))
+    ): TeamRoleResponse = teamRoleService.assignRole(userId, teamId, targetUserId, roleId)
 
     @Operation(summary = "멤버 역할 회수", security = [SecurityRequirement(name = "BearerAuth")])
     @DeleteMapping("/members/{targetUserId}/roles/{roleId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     fun revokeRole(
         @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
         @PathVariable teamId: Long,
         @PathVariable targetUserId: Long,
         @PathVariable roleId: Long,
-    ): ResponseEntity<Void> {
+    ) {
         teamRoleService.revokeRole(userId, teamId, targetUserId, roleId)
-        return ResponseEntity.noContent().build()
     }
 }

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/ChangeRoleRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/ChangeRoleRequest.kt
@@ -4,6 +4,6 @@ import com.cowork.team.domain.TeamRole
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class ChangeRoleRequest(
-    @Schema(description = "변경할 역할", example = "ADMIN", allowableValues = ["ADMIN", "MEMBER"], required = true)
+    @param:Schema(description = "변경할 역할", example = "ADMIN", allowableValues = ["ADMIN", "MEMBER"], required = true)
     val role: TeamRole,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/CreateTeamRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/CreateTeamRequest.kt
@@ -3,10 +3,10 @@ package com.cowork.team.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class CreateTeamRequest(
-    @Schema(description = "팀 이름", example = "코워크팀", required = true)
+    @param:Schema(description = "팀 이름", example = "코워크팀", required = true)
     val name: String,
-    @Schema(description = "팀 설명", example = "협업 서비스 개발팀")
+    @param:Schema(description = "팀 설명", example = "협업 서비스 개발팀")
     val description: String?,
-    @Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
+    @param:Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
     val iconUrl: String?,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/CreateTeamRoleRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/CreateTeamRoleRequest.kt
@@ -3,14 +3,14 @@ package com.cowork.team.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class CreateTeamRoleRequest(
-    @Schema(description = "역할 이름", example = "Frontend")
+    @param:Schema(description = "역할 이름", example = "Frontend")
     val name: String,
-    @Schema(description = "역할 색상 HEX", example = "#5865F2")
+    @param:Schema(description = "역할 색상 HEX", example = "#5865F2")
     val colorHex: String = "#99AAB5",
-    @Schema(description = "역할 우선순위. 숫자가 높을수록 상위 역할", example = "10")
+    @param:Schema(description = "역할 우선순위. 숫자가 높을수록 상위 역할", example = "10")
     val priority: Int = 0,
-    @Schema(description = "역할 멘션 허용 여부", example = "true")
+    @param:Schema(description = "역할 멘션 허용 여부", example = "true")
     val mentionable: Boolean = false,
-    @Schema(description = "권한 목록")
+    @param:Schema(description = "권한 목록")
     val permissions: Set<String> = emptySet(),
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/IconConfirmRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/IconConfirmRequest.kt
@@ -4,5 +4,5 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "팀 아이콘 업로드 확인 요청")
 data class IconConfirmRequest(
-    @Schema(description = "S3에 업로드된 객체 키 (IconPresignedUrlResponse.objectKey 값)") val objectKey: String,
+    @param:Schema(description = "S3에 업로드된 객체 키 (IconPresignedUrlResponse.objectKey 값)") val objectKey: String,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/IconConfirmResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/IconConfirmResponse.kt
@@ -3,4 +3,4 @@ package com.cowork.team.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "팀 아이콘 업로드 확인 응답")
-data class IconConfirmResponse(@Schema(description = "업로드 완료 후 사용할 CDN URL") val iconUrl: String)
+data class IconConfirmResponse(@field:Schema(description = "업로드 완료 후 사용할 CDN URL") val iconUrl: String)

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/IconPresignedUrlRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/IconPresignedUrlRequest.kt
@@ -4,5 +4,5 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "팀 아이콘 Presigned URL 발급 요청")
 data class IconPresignedUrlRequest(
-    @Schema(description = "업로드할 파일의 Content-Type (image/jpeg, image/png, image/webp)") val contentType: String,
+    @param:Schema(description = "업로드할 파일의 Content-Type (image/jpeg, image/png, image/webp)") val contentType: String,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/IconPresignedUrlResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/IconPresignedUrlResponse.kt
@@ -4,6 +4,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "팀 아이콘 Presigned URL 발급 응답")
 data class IconPresignedUrlResponse(
-    @Schema(description = "S3 Presigned PUT URL — 이 URL로 직접 파일을 PUT 요청") val uploadUrl: String,
-    @Schema(description = "업로드된 객체의 S3 키 — confirm 요청 시 사용") val objectKey: String,
+    @field:Schema(description = "S3 Presigned PUT URL — 이 URL로 직접 파일을 PUT 요청") val uploadUrl: String,
+    @field:Schema(description = "업로드된 객체의 S3 키 — confirm 요청 시 사용") val objectKey: String,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/InviteMembersRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/InviteMembersRequest.kt
@@ -3,6 +3,6 @@ package com.cowork.team.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class InviteMembersRequest(
-    @Schema(description = "초대할 사용자 ID 목록", example = "[2, 3, 4]", required = true)
+    @param:Schema(description = "초대할 사용자 ID 목록", example = "[2, 3, 4]", required = true)
     val userIds: List<Long>,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/InviteResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/InviteResponse.kt
@@ -5,19 +5,19 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class InviteResponse(
-    @Schema(description = "초대 코드", example = "aB3xK9mZ")
+    @field:Schema(description = "초대 코드", example = "aB3xK9mZ")
     val inviteCode: String,
-    @Schema(description = "팀 ID", example = "1")
+    @field:Schema(description = "팀 ID", example = "1")
     val teamId: Long,
-    @Schema(description = "생성자 사용자 ID", example = "42")
+    @field:Schema(description = "생성자 사용자 ID", example = "42")
     val createdBy: Long,
-    @Schema(description = "유효 기간", example = "7d", allowableValues = ["1d", "7d", "30d", "never"])
+    @field:Schema(description = "유효 기간", example = "7d", allowableValues = ["1d", "7d", "30d", "never"])
     val duration: String,
-    @Schema(description = "만료 일시 (never이면 null)")
+    @field:Schema(description = "만료 일시 (never이면 null)")
     val expiresAt: LocalDateTime?,
-    @Schema(description = "만료 또는 삭제 여부")
+    @field:Schema(description = "만료 또는 삭제 여부")
     val expired: Boolean,
-    @Schema(description = "생성 일시")
+    @field:Schema(description = "생성 일시")
     val createdAt: LocalDateTime,
 ) {
     companion object {

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/JoinTeamResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/JoinTeamResponse.kt
@@ -4,12 +4,12 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class JoinTeamResponse(
-    @Schema(description = "팀 ID", example = "1")
+    @field:Schema(description = "팀 ID", example = "1")
     val teamId: Long,
-    @Schema(description = "가입한 사용자 ID", example = "99")
+    @field:Schema(description = "가입한 사용자 ID", example = "99")
     val userId: Long,
-    @Schema(description = "부여된 역할", example = "MEMBER")
+    @field:Schema(description = "부여된 역할", example = "MEMBER")
     val role: String,
-    @Schema(description = "가입 일시")
+    @field:Schema(description = "가입 일시")
     val joinedAt: LocalDateTime,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamMemberResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamMemberResponse.kt
@@ -5,15 +5,15 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class TeamMemberResponse(
-    @Schema(description = "멤버 레코드 ID", example = "1")
+    @field:Schema(description = "멤버 레코드 ID", example = "1")
     val id: Long,
-    @Schema(description = "사용자 ID", example = "42")
+    @field:Schema(description = "사용자 ID", example = "42")
     val userId: Long,
-    @Schema(description = "역할", example = "MEMBER", allowableValues = ["OWNER", "ADMIN", "MEMBER"])
+    @field:Schema(description = "역할", example = "MEMBER", allowableValues = ["OWNER", "ADMIN", "MEMBER"])
     val role: String,
-    @Schema(description = "커스텀 역할 목록")
+    @field:Schema(description = "커스텀 역할 목록")
     val roles: List<TeamRoleResponse> = emptyList(),
-    @Schema(description = "가입 일시")
+    @field:Schema(description = "가입 일시")
     val joinedAt: LocalDateTime,
 ) {
     companion object {

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamResponse.kt
@@ -5,19 +5,19 @@ import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 data class TeamResponse(
-    @Schema(description = "팀 ID", example = "1")
+    @field:Schema(description = "팀 ID", example = "1")
     val id: Long,
-    @Schema(description = "팀 이름", example = "코워크팀")
+    @field:Schema(description = "팀 이름", example = "코워크팀")
     val name: String,
-    @Schema(description = "팀 설명", example = "협업 서비스 개발팀")
+    @field:Schema(description = "팀 설명", example = "협업 서비스 개발팀")
     val description: String?,
-    @Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
+    @field:Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
     val iconUrl: String?,
-    @Schema(description = "팀 소유자 ID", example = "1")
+    @field:Schema(description = "팀 소유자 ID", example = "1")
     val ownerId: Long,
-    @Schema(description = "생성 일시")
+    @field:Schema(description = "생성 일시")
     val createdAt: LocalDateTime,
-    @Schema(description = "수정 일시")
+    @field:Schema(description = "수정 일시")
     val updatedAt: LocalDateTime,
 ) {
     companion object {

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamRoleResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamRoleResponse.kt
@@ -3,22 +3,22 @@ package com.cowork.team.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class TeamRoleResponse(
-    @Schema(description = "역할 ID", example = "1")
+    @field:Schema(description = "역할 ID", example = "1")
     val id: Long,
-    @Schema(description = "팀 ID", example = "1")
+    @field:Schema(description = "팀 ID", example = "1")
     val teamId: Long,
-    @Schema(description = "역할 이름", example = "Frontend")
+    @field:Schema(description = "역할 이름", example = "Frontend")
     val name: String,
-    @Schema(description = "역할 색상 HEX", example = "#5865F2")
+    @field:Schema(description = "역할 색상 HEX", example = "#5865F2")
     val colorHex: String,
-    @Schema(description = "역할 우선순위. 숫자가 높을수록 상위 역할", example = "10")
+    @field:Schema(description = "역할 우선순위. 숫자가 높을수록 상위 역할", example = "10")
     val priority: Int,
-    @Schema(description = "역할 멘션 허용 여부", example = "true")
+    @field:Schema(description = "역할 멘션 허용 여부", example = "true")
     val mentionable: Boolean,
-    @Schema(description = "권한 목록")
+    @field:Schema(description = "권한 목록")
     val permissions: Set<String>,
-    @Schema(description = "생성 일시")
+    @field:Schema(description = "생성 일시")
     val createdAt: String?,
-    @Schema(description = "수정 일시")
+    @field:Schema(description = "수정 일시")
     val updatedAt: String?,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamSummaryResponse.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/TeamSummaryResponse.kt
@@ -5,13 +5,13 @@ import com.cowork.team.domain.TeamRole
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class TeamSummaryResponse(
-    @Schema(description = "팀 ID", example = "1")
+    @field:Schema(description = "팀 ID", example = "1")
     val id: Long,
-    @Schema(description = "팀 이름", example = "코워크팀")
+    @field:Schema(description = "팀 이름", example = "코워크팀")
     val name: String,
-    @Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
+    @field:Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
     val iconUrl: String?,
-    @Schema(description = "내 역할", example = "MEMBER", allowableValues = ["OWNER", "ADMIN", "MEMBER"])
+    @field:Schema(description = "내 역할", example = "MEMBER", allowableValues = ["OWNER", "ADMIN", "MEMBER"])
     val myRole: String,
 ) {
     companion object {

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/UpdateIconRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/UpdateIconRequest.kt
@@ -3,4 +3,4 @@ package com.cowork.team.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "팀 아이콘 교체 요청")
-data class UpdateIconRequest(@Schema(description = "confirm 응답에서 받은 iconUrl") val iconUrl: String)
+data class UpdateIconRequest(@param:Schema(description = "confirm 응답에서 받은 iconUrl") val iconUrl: String)

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/UpdateTeamRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/UpdateTeamRequest.kt
@@ -3,10 +3,10 @@ package com.cowork.team.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class UpdateTeamRequest(
-    @Schema(description = "팀 이름", example = "코워크팀")
+    @param:Schema(description = "팀 이름", example = "코워크팀")
     val name: String?,
-    @Schema(description = "팀 설명", example = "협업 서비스 개발팀")
+    @param:Schema(description = "팀 설명", example = "협업 서비스 개발팀")
     val description: String?,
-    @Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
+    @param:Schema(description = "팀 아이콘 URL", example = "https://example.com/icon.png")
     val iconUrl: String?,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/dto/UpdateTeamRoleRequest.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/dto/UpdateTeamRoleRequest.kt
@@ -3,14 +3,14 @@ package com.cowork.team.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class UpdateTeamRoleRequest(
-    @Schema(description = "역할 이름", example = "Backend")
+    @param:Schema(description = "역할 이름", example = "Backend")
     val name: String? = null,
-    @Schema(description = "역할 색상 HEX", example = "#57F287")
+    @param:Schema(description = "역할 색상 HEX", example = "#57F287")
     val colorHex: String? = null,
-    @Schema(description = "역할 우선순위. 숫자가 높을수록 상위 역할", example = "20")
+    @param:Schema(description = "역할 우선순위. 숫자가 높을수록 상위 역할", example = "20")
     val priority: Int? = null,
-    @Schema(description = "역할 멘션 허용 여부", example = "false")
+    @param:Schema(description = "역할 멘션 허용 여부", example = "false")
     val mentionable: Boolean? = null,
-    @Schema(description = "권한 목록")
+    @param:Schema(description = "권한 목록")
     val permissions: Set<String>? = null,
 )

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamInviteService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamInviteService.kt
@@ -34,7 +34,7 @@ class TeamInviteService(
     }
 
     private fun findTeamOrThrow(teamId: Long) = teamRepository.findById(teamId).orElseThrow {
-        ExpectedException("팀을 찾을 수 없습니다. id=$teamId", HttpStatus.NOT_FOUND)
+        ExpectedException("팀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
     }
 
     private fun requireMember(teamId: Long, userId: Long) = teamMemberRepository.findByTeamIdAndUserId(teamId, userId)

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamMemberService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamMemberService.kt
@@ -26,7 +26,7 @@ class TeamMemberService(
 ) {
 
     private fun findTeamOrThrow(teamId: Long) = teamRepository.findById(teamId).orElseThrow {
-        ExpectedException("팀을 찾을 수 없습니다. id=$teamId", HttpStatus.NOT_FOUND)
+        ExpectedException("팀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
     }
 
     private fun requireRole(teamId: Long, userId: Long, vararg roles: TeamRole): TeamMember =

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamRoleService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamRoleService.kt
@@ -29,7 +29,7 @@ class TeamRoleService(
 
     private fun requireTeam(teamId: Long) {
         if (!teamRepository.existsById(teamId)) {
-            throw ExpectedException("팀을 찾을 수 없습니다. id=$teamId", HttpStatus.NOT_FOUND)
+            throw ExpectedException("팀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         }
     }
 
@@ -91,7 +91,7 @@ class TeamRoleService(
         val actor = requireManageRoles(teamId, actorId)
         val allRoles = getRoles(teamId)
         val currentRole = allRoles.firstOrNull { it.id == roleId }
-            ?: throw ExpectedException("역할을 찾을 수 없습니다. id=$roleId", HttpStatus.NOT_FOUND)
+            ?: throw ExpectedException("역할을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         requireManageablePriority(actor, currentRole)
         request.priority?.let {
             requireManageablePriority(actor, currentRole.copy(priority = it))
@@ -102,7 +102,7 @@ class TeamRoleService(
     fun deleteRole(actorId: Long, teamId: Long, roleId: Long) {
         val actor = requireManageRoles(teamId, actorId)
         val role = getRoles(teamId).firstOrNull { it.id == roleId }
-            ?: throw ExpectedException("역할을 찾을 수 없습니다. id=$roleId", HttpStatus.NOT_FOUND)
+            ?: throw ExpectedException("역할을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         requireManageablePriority(actor, role)
         preferenceTeamRoleClient.deleteRole(teamId, roleId)
     }
@@ -111,7 +111,7 @@ class TeamRoleService(
         val actor = requireManageRoles(teamId, actorId)
         requireMember(teamId, targetUserId)
         val role = getRoles(teamId).firstOrNull { it.id == roleId }
-            ?: throw ExpectedException("역할을 찾을 수 없습니다. id=$roleId", HttpStatus.NOT_FOUND)
+            ?: throw ExpectedException("역할을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         requireManageablePriority(actor, role)
         return preferenceTeamRoleClient.assignRole(teamId, roleId, mapOf("accountId" to targetUserId))
     }
@@ -120,7 +120,7 @@ class TeamRoleService(
         val actor = requireManageRoles(teamId, actorId)
         requireMember(teamId, targetUserId)
         val role = getRoles(teamId).firstOrNull { it.id == roleId }
-            ?: throw ExpectedException("역할을 찾을 수 없습니다. id=$roleId", HttpStatus.NOT_FOUND)
+            ?: throw ExpectedException("역할을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
         requireManageablePriority(actor, role)
         preferenceTeamRoleClient.revokeRole(teamId, targetUserId, roleId)
     }

--- a/cowork-team/src/main/kotlin/com/cowork/team/service/TeamService.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/service/TeamService.kt
@@ -31,7 +31,7 @@ class TeamService(
 ) {
 
     private fun findTeamOrThrow(teamId: Long): Team = teamRepository.findById(teamId).orElseThrow {
-        ExpectedException("팀을 찾을 수 없습니다. id=$teamId", HttpStatus.NOT_FOUND)
+        ExpectedException("팀을 찾을 수 없습니다.", HttpStatus.NOT_FOUND)
     }
 
     private fun requireRole(teamId: Long, userId: Long, vararg roles: TeamRole): TeamMember =


### PR DESCRIPTION
## 개요

`gemini-code-assist` 봇이 PR #171(ktlint 도입)에서 지적한 스타일 가이드 위반들을 일괄 정리하였습니다. 당시에는 순수 포맷 PR이라 scope를 벗어나 처리하지 않았으나, 코드베이스 전체를 점검한 결과 봇이 지적한 30곳보다 넓은 범위에 위반이 존재하여 `.gemini/styleguide.md` 기준으로 전수 수정하였습니다. 동작 변경을 동반하는 항목은 커밋을 분리하였습니다.

## 본문

### 1. DTO `@Schema` 어노테이션 타겟 명시 (23개 파일)

styleguide(Swagger Documentation)에 따라 Request DTO는 `@param:Schema`, Response DTO는 `@field:Schema`를 사용하도록 명시하였습니다. 클래스 레벨 `@Schema`(클래스 설명)는 use-site target 대상이 아니므로 프로퍼티 어노테이션에만 적용하였습니다.

### 2. 로그 메시지 영문 표기로 통일 (5개 파일, 10건)

styleguide(Logging)에 따라 한국어 로그 메시지를 영문·동사 시작 패턴으로 변경하였습니다. (예: `"처리되지 않은 예외 발생"` → `"Caught unhandled exception"`) 사용자에게 노출되는 응답 메시지는 로그가 아니므로 변경하지 않았습니다.

### 3. `ExpectedException` 메시지에서 동적 데이터 제거 (11개 파일, 25건)

styleguide(Error Handling)에 따라 비즈니스 예외 메시지에서 `id=$x` 등 동적 데이터를 제거하고 마침표로 끝나도록 통일하였습니다. 해당 메시지는 토스트/알림으로 사용자에게 직접 노출되기 때문입니다.

### 4. 컨트롤러 `ResponseEntity` 제거하고 DTO 직접 반환 (12개 파일, 약 50건)

styleguide(Architecture Patterns)에 따라 컨트롤러가 DTO를 직접 반환하도록 변경하였습니다. SDK Wrapper(`ResponseBodyAdvice`)가 자동으로 `CommonApiResponse`로 감쌉니다. 상태 코드는 `@ResponseStatus`로 보존하였습니다. (201 → `@ResponseStatus(HttpStatus.CREATED)`, 204 → `@ResponseStatus(HttpStatus.NO_CONTENT)`)

다음은 SDK Wrapper 대상이 아니거나 헤더·상태 제어가 본질적이어서 `ResponseEntity`를 유지하였습니다.

- `OAuthAccountController`: 302 리다이렉트(`Location` 헤더)와 400 분기 응답
- `cowork-gateway`의 `FallbackController`, `HealthCheckController`: WebFlux `Mono<ResponseEntity>` (503 등 동적 상태)

### 검증

- `./gradlew compileKotlin` (`cowork-channel`, `cowork-team`) `BUILD SUCCESSFUL`
- `./gradlew ktlintCheck` `BUILD SUCCESSFUL`
- `./gradlew test` (`cowork-channel`, `cowork-team`) 전체 통과
