### PR TITLE
[chat] ESLint 설정 추가 및 발견된 문제 일괄 해결

### DIFF
--- a/cowork-chat/eslint.config.mjs
+++ b/cowork-chat/eslint.config.mjs
@@ -1,0 +1,32 @@
+// @ts-check
+import eslint from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+    {
+        ignores: ['eslint.config.mjs', 'dist/**'],
+    },
+    eslint.configs.recommended,
+    ...tseslint.configs.recommendedTypeChecked,
+    {
+        languageOptions: {
+            globals: {
+                ...globals.node,
+                ...globals.jest,
+            },
+            sourceType: 'commonjs',
+            parserOptions: {
+                projectService: true,
+                tsconfigRootDir: import.meta.dirname,
+            },
+        },
+    },
+    {
+        rules: {
+            '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/no-floating-promises': 'warn',
+            '@typescript-eslint/no-unsafe-argument': 'warn',
+        },
+    },
+);

--- a/cowork-chat/eslint.config.mjs
+++ b/cowork-chat/eslint.config.mjs
@@ -24,9 +24,13 @@ export default tseslint.config(
     },
     {
         rules: {
-            '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/no-explicit-any': 'error',
             '@typescript-eslint/no-floating-promises': 'warn',
             '@typescript-eslint/no-unsafe-argument': 'warn',
+            '@typescript-eslint/no-unused-vars': 'warn',
+            'no-console': 'warn',
+            semi: 'error',
+            eqeqeq: ['error', 'smart'],
         },
     },
 );

--- a/cowork-chat/package-lock.json
+++ b/cowork-chat/package-lock.json
@@ -38,17 +38,21 @@
         "uuid": "^14.0.0"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@nestjs/testing": "^11.1.27",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
         "@types/mime-types": "^3.0.1",
         "@types/node": "^24.13.2",
         "@types/uuid": "^11.0.0",
+        "eslint": "^10.5.0",
+        "globals": "^17.6.0",
         "jest": "^30.4.2",
         "socket.io-client": "^4.8.3",
         "ts-jest": "^29.4.11",
         "ts-node": "^10.9.2",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "typescript-eslint": "^8.61.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -653,6 +657,239 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
       }
     },
     "node_modules/@ioredis/commands": {
@@ -1658,17 +1895,6 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "license": "MIT"
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
-      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -1787,22 +2013,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/command-line-args": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
-      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@types/command-line-usage": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
-      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -1821,6 +2031,20 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "5.0.6",
@@ -1891,6 +2115,13 @@
         "expect": "^30.0.0",
         "pretty-format": "^30.0.0"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
@@ -2023,6 +2254,288 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/type-utils": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.61.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -2380,6 +2893,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.5",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
@@ -2391,6 +2914,23 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2465,28 +3005,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/apache-arrow": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
-      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@swc/helpers": "^0.5.11",
-        "@types/command-line-args": "^5.2.3",
-        "@types/command-line-usage": "^5.0.4",
-        "@types/node": "^24.0.3",
-        "command-line-args": "^6.0.1",
-        "command-line-usage": "^7.0.1",
-        "flatbuffers": "^25.1.24",
-        "json-bignum": "^0.0.3",
-        "tslib": "^2.6.2"
-      },
-      "bin": {
-        "arrow2csv": "bin/arrow2csv.js"
-      }
-    },
     "node_modules/append-field": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
@@ -2505,17 +3023,6 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
-    },
-    "node_modules/array-back": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
-      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12.17"
-      }
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -2909,23 +3416,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chalk-template": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
-      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk-template?sponsor=1"
-      }
-    },
     "node_modules/char-regex": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
@@ -3101,48 +3591,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/command-line-args": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
-      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "array-back": "^6.2.3",
-        "find-replace": "^5.0.2",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^7.3.0"
-      },
-      "engines": {
-        "node": ">=12.20"
-      },
-      "peerDependencies": {
-        "@75lb/nature": "latest"
-      },
-      "peerDependenciesMeta": {
-        "@75lb/nature": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/command-line-usage": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
-      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "array-back": "^6.2.2",
-        "chalk-template": "^0.4.0",
-        "table-layout": "^4.1.1",
-        "typical": "^7.3.0"
-      },
-      "engines": {
-        "node": ">=12.20.0"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3291,6 +3739,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
@@ -3604,6 +4059,216 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.5.0.tgz",
+      "integrity": "sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -3616,6 +4281,52 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
@@ -3735,10 +4446,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3794,6 +4519,37 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/file-type": {
       "version": "21.3.4",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
@@ -3842,25 +4598,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/find-replace": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
-      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "@75lb/nature": "latest"
-      },
-      "peerDependenciesMeta": {
-        "@75lb/nature": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -3875,13 +4612,26 @@
         "node": ">=8"
       }
     },
-    "node_modules/flatbuffers": {
-      "version": "25.9.23",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
-      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/foreground-child": {
       "version": "3.3.1",
@@ -4050,6 +4800,32 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4207,6 +4983,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
@@ -4293,6 +5079,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4311,6 +5107,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -5084,20 +5893,31 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-bignum": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
-      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.8"
-      }
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5187,6 +6007,16 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5195,6 +6025,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/libphonenumber-js": {
@@ -5247,14 +6091,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
-    },
-    "node_modules/lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
@@ -5862,6 +6698,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6122,6 +6976,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/pretty-format": {
@@ -7126,21 +7990,6 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/table-layout": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
-      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "array-back": "^6.2.2",
-        "wordwrapjs": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=12.17"
-      }
-    },
     "node_modules/tdigest": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
@@ -7238,6 +8087,23 @@
         "readable-stream": "3"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -7282,6 +8148,19 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-jest": {
@@ -7413,6 +8292,19 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -7470,15 +8362,28 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/typical": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
-      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+    "node_modules/typescript-eslint": {
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
+      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
+      },
       "engines": {
-        "node": ">=12.17"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/uglify-js": {
@@ -7612,6 +8517,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -7730,23 +8645,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/wordwrapjs": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
-      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12.17"
-      }
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/cowork-chat/package.json
+++ b/cowork-chat/package.json
@@ -9,7 +9,9 @@
     "build": "tsc",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:cov": "jest --coverage"
+    "test:cov": "jest --coverage",
+    "lint": "eslint \"src/**/*.ts\"",
+    "lint:fix": "eslint \"src/**/*.ts\" --fix"
   },
   "keywords": [],
   "author": "",
@@ -45,16 +47,20 @@
     "uuid": "^14.0.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@nestjs/testing": "^11.1.27",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",
     "@types/mime-types": "^3.0.1",
     "@types/node": "^24.13.2",
     "@types/uuid": "^11.0.0",
+    "eslint": "^10.5.0",
+    "globals": "^17.6.0",
     "jest": "^30.4.2",
     "socket.io-client": "^4.8.3",
     "ts-jest": "^29.4.11",
     "ts-node": "^10.9.2",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.61.1"
   }
 }

--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -246,8 +246,7 @@ describe('ChatController', () => {
 
             expect(mockChatService.handleSlashCommand).toHaveBeenCalledWith(
                 { channelId: 1, userId: 42 },
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.objectContaining()의 반환 타입이 any로 선언되어 있음
-                expect.objectContaining({ payload: expect.objectContaining({ body: undefined }) }),
+                expect.objectContaining({ payload: expect.objectContaining({ body: undefined }) as unknown }),
             );
         });
 

--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -114,7 +114,7 @@ describe('ChatController', () => {
                 nextCursor: null,
             });
 
-            const result = await controller.getFiles(1, { limit: 20, before: undefined } as any, userId);
+            const result = await controller.getFiles(1, { limit: 20, before: undefined }, userId);
 
             expect(mockChatService.getFileList).toHaveBeenCalledWith(
                 { channelId: 1, userId: 42 },
@@ -131,7 +131,7 @@ describe('ChatController', () => {
         it('멤버십 검증 후 Kafka로 메시지를 발행한다', async () => {
             mockChatService.sendMessage.mockResolvedValue(undefined);
 
-            const result = await controller.sendMessage(1, dto as any, userId, userRole);
+            const result = await controller.sendMessage(1, dto, userId, userRole);
 
             expect(mockChatService.sendMessage).toHaveBeenCalledWith(
                 { channelId: 1, userId: 42, userRole: 'ROLE_USER' },
@@ -144,7 +144,7 @@ describe('ChatController', () => {
             mockChatService.sendMessage.mockRejectedValue(new ForbiddenException());
 
             await expect(
-                controller.sendMessage(1, dto as any, userId, userRole),
+                controller.sendMessage(1, dto, userId, userRole),
             ).rejects.toThrow(ForbiddenException);
         });
     });
@@ -159,7 +159,7 @@ describe('ChatController', () => {
         it('프로젝트 레포 정보를 조회한 뒤 github.issue.create 토픽으로 이벤트를 발행한다', async () => {
             mockChatService.publishGithubIssueCreateCommand.mockResolvedValue(undefined);
 
-            const result = await controller.createGithubIssue(1, dto as any, userId);
+            const result = await controller.createGithubIssue(1, dto, userId);
 
             expect(mockChatService.publishGithubIssueCreateCommand).toHaveBeenCalledWith(
                 { channelId: 1, userId: 42 },
@@ -171,7 +171,7 @@ describe('ChatController', () => {
         it('body 없이도 이슈 생성 이벤트를 발행한다', async () => {
             mockChatService.publishGithubIssueCreateCommand.mockResolvedValue(undefined);
 
-            await controller.createGithubIssue(1, { ...dto, body: undefined } as any, userId);
+            await controller.createGithubIssue(1, { ...dto, body: undefined }, userId);
 
             expect(mockChatService.publishGithubIssueCreateCommand).toHaveBeenCalledWith(
                 { channelId: 1, userId: 42 },
@@ -183,7 +183,7 @@ describe('ChatController', () => {
             mockChatService.publishGithubIssueCreateCommand.mockRejectedValue(new ForbiddenException());
 
             await expect(
-                controller.createGithubIssue(1, dto as any, userId),
+                controller.createGithubIssue(1, dto, userId),
             ).rejects.toThrow(ForbiddenException);
         });
 
@@ -191,7 +191,7 @@ describe('ChatController', () => {
             mockChatService.publishGithubIssueCreateCommand.mockRejectedValue(new BadRequestException('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다'));
 
             await expect(
-                controller.createGithubIssue(1, dto as any, userId),
+                controller.createGithubIssue(1, dto, userId),
             ).rejects.toThrow('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
         });
 
@@ -199,7 +199,7 @@ describe('ChatController', () => {
             mockChatService.publishGithubIssueCreateCommand.mockRejectedValue(new ForbiddenException('해당 프로젝트는 이 채널의 팀에 속하지 않습니다'));
 
             await expect(
-                controller.createGithubIssue(1, dto as any, userId),
+                controller.createGithubIssue(1, dto, userId),
             ).rejects.toThrow('해당 프로젝트는 이 채널의 팀에 속하지 않습니다');
         });
 
@@ -207,7 +207,7 @@ describe('ChatController', () => {
             mockChatService.publishGithubIssueCreateCommand.mockRejectedValue(new Error('Kafka 연결 오류'));
 
             await expect(
-                controller.createGithubIssue(1, dto as any, userId),
+                controller.createGithubIssue(1, dto, userId),
             ).rejects.toThrow('Kafka 연결 오류');
         });
     });
@@ -224,7 +224,7 @@ describe('ChatController', () => {
 
             const result = await controller.createSlashCommand(
                 1,
-                { command: SlashCommand.GITHUB_ISSUE_CREATE, payload } as any,
+                { command: SlashCommand.GITHUB_ISSUE_CREATE, payload },
                 userId,
             );
 
@@ -240,12 +240,13 @@ describe('ChatController', () => {
 
             await controller.createSlashCommand(
                 1,
-                { command: SlashCommand.GITHUB_ISSUE_CREATE, payload: { ...payload, body: undefined } } as any,
+                { command: SlashCommand.GITHUB_ISSUE_CREATE, payload: { ...payload, body: undefined } },
                 userId,
             );
 
             expect(mockChatService.handleSlashCommand).toHaveBeenCalledWith(
                 { channelId: 1, userId: 42 },
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.objectContaining()의 반환 타입이 any로 선언되어 있음
                 expect.objectContaining({ payload: expect.objectContaining({ body: undefined }) }),
             );
         });
@@ -256,7 +257,7 @@ describe('ChatController', () => {
             await expect(
                 controller.createSlashCommand(
                     1,
-                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload } as any,
+                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload },
                     userId,
                 ),
             ).rejects.toThrow(ForbiddenException);
@@ -268,7 +269,7 @@ describe('ChatController', () => {
             await expect(
                 controller.createSlashCommand(
                     1,
-                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload } as any,
+                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload },
                     userId,
                 ),
             ).rejects.toThrow('프로젝트 GitHub 레포지토리 정보를 찾을 수 없습니다');
@@ -280,7 +281,7 @@ describe('ChatController', () => {
             await expect(
                 controller.createSlashCommand(
                     1,
-                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload } as any,
+                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload },
                     userId,
                 ),
             ).rejects.toThrow('해당 프로젝트는 이 채널의 팀에 속하지 않습니다');
@@ -292,7 +293,7 @@ describe('ChatController', () => {
             await expect(
                 controller.createSlashCommand(
                     1,
-                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload } as any,
+                    { command: SlashCommand.GITHUB_ISSUE_CREATE, payload },
                     userId,
                 ),
             ).rejects.toThrow('Kafka 연결 오류');

--- a/cowork-chat/src/chat/chat.controller.spec.ts
+++ b/cowork-chat/src/chat/chat.controller.spec.ts
@@ -8,7 +8,7 @@ import { ChatMessageProducer } from './kafka/chat-message.producer';
 import { GithubIssueProducer } from './kafka/github-issue.producer';
 import { ProjectClient } from './service/project.client';
 import { MinioService } from '../storage/minio.service';
-import { SlashCommand } from './dto/slash-command.dto';
+import { SlashCommand, SlashCommandDto } from './dto/slash-command.dto';
 import { ReadChannelDto } from './dto/read-channel.dto';
 
 const mockMessageId = new Types.ObjectId().toString();
@@ -305,7 +305,7 @@ describe('ChatController', () => {
             await expect(
                 controller.createSlashCommand(
                     1,
-                    { command: 'unknown.command', payload } as any,
+                    { command: 'unknown.command', payload } as unknown as SlashCommandDto,
                     userId,
                 ),
             ).rejects.toThrow(BadRequestException);

--- a/cowork-chat/src/chat/chat.gateway.spec.ts
+++ b/cowork-chat/src/chat/chat.gateway.spec.ts
@@ -1,7 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import { ChatGateway } from './chat.gateway';
+import { ChatGateway, ChatSocket } from './chat.gateway';
 import { ChatService } from './chat.service';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
@@ -79,7 +79,7 @@ describe('ChatGateway', () => {
     describe('handleConnection', () => {
         it('유효한 JWT 토큰으로 연결 시 client.data에 userId가 저장되고 전용 룸에 join한다', async () => {
             const client = mockSocket('valid-token');
-            await gateway.handleConnection(client as any);
+            await gateway.handleConnection(client as unknown as ChatSocket);
             expect(client.data.userId).toBe(42);
             expect(client.data.userRole).toBe('ROLE_USER');
             expect(client.join).toHaveBeenCalledWith('user:42');
@@ -88,7 +88,7 @@ describe('ChatGateway', () => {
 
         it('토큰 없이 연결하면 exception 이벤트를 emit하고 disconnect된다', async () => {
             const client = mockSocket(undefined);
-            await gateway.handleConnection(client as any);
+            await gateway.handleConnection(client as unknown as ChatSocket);
             expect(client.emit).toHaveBeenCalledWith('exception', { message: '인증 실패: 토큰이 전달되지 않았습니다' });
             expect(client.disconnect).toHaveBeenCalled();
         });
@@ -96,7 +96,7 @@ describe('ChatGateway', () => {
         it('유효하지 않은 토큰으로 연결하면 exception 이벤트를 emit하고 disconnect된다', async () => {
             mockJwtService.verifyAsync.mockRejectedValue(new Error('Invalid token'));
             const client = mockSocket('invalid-token');
-            await gateway.handleConnection(client as any);
+            await gateway.handleConnection(client as unknown as ChatSocket);
             expect(client.emit).toHaveBeenCalledWith('exception', { message: '인증 실패: Invalid token' });
             expect(client.disconnect).toHaveBeenCalled();
         });
@@ -108,7 +108,7 @@ describe('ChatGateway', () => {
             const client = mockSocket('valid-token');
             client.data.userId = 42;
 
-            await gateway.handleJoin(client as any, { channelId: 1 });
+            await gateway.handleJoin(client as unknown as ChatSocket, { channelId: 1 });
 
             expect(client.join).toHaveBeenCalledWith('chat:1');
             expect(client.emit).not.toHaveBeenCalledWith('error', expect.anything());
@@ -119,7 +119,7 @@ describe('ChatGateway', () => {
             const client = mockSocket('valid-token');
             client.data.userId = 42;
 
-            await gateway.handleJoin(client as any, { channelId: 1 });
+            await gateway.handleJoin(client as unknown as ChatSocket, { channelId: 1 });
 
             expect(client.join).not.toHaveBeenCalled();
             expect(client.emit).toHaveBeenCalledWith('error', { message: '채널 접근 권한이 없습니다' });
@@ -129,7 +129,7 @@ describe('ChatGateway', () => {
     describe('handleLeave', () => {
         it('채널 room에서 퇴장한다', () => {
             const client = mockSocket('valid-token');
-            gateway.handleLeave(client as any, { channelId: 1 });
+            gateway.handleLeave(client as unknown as ChatSocket, { channelId: 1 });
             expect(client.leave).toHaveBeenCalledWith('chat:1');
         });
     });

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -97,7 +97,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 
             client.data.userId = userId;
             client.data.userRole = payload.role ?? UserRole.USER;
-            void client.join(`user:${userId}`);
+            this.joinRoom(client, `user:${userId}`);
             this.logger.log(`연결됨: ${client.id} (userId=${userId})`);
         } catch (err) {
             const message = err instanceof Error ? err.message : '인증 실패';
@@ -131,7 +131,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
             client.emit('error', { message: '채널 접근 권한이 없습니다' });
             return;
         }
-        void client.join(`chat:${payload.channelId}`);
+        this.joinRoom(client, `chat:${payload.channelId}`);
         this.logger.log(`userId=${userId} joined chat:${payload.channelId}`);
     }
 
@@ -143,7 +143,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      */
     @SubscribeMessage('leave')
     handleLeave(@ConnectedSocket() client: ChatSocket, @MessageBody() payload: JoinChannelDto) {
-        void client.leave(`chat:${payload.channelId}`);
+        this.leaveRoom(client, `chat:${payload.channelId}`);
     }
 
     /**
@@ -187,7 +187,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
             client.emit('error', { message: '팀 접근 권한이 없습니다' });
             return;
         }
-        void client.join(`team:${payload.teamId}`);
+        this.joinRoom(client, `team:${payload.teamId}`);
     }
 
     /**
@@ -199,6 +199,14 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
             client.emit('error', { message: '올바르지 않은 요청 형식입니다' });
             return;
         }
-        void client.leave(`team:${payload.teamId}`);
+        this.leaveRoom(client, `team:${payload.teamId}`);
+    }
+
+    private joinRoom(client: ChatSocket, room: string): void {
+        Promise.resolve(client.join(room)).catch((err: unknown) => this.logger.error(`방 참여 실패 (room=${room}): ${String(err)}`));
+    }
+
+    private leaveRoom(client: ChatSocket, room: string): void {
+        Promise.resolve(client.leave(room)).catch((err: unknown) => this.logger.error(`방 퇴장 실패 (room=${room}): ${String(err)}`));
     }
 }

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -11,7 +11,7 @@ import {
 } from '@nestjs/websockets';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
-import { Server, Socket } from 'socket.io';
+import { Server, Socket, DefaultEventsMap } from 'socket.io';
 import { ChatService } from './chat.service';
 import { ChatMessageConsumer } from './kafka/chat-message.consumer';
 import { GithubIssueResultConsumer } from './kafka/github-issue-result.consumer';
@@ -20,6 +20,13 @@ import { ProjectEventConsumer } from './kafka/project-event.consumer';
 import { MembershipConsumer } from '../membership/membership.consumer';
 import { JoinChannelDto } from './dto/join-channel.dto';
 import { UserRole } from '../common/enum/user-role.enum';
+
+export interface ChatSocketData {
+    userId: number;
+    userRole: string;
+}
+
+export type ChatSocket = Socket<DefaultEventsMap, DefaultEventsMap, DefaultEventsMap, ChatSocketData>;
 
 /**
  * `/chat` 네임스페이스의 WebSocket 게이트웨이.
@@ -75,7 +82,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      *
      * @param client - 연결된 Socket.IO 소켓
      */
-    async handleConnection(client: Socket) {
+    async handleConnection(client: ChatSocket) {
         try {
             const token = client.handshake.auth?.token as string | undefined;
             if (!token) {
@@ -90,7 +97,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
 
             client.data.userId = userId;
             client.data.userRole = payload.role ?? UserRole.USER;
-            client.join(`user:${userId}`);
+            void client.join(`user:${userId}`);
             this.logger.log(`연결됨: ${client.id} (userId=${userId})`);
         } catch (err) {
             const message = err instanceof Error ? err.message : '인증 실패';
@@ -105,7 +112,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      *
      * @param client - 연결 해제된 Socket.IO 소켓
      */
-    handleDisconnect(client: Socket) {
+    handleDisconnect(client: ChatSocket) {
         this.logger.log(`연결 해제: ${client.id}`);
     }
 
@@ -117,14 +124,14 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      * @param payload - 참여할 채널 ID
      */
     @SubscribeMessage('join')
-    async handleJoin(@ConnectedSocket() client: Socket, @MessageBody() payload: JoinChannelDto) {
+    async handleJoin(@ConnectedSocket() client: ChatSocket, @MessageBody() payload: JoinChannelDto) {
         const { userId } = client.data;
         const isMember = await this.chatService.isMember(payload.channelId, userId);
         if (!isMember) {
             client.emit('error', { message: '채널 접근 권한이 없습니다' });
             return;
         }
-        client.join(`chat:${payload.channelId}`);
+        void client.join(`chat:${payload.channelId}`);
         this.logger.log(`userId=${userId} joined chat:${payload.channelId}`);
     }
 
@@ -135,8 +142,8 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      * @param payload - 나갈 채널 ID
      */
     @SubscribeMessage('leave')
-    handleLeave(@ConnectedSocket() client: Socket, @MessageBody() payload: JoinChannelDto) {
-        client.leave(`chat:${payload.channelId}`);
+    handleLeave(@ConnectedSocket() client: ChatSocket, @MessageBody() payload: JoinChannelDto) {
+        void client.leave(`chat:${payload.channelId}`);
     }
 
     /**
@@ -144,16 +151,16 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      * 같은 채널 룸의 다른 참여자에게 `typing` 이벤트를 릴레이한다.
      */
     @SubscribeMessage('typing:start')
-    handleTypingStart(@ConnectedSocket() client: Socket, @MessageBody() payload: JoinChannelDto) {
+    handleTypingStart(@ConnectedSocket() client: ChatSocket, @MessageBody() payload: JoinChannelDto) {
         this.relayTyping(client, payload, true);
     }
 
     @SubscribeMessage('typing:stop')
-    handleTypingStop(@ConnectedSocket() client: Socket, @MessageBody() payload: JoinChannelDto) {
+    handleTypingStop(@ConnectedSocket() client: ChatSocket, @MessageBody() payload: JoinChannelDto) {
         this.relayTyping(client, payload, false);
     }
 
-    private relayTyping(client: Socket, payload: JoinChannelDto, isTyping: boolean) {
+    private relayTyping(client: ChatSocket, payload: JoinChannelDto, isTyping: boolean) {
         if (!payload || typeof payload.channelId !== 'number') return;
         const room = `chat:${payload.channelId}`;
         if (!client.rooms.has(room)) return;
@@ -169,7 +176,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      * 채널/프로젝트 생성·수정·삭제 이벤트 수신에 사용한다.
      */
     @SubscribeMessage('join:team')
-    async handleJoinTeam(@ConnectedSocket() client: Socket, @MessageBody() payload: { teamId: number }) {
+    async handleJoinTeam(@ConnectedSocket() client: ChatSocket, @MessageBody() payload: { teamId: number }) {
         if (!payload || typeof payload.teamId !== 'number') {
             client.emit('error', { message: '올바르지 않은 요청 형식입니다' });
             return;
@@ -180,18 +187,18 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
             client.emit('error', { message: '팀 접근 권한이 없습니다' });
             return;
         }
-        client.join(`team:${payload.teamId}`);
+        void client.join(`team:${payload.teamId}`);
     }
 
     /**
      * `leave:team` 이벤트 핸들러. `team:{teamId}` 룸에서 나간다.
      */
     @SubscribeMessage('leave:team')
-    handleLeaveTeam(@ConnectedSocket() client: Socket, @MessageBody() payload: { teamId: number }) {
+    handleLeaveTeam(@ConnectedSocket() client: ChatSocket, @MessageBody() payload: { teamId: number }) {
         if (!payload || typeof payload.teamId !== 'number') {
             client.emit('error', { message: '올바르지 않은 요청 형식입니다' });
             return;
         }
-        client.leave(`team:${payload.teamId}`);
+        void client.leave(`team:${payload.teamId}`);
     }
 }

--- a/cowork-chat/src/chat/chat.service.spec.ts
+++ b/cowork-chat/src/chat/chat.service.spec.ts
@@ -159,7 +159,7 @@ describe('ChatService', () => {
         it('일반 채널 메시지는 DTO 그대로 producer에 위임한다', async () => {
             mockChannelMemberRepository.findMembership.mockResolvedValue({ teamId: 100, channelType: 'TEXT' });
 
-            await service.sendMessage(ctx, { teamId: 100, content: 'hi' } as any);
+            await service.sendMessage(ctx, { teamId: 100, content: 'hi' });
 
             expect(mockChatMessageProducer.sendMessage).toHaveBeenCalledWith(1, { teamId: 100, content: 'hi' }, 42, 'USER');
             expect(mockBlockService.isBlocked).not.toHaveBeenCalled();
@@ -168,7 +168,7 @@ describe('ChatService', () => {
         it('팀 채널 메시지는 클라이언트 teamId를 멤버십의 teamId로 덮어쓴다', async () => {
             mockChannelMemberRepository.findMembership.mockResolvedValue({ teamId: 100, channelType: 'TEXT' });
 
-            await service.sendMessage(ctx, { teamId: 999, content: 'hi' } as any);
+            await service.sendMessage(ctx, { teamId: 999, content: 'hi' });
 
             expect(mockChatMessageProducer.sendMessage).toHaveBeenCalledWith(
                 1,
@@ -181,7 +181,7 @@ describe('ChatService', () => {
         it('채널 멤버가 아니면 ForbiddenException을 던진다', async () => {
             mockChannelMemberRepository.findMembership.mockResolvedValue(null);
 
-            await expect(service.sendMessage(ctx, { content: 'hi' } as any)).rejects.toThrow(ForbiddenException);
+            await expect(service.sendMessage(ctx, { content: 'hi' })).rejects.toThrow(ForbiddenException);
             expect(mockChatMessageProducer.sendMessage).not.toHaveBeenCalled();
         });
 
@@ -192,7 +192,7 @@ describe('ChatService', () => {
                 { name: 'a.png', url: 'http://minio/chat-files/1/42/uuid.png', size: 1, mimeType: 'image/png' },
             ];
 
-            await service.sendMessage(ctx, { content: 'hi', attachments } as any);
+            await service.sendMessage(ctx, { content: 'hi', attachments });
 
             expect(mockMinioService.assertOwnedAttachmentUrl).toHaveBeenCalledWith(attachments[0].url, 1, 42);
             expect(mockChatMessageProducer.sendMessage).toHaveBeenCalled();
@@ -207,7 +207,7 @@ describe('ChatService', () => {
                 { name: 'a.png', url: 'http://minio/chat-files/999/7/uuid.png', size: 1, mimeType: 'image/png' },
             ];
 
-            await expect(service.sendMessage(ctx, { content: 'hi', attachments } as any)).rejects.toThrow(BadRequestException);
+            await expect(service.sendMessage(ctx, { content: 'hi', attachments })).rejects.toThrow(BadRequestException);
             expect(mockChatMessageProducer.sendMessage).not.toHaveBeenCalled();
         });
 
@@ -216,7 +216,7 @@ describe('ChatService', () => {
             mockChannelMemberRepository.findByChannelId.mockResolvedValue([{ userId: 42 }, { userId: 7 }]);
             mockBlockService.isBlocked.mockResolvedValue(true);
 
-            await expect(service.sendMessage(ctx, { content: 'hi' } as any)).rejects.toThrow(ForbiddenException);
+            await expect(service.sendMessage(ctx, { content: 'hi' })).rejects.toThrow(ForbiddenException);
             expect(mockBlockService.isBlocked).toHaveBeenCalledWith(7, 42);
             expect(mockChatMessageProducer.sendMessage).not.toHaveBeenCalled();
         });
@@ -226,7 +226,7 @@ describe('ChatService', () => {
             mockChannelMemberRepository.findByChannelId.mockResolvedValue([{ userId: 42 }, { userId: 7 }]);
             mockBlockService.isBlocked.mockResolvedValue(false);
 
-            await service.sendMessage(ctx, { teamId: 999, projectId: 5, content: 'hi' } as any);
+            await service.sendMessage(ctx, { teamId: 999, projectId: 5, content: 'hi' });
 
             expect(mockChannelMemberRepository.setHidden).toHaveBeenCalledWith(1, 7, false);
             expect(mockChatMessageProducer.sendMessage).toHaveBeenCalledWith(

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -510,7 +510,7 @@ export class ChatService {
             .emit('message:edited', {
                 messageId: ctx.messageId,
                 content: updated.content,
-                editedAt: (updated as MessageDocument).updatedAt?.toISOString(),
+                editedAt: (updated).updatedAt?.toISOString(),
             });
 
         return updated;
@@ -724,7 +724,7 @@ export class ChatService {
      * @returns ADMIN 역할이면 `true`
      */
     private isAdmin(role: string): boolean {
-        return role === UserRole.ADMIN;
+        return role === (UserRole.ADMIN as string);
     }
 
     /**

--- a/cowork-chat/src/chat/kafka/channel-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/channel-event.consumer.ts
@@ -38,10 +38,11 @@ export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
 
         void this.consumer
             .run({
+                // eslint-disable-next-line @typescript-eslint/require-await -- kafkajs의 EachMessageHandler가 Promise<void> 반환을 요구함
                 eachMessage: async ({ message }) => {
                     if (!message.value) return;
                     try {
-                        const event: ChannelEvent = JSON.parse(message.value.toString());
+                        const event = JSON.parse(message.value.toString()) as ChannelEvent;
                         this.handleEvent(event);
                     } catch (err) {
                         this.logger.error('채널 이벤트 Kafka 메시지 처리 중 예외 발생', err);

--- a/cowork-chat/src/chat/kafka/channel-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/channel-event.consumer.ts
@@ -38,16 +38,17 @@ export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
 
         void this.consumer
             .run({
-                // eslint-disable-next-line @typescript-eslint/require-await -- kafkajs의 EachMessageHandler가 Promise<void> 반환을 요구함
-                eachMessage: async ({ message }) => {
-                    if (!message.value) return;
-                    try {
-                        const event = JSON.parse(message.value.toString()) as ChannelEvent;
-                        this.handleEvent(event);
-                    } catch (err) {
-                        this.logger.error('채널 이벤트 Kafka 메시지 처리 중 예외 발생', err);
-                        if (!(err instanceof SyntaxError)) throw err;
+                eachMessage: ({ message }): Promise<void> => {
+                    if (message.value) {
+                        try {
+                            const event = JSON.parse(message.value.toString()) as ChannelEvent;
+                            this.handleEvent(event);
+                        } catch (err) {
+                            this.logger.error('채널 이벤트 Kafka 메시지 처리 중 예외 발생', err);
+                            if (!(err instanceof SyntaxError)) throw err;
+                        }
                     }
+                    return Promise.resolve();
                 },
             })
             .catch((err) => {

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.spec.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.spec.ts
@@ -1,4 +1,13 @@
+import { ConfigService } from '@nestjs/config';
 import { ChatMessageConsumer } from './chat-message.consumer';
+import { ChatMessageEvent } from './event/chat-message.event';
+import { ElasticsearchService } from '../../search/elasticsearch.service';
+import { MessageRepository } from '../repository/message.repository';
+import { ChannelMemberRepository } from '../repository/channel-member.repository';
+
+type ConsumerWithPrivates = Omit<ChatMessageConsumer, 'handleMessageEvent'> & {
+    handleMessageEvent: (event: ChatMessageEvent) => Promise<void>;
+};
 
 const mockMessageRepository = {
     createMessage: jest.fn(),
@@ -20,7 +29,12 @@ describe('ChatMessageConsumer', () => {
     let consumer: ChatMessageConsumer;
 
     beforeEach(() => {
-        consumer = new ChatMessageConsumer(mockMessageRepository as any, mockChannelMemberRepository as any, mockConfigService as any, mockElasticsearchService as any);
+        consumer = new ChatMessageConsumer(
+            mockMessageRepository as unknown as MessageRepository,
+            mockChannelMemberRepository as unknown as ChannelMemberRepository,
+            mockConfigService as unknown as ConfigService,
+            mockElasticsearchService as unknown as ElasticsearchService,
+        );
         jest.clearAllMocks();
     });
 
@@ -28,7 +42,8 @@ describe('ChatMessageConsumer', () => {
         const savedMessage = { _id: 'msg-id-1', toObject: jest.fn().mockReturnValue({}) };
         mockMessageRepository.createMessage.mockResolvedValue(savedMessage);
 
-        await (consumer as any).handleMessageEvent({
+        await (consumer as unknown as ConsumerWithPrivates).handleMessageEvent({
+            eventType: 'MESSAGE_SENT',
             teamId: 10,
             projectId: null,
             channelId: 1,
@@ -52,8 +67,9 @@ describe('ChatMessageConsumer', () => {
         const savedMessage = { _id: 'msg-id-42', toObject: jest.fn().mockReturnValue({}) };
         mockMessageRepository.createMessage.mockResolvedValue(savedMessage);
 
-        await (consumer as any).handleMessageEvent({
+        await (consumer as unknown as ConsumerWithPrivates).handleMessageEvent({
             teamId: 10,
+            eventType: 'MESSAGE_SENT',
             projectId: null,
             channelId: 5,
             authorId: 42,

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.ts
@@ -62,7 +62,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
                 eachMessage: async ({ message }) => {
                     if (!message.value) return;
                     try {
-                        const event: ChatMessageEvent = JSON.parse(message.value.toString());
+                        const event = JSON.parse(message.value.toString()) as ChatMessageEvent;
                         await this.handleMessageEvent(event);
                     } catch (err) {
                         this.logger.error('Kafka 메시지 처리 중 예외 발생', err);
@@ -138,7 +138,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
                 notificationStatus: 'PENDING',
             });
 
-            this.logger.log(`message saved messageId=${saved._id} channelId=${event.channelId}`);
+            this.logger.log(`message saved messageId=${saved._id.toString()} channelId=${event.channelId}`);
             this.io?.to(`chat:${event.channelId}`).emit('message', saved.toObject());
             void this.channelMemberRepository
                 .updateLastRead(event.channelId, event.authorId, saved._id)
@@ -158,8 +158,8 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
                     createdAt: event.occurredAt,
                 });
             }
-        } catch (err: any) {
-            if (err?.code === 11000) {
+        } catch (err) {
+            if (typeof err === 'object' && err !== null && 'code' in err && err.code === 11000) {
                 this.logger.warn(`중복 메시지 감지, 스킵합니다 (clientMessageId: ${event.clientMessageId})`);
                 return;
             }

--- a/cowork-chat/src/chat/kafka/chat-message.producer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.producer.ts
@@ -27,7 +27,7 @@ export class ChatMessageProducer implements OnModuleInit, OnModuleDestroy {
      * 연결 실패는 오류 로그로만 기록되며, 모듈 초기화 자체는 성공으로 처리된다.
      * 실제 연결은 첫 번째 메시지 발행 시 {@link ensureConnected}를 통해 재시도된다.
      */
-    async onModuleInit() {
+    onModuleInit() {
         const kafka = new Kafka({
             clientId: 'cowork-chat',
             brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),

--- a/cowork-chat/src/chat/kafka/event/chat-message.event.ts
+++ b/cowork-chat/src/chat/kafka/event/chat-message.event.ts
@@ -1,3 +1,5 @@
+import { AttachmentDto } from '../../dto/send-message.dto';
+
 /**
  * 채팅 메시지 발행 시 Kafka로 전송되는 이벤트 페이로드.
  *
@@ -22,7 +24,7 @@ export interface ChatMessageEvent {
     content: string;
     /** 메시지 렌더링 타입 (예: TEXT, FILE, SYSTEM) */
     type: string;
-    attachments?: any[];
+    attachments?: AttachmentDto[];
     /** 스레드 부모 메시지 ID (MongoDB ObjectId 문자열); 최상위 메시지는 undefined */
     parentMessageId?: string;
     /** 클라이언트 측 멱등성 키; 중복 전송 방지에 사용 */

--- a/cowork-chat/src/chat/kafka/github-issue-result.consumer.spec.ts
+++ b/cowork-chat/src/chat/kafka/github-issue-result.consumer.spec.ts
@@ -5,6 +5,10 @@ import { GithubIssueResultConsumer } from './github-issue-result.consumer';
 import { ChatService } from '../chat.service';
 import { GithubIssueResultEvent } from './event/github-issue.event';
 
+type ConsumerWithPrivates = Omit<GithubIssueResultConsumer, 'handleResultEvent'> & {
+    handleResultEvent: (event: GithubIssueResultEvent) => Promise<void>;
+};
+
 const mockToObject = jest.fn();
 const mockSaveSystemMessage = jest.fn();
 
@@ -40,7 +44,7 @@ describe('GithubIssueResultConsumer', () => {
     });
 
     const callHandleResultEvent = (event: GithubIssueResultEvent) =>
-        (consumer as any).handleResultEvent(event);
+        (consumer as unknown as ConsumerWithPrivates).handleResultEvent(event);
 
     describe('이슈 생성 성공', () => {
         it('성공 SYSTEM 메시지를 저장하고 WebSocket으로 브로드캐스트한다', async () => {
@@ -108,13 +112,13 @@ describe('GithubIssueResultConsumer', () => {
     describe('WebSocket 서버 미설정', () => {
         it('io가 없어도 메시지 저장은 정상 처리된다', async () => {
             const consumerWithoutIo = new GithubIssueResultConsumer(
-                mockChatService as any,
-                { get: jest.fn().mockReturnValue('localhost:9092') } as any,
+                mockChatService as unknown as ChatService,
+                { get: jest.fn().mockReturnValue('localhost:9092') } as unknown as ConfigService,
             );
             mockSaveSystemMessage.mockResolvedValue({ toObject: jest.fn().mockReturnValue({}) });
 
             await expect(
-                (consumerWithoutIo as any).handleResultEvent({
+                (consumerWithoutIo as unknown as ConsumerWithPrivates).handleResultEvent({
                     channelId: 5,
                     teamId: 1,
                     success: true,

--- a/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
+++ b/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
@@ -55,7 +55,7 @@ export class GithubIssueResultConsumer implements OnModuleInit, OnModuleDestroy 
                 eachMessage: async ({ message }) => {
                     if (!message.value) return;
                     try {
-                        const event: GithubIssueResultEvent = JSON.parse(message.value.toString());
+                        const event = JSON.parse(message.value.toString()) as GithubIssueResultEvent;
                         await this.handleResultEvent(event);
                     } catch (err) {
                         this.logger.error('이슈 결과 처리 중 오류 발생', err);

--- a/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
+++ b/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
@@ -119,7 +119,7 @@ export class GithubIssueResultConsumer implements OnModuleInit, OnModuleDestroy 
      * @param channelId - 브로드캐스트 대상 채널 ID
      * @param message - 전송할 메시지 객체
      */
-    private notifyClient(channelId: number, message: any): void {
+    private notifyClient(channelId: number, message: unknown): void {
         this.io?.to(`chat:${channelId}`).emit('message', message);
     }
 }

--- a/cowork-chat/src/chat/kafka/github-issue.producer.spec.ts
+++ b/cowork-chat/src/chat/kafka/github-issue.producer.spec.ts
@@ -19,7 +19,7 @@ jest.mock('kafkajs', () => ({
 describe('GithubIssueProducer', () => {
     let producer: GithubIssueProducer;
 
-    beforeEach(async () => {
+    beforeEach(() => {
         jest.clearAllMocks();
         mockConnect.mockResolvedValue(undefined);
         const configService = {
@@ -27,7 +27,7 @@ describe('GithubIssueProducer', () => {
         } as unknown as ConfigService;
 
         producer = new GithubIssueProducer(configService);
-        await producer.onModuleInit();
+        producer.onModuleInit();
     });
 
     afterEach(async () => {

--- a/cowork-chat/src/chat/kafka/github-issue.producer.ts
+++ b/cowork-chat/src/chat/kafka/github-issue.producer.ts
@@ -26,7 +26,7 @@ export class GithubIssueProducer implements OnModuleInit, OnModuleDestroy {
      * 연결 실패는 오류 로그로만 기록되며, 모듈 초기화 자체는 성공으로 처리된다.
      * 실제 연결은 첫 번째 이벤트 발행 시 {@link ensureConnected}를 통해 재시도된다.
      */
-    async onModuleInit() {
+    onModuleInit() {
         const kafka = new Kafka({
             clientId: 'cowork-chat-github',
             brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),

--- a/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
+++ b/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
@@ -41,16 +41,20 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
      * 이전 폴링이 완료되지 않은 경우 (`isPolling === true`) 해당 인터벌은 건너뛴다.
      */
     onModuleInit() {
-        this.timer = setInterval(async () => {
-            if (this.isPolling) return;
-            this.isPolling = true;
-            try {
-                await this.poll();
-            } finally {
-                this.isPolling = false;
-            }
+        this.timer = setInterval(() => {
+            void this.runPollCycle();
         }, POLL_INTERVAL_MS);
         this.logger.log('Notification outbox poller started');
+    }
+
+    private async runPollCycle(): Promise<void> {
+        if (this.isPolling) return;
+        this.isPolling = true;
+        try {
+            await this.poll();
+        } finally {
+            this.isPolling = false;
+        }
     }
 
     /**
@@ -110,7 +114,7 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
             } catch (err) {
                 const retryCount = (msg.notificationRetryCount ?? 0) + 1;
                 const nextStatus = retryCount >= MAX_RETRY ? 'FAILED' : 'PENDING';
-                this.logger.error(`outbox 처리 실패 (messageId: ${msg._id}, retry: ${retryCount}/${MAX_RETRY}), ${nextStatus} 전환`, err);
+                this.logger.error(`outbox 처리 실패 (messageId: ${msg._id.toString()}, retry: ${retryCount}/${MAX_RETRY}), ${nextStatus} 전환`, err);
                 await this.messageRepository.updateNotificationStatus(msg._id, nextStatus, retryCount);
             }
         }

--- a/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
+++ b/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
@@ -52,6 +52,8 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
         this.isPolling = true;
         try {
             await this.poll();
+        } catch (err) {
+            this.logger.error('Notification outbox polling failed', err);
         } finally {
             this.isPolling = false;
         }

--- a/cowork-chat/src/chat/kafka/notification-trigger.producer.ts
+++ b/cowork-chat/src/chat/kafka/notification-trigger.producer.ts
@@ -49,7 +49,7 @@ export class NotificationTriggerProducer implements OnModuleInit, OnModuleDestro
 
     constructor(private readonly configService: ConfigService) {}
 
-    async onModuleInit() {
+    onModuleInit() {
         const kafka = new Kafka({
             clientId: 'cowork-chat-notification',
             brokers: getRequiredCsvConfig(this.configService, 'KAFKA_BOOTSTRAP_SERVERS'),

--- a/cowork-chat/src/chat/kafka/project-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/project-event.consumer.ts
@@ -36,10 +36,11 @@ export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
 
         void this.consumer
             .run({
+                // eslint-disable-next-line @typescript-eslint/require-await -- kafkajs의 EachMessageHandler가 Promise<void> 반환을 요구함
                 eachMessage: async ({ message }) => {
                     if (!message.value) return;
                     try {
-                        const event: ProjectEvent = JSON.parse(message.value.toString());
+                        const event = JSON.parse(message.value.toString()) as ProjectEvent;
                         this.handleEvent(event);
                     } catch (err) {
                         this.logger.error('프로젝트 이벤트 Kafka 메시지 처리 중 예외 발생', err);

--- a/cowork-chat/src/chat/kafka/project-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/project-event.consumer.ts
@@ -36,16 +36,17 @@ export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
 
         void this.consumer
             .run({
-                // eslint-disable-next-line @typescript-eslint/require-await -- kafkajs의 EachMessageHandler가 Promise<void> 반환을 요구함
-                eachMessage: async ({ message }) => {
-                    if (!message.value) return;
-                    try {
-                        const event = JSON.parse(message.value.toString()) as ProjectEvent;
-                        this.handleEvent(event);
-                    } catch (err) {
-                        this.logger.error('프로젝트 이벤트 Kafka 메시지 처리 중 예외 발생', err);
-                        if (!(err instanceof SyntaxError)) throw err;
+                eachMessage: ({ message }): Promise<void> => {
+                    if (message.value) {
+                        try {
+                            const event = JSON.parse(message.value.toString()) as ProjectEvent;
+                            this.handleEvent(event);
+                        } catch (err) {
+                            this.logger.error('프로젝트 이벤트 Kafka 메시지 처리 중 예외 발생', err);
+                            if (!(err instanceof SyntaxError)) throw err;
+                        }
                     }
+                    return Promise.resolve();
                 },
             })
             .catch((err) => {

--- a/cowork-chat/src/chat/project-message.controller.spec.ts
+++ b/cowork-chat/src/chat/project-message.controller.spec.ts
@@ -25,7 +25,7 @@ describe('ProjectMessageController', () => {
 
     describe('searchMessages', () => {
         it('프로젝트 메시지 검색을 ChatService에 위임한다', async () => {
-            const query = { q: '안녕', channelId: 2, limit: 50 } as any;
+            const query = { q: '안녕', channelId: 2, limit: 50 };
             const expected = {
                 messages: [
                     {
@@ -55,7 +55,7 @@ describe('ProjectMessageController', () => {
             mockChatService.searchProjectMessages.mockRejectedValue(error);
 
             await expect(
-                controller.searchMessages(5, { q: '안녕' } as any, userId),
+                controller.searchMessages(5, { q: '안녕' }, userId),
             ).rejects.toThrow(error);
         });
     });

--- a/cowork-chat/src/chat/repository/channel-member.repository.ts
+++ b/cowork-chat/src/chat/repository/channel-member.repository.ts
@@ -73,7 +73,7 @@ export class ChannelMemberRepository {
      * @returns 채널에 속한 {@link ChannelMember} 객체 배열
      */
     findByChannelId(channelId: number): Promise<ChannelMember[]> {
-        return this.memberModel.find({ channelId }).lean() as Promise<ChannelMember[]>;
+        return this.memberModel.find({ channelId }).lean();
     }
 
     async updateLastRead(channelId: number, userId: number, messageId: Types.ObjectId): Promise<void> {

--- a/cowork-chat/src/chat/repository/message.repository.spec.ts
+++ b/cowork-chat/src/chat/repository/message.repository.spec.ts
@@ -1,4 +1,5 @@
-import { Types } from 'mongoose';
+import { Model, Types } from 'mongoose';
+import { Message } from '../schema/message.schema';
 import { MessageRepository } from './message.repository';
 
 const mockAggregate = jest.fn();
@@ -10,11 +11,18 @@ const mockMessageModel = {
     collection: { name: 'messages' },
 };
 
+type AggregatePipelineStage = Record<string, unknown>;
+
+function getAggregatePipeline(): AggregatePipelineStage[] {
+    const calls = mockAggregate.mock.calls as unknown as AggregatePipelineStage[][][];
+    return calls[0][0];
+}
+
 describe('MessageRepository', () => {
     let repository: MessageRepository;
 
     beforeEach(() => {
-        repository = new MessageRepository(mockMessageModel as any);
+        repository = new MessageRepository(mockMessageModel as unknown as Model<Message>);
         jest.clearAllMocks();
     });
 
@@ -60,7 +68,7 @@ describe('MessageRepository', () => {
 
             await repository.findMessages(1);
 
-            const pipeline = mockAggregate.mock.calls[0][0];
+            const pipeline = getAggregatePipeline();
             expect(pipeline[0].$match).toEqual({ channelId: 1 });
             expect(pipeline[1].$sort).toEqual({ _id: -1 });
             expect(pipeline[2].$limit).toBe(100);
@@ -72,7 +80,7 @@ describe('MessageRepository', () => {
 
             await repository.findMessages(1, messageId);
 
-            const pipeline = mockAggregate.mock.calls[0][0];
+            const pipeline = getAggregatePipeline();
             expect(pipeline[0].$match).toEqual({
                 channelId: 1,
                 _id: { $lt: new Types.ObjectId(messageId) },
@@ -84,7 +92,7 @@ describe('MessageRepository', () => {
 
             await repository.findMessages(1);
 
-            const pipeline = mockAggregate.mock.calls[0][0];
+            const pipeline = getAggregatePipeline();
             expect(pipeline[3].$lookup).toEqual(expect.objectContaining({
                 from: 'messages',
                 localField: 'parentMessageId',
@@ -146,7 +154,7 @@ describe('MessageRepository', () => {
 
             await repository.findFileAttachments(1, before, 20);
 
-            const pipeline = mockAggregate.mock.calls[0][0];
+            const pipeline = getAggregatePipeline();
             expect(pipeline[2].$match).toEqual({
                 $or: [
                     { createdAt: { $lt: new Date(cursorRow.createdAt) } },

--- a/cowork-chat/src/chat/repository/message.repository.ts
+++ b/cowork-chat/src/chat/repository/message.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model, Types } from 'mongoose';
+import { Model, PipelineStage, Types } from 'mongoose';
 import { Message, MessageDocument } from '../schema/message.schema';
 
 /** 한 번에 조회하는 최대 메시지 수 */
@@ -30,6 +30,15 @@ export type FileAttachmentRow = {
     uploadedAt: string;
     /** 메시지 내 첨부 파일 배열에서의 0-based 인덱스 */
     attachmentIndex: number;
+};
+
+/** {@link findFileAttachments}의 집계 파이프라인 `$project` 결과 행 타입. */
+type FileAttachmentAggregateRow = {
+    _id: Types.ObjectId;
+    authorId: number;
+    createdAt: Date;
+    attachmentIndex?: number;
+    attachment: { name: string; url: string; size: number; mimeType: string };
 };
 
 /**
@@ -278,7 +287,7 @@ export class MessageRepository {
         const safeLimit = Math.min(Math.max(limit, 1), FILE_ATTACHMENT_LIMIT);
         const cursorMatch = before ? this.buildFileCursorMatch(before) : null;
 
-        const pipeline: any[] = [
+        const pipeline: PipelineStage[] = [
             {
                 $match: {
                     channelId,
@@ -312,10 +321,10 @@ export class MessageRepository {
             },
         ];
 
-        const rows = await this.messageModel.aggregate(pipeline);
+        const rows = await this.messageModel.aggregate<FileAttachmentAggregateRow>(pipeline);
         const hasNext = rows.length > safeLimit;
         const pageRows = rows.slice(0, safeLimit);
-        const items: FileAttachmentRow[] = pageRows.map((row: any) => {
+        const items: FileAttachmentRow[] = pageRows.map((row) => {
             const attachmentIndex = row.attachmentIndex ?? 0;
             return {
                 fileId: this.encodeFileCursor(row)!,
@@ -351,7 +360,7 @@ export class MessageRepository {
             { notificationStatus: 'PENDING' },
             { $set: { notificationStatus: 'PROCESSING', notificationProcessingStartedAt: new Date() } },
             { sort: { createdAt: 1 }, new: true },
-        ).lean() as Promise<NotificationMessage | null>;
+        ).lean();
     }
 
     /**
@@ -668,7 +677,7 @@ export class MessageRepository {
      * @param row - 집계 결과의 단일 행 (`_id`, `createdAt`, `attachmentIndex` 필드 필요)
      * @returns base64 인코딩된 커서 문자열. `row`가 falsy이면 `null`
      */
-    private encodeFileCursor(row: any): string | null {
+    private encodeFileCursor(row: FileAttachmentAggregateRow | undefined): string | null {
         if (!row) {
             return null;
         }

--- a/cowork-chat/src/chat/service/base-http-client.ts
+++ b/cowork-chat/src/chat/service/base-http-client.ts
@@ -43,7 +43,7 @@ export abstract class BaseHttpClient {
             return await res.json() as T;
         } catch (err) {
             this.logger.warn(`${this.serviceName} JSON 응답 파싱 실패: ${String(err)}`);
-            throw new Error(`${this.serviceName} 응답 본문 파싱에 실패했습니다`);
+            throw new Error(`${this.serviceName} 응답 본문 파싱에 실패했습니다`, { cause: err });
         }
     }
 }

--- a/cowork-chat/src/chat/service/channel.client.spec.ts
+++ b/cowork-chat/src/chat/service/channel.client.spec.ts
@@ -38,8 +38,7 @@ describe('ChannelClient', () => {
             'http://localhost:8083/channels/1',
             expect.objectContaining({
                 headers: { 'X-User-Id': '42' },
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.any()의 반환 타입이 any로 선언되어 있음
-                signal: expect.any(AbortSignal),
+                signal: expect.any(AbortSignal) as unknown,
             }),
         );
     });

--- a/cowork-chat/src/chat/service/channel.client.spec.ts
+++ b/cowork-chat/src/chat/service/channel.client.spec.ts
@@ -38,6 +38,7 @@ describe('ChannelClient', () => {
             'http://localhost:8083/channels/1',
             expect.objectContaining({
                 headers: { 'X-User-Id': '42' },
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.any()의 반환 타입이 any로 선언되어 있음
                 signal: expect.any(AbortSignal),
             }),
         );

--- a/cowork-chat/src/chat/service/project.client.spec.ts
+++ b/cowork-chat/src/chat/service/project.client.spec.ts
@@ -91,8 +91,7 @@ describe('ProjectClient', () => {
 
             expect(global.fetch).toHaveBeenCalledWith(
                 'http://localhost:8084/projects/1',
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.any()의 반환 타입이 any로 선언되어 있음
-                expect.objectContaining({ signal: expect.any(AbortSignal) }),
+                expect.objectContaining({ signal: expect.any(AbortSignal) as unknown }),
             );
             expect(result).toEqual({ teamId: 10, owner: 'my-org', repo: 'backend' });
         });
@@ -152,8 +151,7 @@ describe('ProjectClient', () => {
                 'http://localhost:8084/projects/5/members/me',
                 expect.objectContaining({
                     headers: { 'X-User-Id': '42' },
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.any()의 반환 타입이 any로 선언되어 있음
-                    signal: expect.any(AbortSignal),
+                    signal: expect.any(AbortSignal) as unknown,
                 }),
             );
             expect(result).toBe(true);

--- a/cowork-chat/src/chat/service/project.client.spec.ts
+++ b/cowork-chat/src/chat/service/project.client.spec.ts
@@ -1,6 +1,10 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
-import { ProjectClient } from './project.client';
+import { ProjectClient, GithubRepoInfo } from './project.client';
+
+type ClientWithPrivates = Omit<ProjectClient, 'parseRepoUrl'> & {
+    parseRepoUrl: (url: string | null | undefined) => Omit<GithubRepoInfo, 'teamId'> | null;
+};
 
 describe('ProjectClient', () => {
     let client: ProjectClient;
@@ -21,7 +25,7 @@ describe('ProjectClient', () => {
 
     describe('parseRepoUrl (private)', () => {
         const parse = (url: string | null | undefined) =>
-            (client as any).parseRepoUrl(url);
+            (client as unknown as ClientWithPrivates).parseRepoUrl(url);
 
         it('표준 GitHub URL에서 owner와 repo를 파싱한다', () => {
             expect(parse('https://github.com/my-org/backend')).toEqual({
@@ -87,6 +91,7 @@ describe('ProjectClient', () => {
 
             expect(global.fetch).toHaveBeenCalledWith(
                 'http://localhost:8084/projects/1',
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.any()의 반환 타입이 any로 선언되어 있음
                 expect.objectContaining({ signal: expect.any(AbortSignal) }),
             );
             expect(result).toEqual({ teamId: 10, owner: 'my-org', repo: 'backend' });
@@ -147,6 +152,7 @@ describe('ProjectClient', () => {
                 'http://localhost:8084/projects/5/members/me',
                 expect.objectContaining({
                     headers: { 'X-User-Id': '42' },
+                    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- expect.any()의 반환 타입이 any로 선언되어 있음
                     signal: expect.any(AbortSignal),
                 }),
             );

--- a/cowork-chat/src/common/config/config-server.ts
+++ b/cowork-chat/src/common/config/config-server.ts
@@ -53,5 +53,5 @@ function flattenPropertySources(propertySources: PropertySource[]): Record<strin
 function stringifyPropertyValue(value: unknown): string {
     if (typeof value === 'string') return value;
     if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return value.toString();
-    return JSON.stringify(value);
+    return JSON.stringify(value) ?? '';
 }

--- a/cowork-chat/src/common/config/config-server.ts
+++ b/cowork-chat/src/common/config/config-server.ts
@@ -43,9 +43,15 @@ function flattenPropertySources(propertySources: PropertySource[]): Record<strin
     for (let i = propertySources.length - 1; i >= 0; i -= 1) {
         const source = propertySources[i]?.source ?? {};
         for (const [key, value] of Object.entries(source)) {
-            flatMap[key] = value == null ? '' : String(value);
+            flatMap[key] = value == null ? '' : stringifyPropertyValue(value);
         }
     }
 
     return flatMap;
+}
+
+function stringifyPropertyValue(value: unknown): string {
+    if (typeof value === 'string') return value;
+    if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') return value.toString();
+    return JSON.stringify(value);
 }

--- a/cowork-chat/src/common/decorator/user.decorator.ts
+++ b/cowork-chat/src/common/decorator/user.decorator.ts
@@ -1,16 +1,17 @@
 import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { Request } from 'express';
 import { RequestContextUtil } from '../util/request-context.util';
 
 export const UserId = createParamDecorator(
     (data: unknown, ctx: ExecutionContext): number => {
-        const request = ctx.switchToHttp().getRequest();
+        const request = ctx.switchToHttp().getRequest<Request>();
         return RequestContextUtil.getUserId(request.headers);
     },
 );
 
 export const UserRole = createParamDecorator(
     (data: unknown, ctx: ExecutionContext): string => {
-        const request = ctx.switchToHttp().getRequest();
+        const request = ctx.switchToHttp().getRequest<Request>();
         return RequestContextUtil.getUserRole(request.headers);
     },
 );

--- a/cowork-chat/src/eureka/eureka-client.ts
+++ b/cowork-chat/src/eureka/eureka-client.ts
@@ -83,24 +83,28 @@ export class EurekaClient {
 
     private startHeartbeat(): void {
         this.stopHeartbeat();
-        this.heartbeatTimer = setInterval(async () => {
-            if (this.isPolling) return;
-            this.isPolling = true;
-            try {
-                await this.request(`/apps/${this.config.appName}/${this.config.instanceId}`, {
-                    method: 'PUT',
-                });
-            } catch (err: unknown) {
-                console.warn('eureka heartbeat failed', err);
-                if (err instanceof Error && err.message.includes('404')) {
-                    await this.register().catch((regErr: unknown) => {
-                        console.error('eureka re-registration failed', regErr);
-                    });
-                }
-            } finally {
-                this.isPolling = false;
-            }
+        this.heartbeatTimer = setInterval(() => {
+            void this.sendHeartbeat();
         }, this.config.leaseRenewalIntervalSeconds * 1000);
+    }
+
+    private async sendHeartbeat(): Promise<void> {
+        if (this.isPolling) return;
+        this.isPolling = true;
+        try {
+            await this.request(`/apps/${this.config.appName}/${this.config.instanceId}`, {
+                method: 'PUT',
+            });
+        } catch (err: unknown) {
+            console.warn('eureka heartbeat failed', err);
+            if (err instanceof Error && err.message.includes('404')) {
+                await this.register().catch((regErr: unknown) => {
+                    console.error('eureka re-registration failed', regErr);
+                });
+            }
+        } finally {
+            this.isPolling = false;
+        }
     }
 
     private stopHeartbeat(): void {

--- a/cowork-chat/src/eureka/eureka-client.ts
+++ b/cowork-chat/src/eureka/eureka-client.ts
@@ -1,4 +1,5 @@
 import os from 'os';
+import { Logger } from '@nestjs/common';
 import { requireEnv } from '../common/config/config.util';
 
 type EurekaConfig = {
@@ -12,6 +13,7 @@ type EurekaConfig = {
 };
 
 export class EurekaClient {
+    private readonly logger = new Logger(EurekaClient.name);
     private heartbeatTimer?: NodeJS.Timeout;
     private isPolling = false;
 
@@ -96,10 +98,10 @@ export class EurekaClient {
                 method: 'PUT',
             });
         } catch (err: unknown) {
-            console.warn('eureka heartbeat failed', err);
+            this.logger.warn(`eureka heartbeat failed: ${String(err)}`);
             if (err instanceof Error && err.message.includes('404')) {
                 await this.register().catch((regErr: unknown) => {
-                    console.error('eureka re-registration failed', regErr);
+                    this.logger.error(`eureka re-registration failed: ${String(regErr)}`);
                 });
             }
         } finally {
@@ -132,7 +134,8 @@ export class EurekaClient {
     private resolveIpAddress(): string {
         for (const interfaces of Object.values(os.networkInterfaces())) {
             for (const iface of interfaces ?? []) {
-                if ((iface.family === 'IPv4' || (iface.family as any) === 4) && !iface.internal) {
+                // Node.js 18 미만에서는 family가 숫자(4)였던 레거시 동작을 함께 지원한다.
+                if ((iface.family === 'IPv4' || (iface.family as unknown) === 4) && !iface.internal) {
                     return iface.address;
                 }
             }

--- a/cowork-chat/src/main.ts
+++ b/cowork-chat/src/main.ts
@@ -12,7 +12,7 @@ import { loadConfigServerEnv } from './common/config/config-server';
 
 function debugStartup(message: string) {
     if (process.env.DEBUG_STARTUP === 'true') {
-        console.log(`[startup] ${message}`);
+        new Logger('Startup').log(message);
     }
 }
 
@@ -89,7 +89,7 @@ async function bootstrap() {
     new Logger('Bootstrap').log(`Swagger UI: ${await app.getUrl()}/api`);
 }
 
-bootstrap().catch((err) => {
-    console.error('Application failed to start', err);
+bootstrap().catch((err: unknown) => {
+    new Logger('Bootstrap').error('Application failed to start', err instanceof Error ? err.stack : String(err));
     process.exit(1);
 });

--- a/cowork-chat/src/main.ts
+++ b/cowork-chat/src/main.ts
@@ -82,8 +82,8 @@ async function bootstrap() {
         await app.close();
         process.exit(0);
     };
-    process.once('SIGINT', shutdown);
-    process.once('SIGTERM', shutdown);
+    process.once('SIGINT', () => void shutdown());
+    process.once('SIGTERM', () => void shutdown());
 
     new Logger('Bootstrap').log(`Chat server running on port ${port}`);
     new Logger('Bootstrap').log(`Swagger UI: ${await app.getUrl()}/api`);

--- a/cowork-chat/src/membership/membership.consumer.ts
+++ b/cowork-chat/src/membership/membership.consumer.ts
@@ -37,7 +37,7 @@ export class MembershipConsumer implements OnModuleInit, OnModuleDestroy {
                 eachMessage: async ({ message }) => {
                     if (!message.value) return;
                     try {
-                        const event: ChannelMemberEvent = JSON.parse(message.value.toString());
+                        const event = JSON.parse(message.value.toString()) as ChannelMemberEvent;
                         await this.handleEvent(event);
                     } catch (err) {
                         this.logger.error('멤버십 Kafka 메시지 처리 중 예외 발생', err);

--- a/cowork-chat/src/search/elasticsearch.service.spec.ts
+++ b/cowork-chat/src/search/elasticsearch.service.spec.ts
@@ -13,6 +13,16 @@ const mockClient = {
     search: jest.fn(),
 };
 
+interface CapturedSearchRequest {
+    query: { bool: { must: unknown[]; filter: unknown[] } };
+    search_after?: unknown;
+}
+
+function getSearchRequestBody(): CapturedSearchRequest {
+    const calls = mockClient.search.mock.calls as unknown as CapturedSearchRequest[][];
+    return calls[0][0];
+}
+
 describe('ElasticsearchService', () => {
     let service: ElasticsearchService;
 
@@ -163,7 +173,7 @@ describe('ElasticsearchService', () => {
 
             const result = await service.searchMessages(baseParams);
 
-            const body = mockClient.search.mock.calls[0][0];
+            const body = getSearchRequestBody();
             expect(body.query.bool.must[0]).toEqual({ term: { projectId: 5 } });
             expect(body.query.bool.must[1]).toEqual({ terms: { channelId: [2, 3] } });
             expect(result.hits).toHaveLength(1);
@@ -198,7 +208,7 @@ describe('ElasticsearchService', () => {
 
             await service.searchMessages({ ...baseParams, before });
 
-            const body = mockClient.search.mock.calls[0][0];
+            const body = getSearchRequestBody();
             expect(body.search_after).toEqual(sortValues);
         });
 
@@ -207,7 +217,7 @@ describe('ElasticsearchService', () => {
 
             await service.searchMessages(baseParams);
 
-            const body = mockClient.search.mock.calls[0][0];
+            const body = getSearchRequestBody();
             expect(body.search_after).toBeUndefined();
         });
 
@@ -216,7 +226,7 @@ describe('ElasticsearchService', () => {
 
             await service.searchMessages({ ...baseParams, authorId: 42 });
 
-            const body = mockClient.search.mock.calls[0][0];
+            const body = getSearchRequestBody();
             expect(body.query.bool.filter).toEqual(
                 expect.arrayContaining([{ term: { authorId: 42 } }]),
             );
@@ -227,7 +237,7 @@ describe('ElasticsearchService', () => {
 
             await service.searchMessages({ ...baseParams, type: 'FILE' });
 
-            const body = mockClient.search.mock.calls[0][0];
+            const body = getSearchRequestBody();
             expect(body.query.bool.filter).toEqual(
                 expect.arrayContaining([{ term: { type: 'FILE' } }]),
             );
@@ -238,7 +248,7 @@ describe('ElasticsearchService', () => {
 
             await service.searchMessages({ ...baseParams, hasFile: true });
 
-            const body = mockClient.search.mock.calls[0][0];
+            const body = getSearchRequestBody();
             expect(body.query.bool.filter).toEqual(
                 expect.arrayContaining([{ term: { hasAttachments: true } }]),
             );

--- a/cowork-chat/src/search/elasticsearch.service.ts
+++ b/cowork-chat/src/search/elasticsearch.service.ts
@@ -122,8 +122,8 @@ export class ElasticsearchService implements OnModuleInit {
                 id: messageId,
                 doc: { content },
             });
-        } catch (err: any) {
-            if (err?.statusCode === 404) return;
+        } catch (err) {
+            if (this.isNotFoundError(err)) return;
             this.logger.error(`ES 메시지 업데이트 실패 id=${messageId}`, err);
         }
     }
@@ -135,8 +135,8 @@ export class ElasticsearchService implements OnModuleInit {
                 id: messageId,
                 doc: { isPinned },
             });
-        } catch (err: any) {
-            if (err?.statusCode === 404) return;
+        } catch (err) {
+            if (this.isNotFoundError(err)) return;
             this.logger.error(`ES 메시지 핀 상태 업데이트 실패 id=${messageId}`, err);
         }
     }
@@ -144,30 +144,58 @@ export class ElasticsearchService implements OnModuleInit {
     async deleteMessage(messageId: string): Promise<void> {
         try {
             await this.client.delete({ index: INDEX, id: messageId });
-        } catch (err: any) {
-            if (err?.statusCode === 404) return;
+        } catch (err) {
+            if (this.isNotFoundError(err)) return;
             this.logger.error(`ES 메시지 삭제 실패 id=${messageId}`, err);
+        }
+    }
+
+    private isNotFoundError(err: unknown): boolean {
+        return typeof err === 'object' && err !== null && 'statusCode' in err && err.statusCode === 404;
+    }
+
+    private toSearchHits(rawHits: estypes.SearchHit<MessageIndexDoc>[]): SearchHit[] {
+        return rawHits.map((hit) => {
+            const source = hit._source!;
+            return {
+                messageId: source.messageId,
+                channelId: source.channelId,
+                authorId: source.authorId,
+                content: source.content,
+                highlight: hit.highlight?.content ?? [],
+                type: source.type,
+                hasAttachments: source.hasAttachments,
+                isPinned: source.isPinned,
+                createdAt: source.createdAt,
+            };
+        });
+    }
+
+    private buildNextCursor(rawHits: estypes.SearchHit<MessageIndexDoc>[], hitCount: number, limit: number): string | null {
+        const lastHit = rawHits.at(-1);
+        return hitCount === limit && lastHit?.sort ? Buffer.from(JSON.stringify(lastHit.sort)).toString('base64') : null;
+    }
+
+    private parseSearchAfter(before: string | undefined): estypes.SortResults | undefined {
+        if (!before) return undefined;
+        try {
+            return JSON.parse(Buffer.from(before, 'base64').toString()) as estypes.SortResults;
+        } catch {
+            return undefined;
         }
     }
 
     async searchTeamMessages(params: SearchTeamMessagesParams): Promise<{ hits: SearchHit[]; nextCursor: string | null }> {
         const { teamId, accessibleChannelIds, q, authorId, type, hasFile, before, limit } = params;
 
-        const filter: any[] = [];
+        const filter: estypes.QueryDslQueryContainer[] = [];
         if (authorId !== undefined) filter.push({ term: { authorId } });
         if (type !== undefined) filter.push({ term: { type } });
         if (hasFile === true) filter.push({ term: { hasAttachments: true } });
 
-        let searchAfter: any[] | undefined;
-        if (before) {
-            try {
-                searchAfter = JSON.parse(Buffer.from(before, 'base64').toString());
-            } catch {
-                searchAfter = undefined;
-            }
-        }
+        const searchAfter = this.parseSearchAfter(before);
 
-        const response = await this.client.search({
+        const response = await this.client.search<MessageIndexDoc>({
             index: INDEX,
             query: {
                     bool: {
@@ -202,24 +230,9 @@ export class ElasticsearchService implements OnModuleInit {
                 ...(searchAfter ? { search_after: searchAfter } : {}),
         });
 
-        const rawHits = (response as any).hits?.hits ?? [];
-
-        const hits: SearchHit[] = rawHits.map((hit: any) => ({
-            messageId: hit._source.messageId,
-            channelId: hit._source.channelId,
-            authorId: hit._source.authorId,
-            content: hit._source.content,
-            highlight: hit.highlight?.content ?? [],
-            type: hit._source.type,
-            hasAttachments: hit._source.hasAttachments,
-            isPinned: hit._source.isPinned,
-            createdAt: hit._source.createdAt,
-        }));
-
-        const lastHit = rawHits.at(-1);
-        const nextCursor = hits.length === limit && lastHit?.sort
-            ? Buffer.from(JSON.stringify(lastHit.sort)).toString('base64')
-            : null;
+        const rawHits = response.hits.hits;
+        const hits = this.toSearchHits(rawHits);
+        const nextCursor = this.buildNextCursor(rawHits, hits.length, limit);
 
         return { hits, nextCursor };
     }
@@ -227,7 +240,7 @@ export class ElasticsearchService implements OnModuleInit {
     async searchMessages(params: SearchMessagesParams): Promise<{ hits: SearchHit[]; nextCursor: string | null }> {
         const { projectId, accessibleChannelIds, q, channelId, authorId, type, hasFile, before, limit } = params;
 
-        const filter: any[] = [];
+        const filter: estypes.QueryDslQueryContainer[] = [];
         if (channelId !== undefined) {
             filter.push({ term: { channelId } });
         }
@@ -241,16 +254,9 @@ export class ElasticsearchService implements OnModuleInit {
             filter.push({ term: { hasAttachments: true } });
         }
 
-        let searchAfter: any[] | undefined;
-        if (before) {
-            try {
-                searchAfter = JSON.parse(Buffer.from(before, 'base64').toString());
-            } catch {
-                searchAfter = undefined;
-            }
-        }
+        const searchAfter = this.parseSearchAfter(before);
 
-        const response = await this.client.search({
+        const response = await this.client.search<MessageIndexDoc>({
             index: INDEX,
             query: {
                     bool: {
@@ -285,24 +291,9 @@ export class ElasticsearchService implements OnModuleInit {
                 ...(searchAfter ? { search_after: searchAfter } : {}),
         });
 
-        const rawHits = (response as any).hits?.hits ?? [];
-
-        const hits: SearchHit[] = rawHits.map((hit: any) => ({
-            messageId: hit._source.messageId,
-            channelId: hit._source.channelId,
-            authorId: hit._source.authorId,
-            content: hit._source.content,
-            highlight: hit.highlight?.content ?? [],
-            type: hit._source.type,
-            hasAttachments: hit._source.hasAttachments,
-            isPinned: hit._source.isPinned,
-            createdAt: hit._source.createdAt,
-        }));
-
-        const lastHit = rawHits.at(-1);
-        const nextCursor = hits.length === limit && lastHit?.sort
-            ? Buffer.from(JSON.stringify(lastHit.sort)).toString('base64')
-            : null;
+        const rawHits = response.hits.hits;
+        const hits = this.toSearchHits(rawHits);
+        const nextCursor = this.buildNextCursor(rawHits, hits.length, limit);
 
         return { hits, nextCursor };
     }

--- a/cowork-chat/src/storage/minio.service.spec.ts
+++ b/cowork-chat/src/storage/minio.service.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, HttpException, PayloadTooLargeException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import * as Minio from 'minio';
 import { MinioService } from './minio.service';
 
 const mockMinioClient = {
@@ -25,7 +26,7 @@ describe('MinioService', () => {
     });
 
     it('허용된 파일 타입과 100MB 이하 파일이면 presigned URL을 발급한다', async () => {
-        const service = new MinioService(mockMinioClient as any, createConfigService());
+        const service = new MinioService(mockMinioClient as unknown as Minio.Client, createConfigService());
 
         const result = await service.createPresignedUpload({
             channelId: 1,
@@ -44,7 +45,7 @@ describe('MinioService', () => {
     });
 
     it('허용되지 않은 파일 타입이면 BadRequestException을 던진다', async () => {
-        const service = new MinioService(mockMinioClient as any, createConfigService());
+        const service = new MinioService(mockMinioClient as unknown as Minio.Client, createConfigService());
 
         await expect(service.createPresignedUpload({
             channelId: 1,
@@ -56,7 +57,7 @@ describe('MinioService', () => {
     });
 
     it('100MB를 초과하면 PayloadTooLargeException을 던진다', async () => {
-        const service = new MinioService(mockMinioClient as any, createConfigService());
+        const service = new MinioService(mockMinioClient as unknown as Minio.Client, createConfigService());
 
         await expect(service.createPresignedUpload({
             channelId: 1,
@@ -68,7 +69,7 @@ describe('MinioService', () => {
     });
 
     it('짧은 시간에 업로드 URL을 너무 많이 발급하면 TooManyRequestsException을 던진다', async () => {
-        const service = new MinioService(mockMinioClient as any, createConfigService({
+        const service = new MinioService(mockMinioClient as unknown as Minio.Client, createConfigService({
             'minio.chatUploadRateLimitMaxRequests': '2',
             'minio.chatUploadRateLimitWindowMs': '60000',
         }));

--- a/cowork-chat/src/storage/minio.service.ts
+++ b/cowork-chat/src/storage/minio.service.ts
@@ -42,7 +42,7 @@ export class MinioService implements OnModuleInit, OnModuleDestroy {
     }
 
     onModuleInit(): void {
-        this.cleanupTimer = setInterval(async () => {
+        this.cleanupTimer = setInterval(() => {
             if (this.isCleaningUpRateLimitEntries) {
                 return;
             }


### PR DESCRIPTION
## 개요

`cowork-chat`에 `ESLint`를 처음으로 도입하고, 적용 과정에서 드러난 타입 안전성 위반 236건을 모두 수정하였습니다.

## 본문

### `ESLint` 설정 추가

- `eslint.config.mjs`(flat config)를 신규 작성하였습니다. `@eslint/js`의 `recommended`와 `typescript-eslint`의 `recommendedTypeChecked`를 기반으로 구성하였습니다.
- `package.json`에 `lint`/`lint:fix` 스크립트를 추가하였습니다.
- 아래 5개 규칙을 추가로 활성화하였습니다.
  - `@typescript-eslint/no-explicit-any`: `error`
  - `@typescript-eslint/no-unused-vars`: `warn`
  - `no-console`: `warn`
  - `semi`: `error`
  - `eqeqeq`: `error` (`smart` 옵션으로 `== null`/`!= null` 관용구는 허용)

### 발견된 문제 수정

- `elasticsearch.service.ts`: `client.search<MessageIndexDoc>()` 제네릭을 사용해 `any` 캐스팅을 전부 제거하고 `Elasticsearch` 응답을 타입 안전하게 처리하였습니다.
- Kafka 컨슈머(`chat-message.consumer.ts` 등 6개 파일): `JSON.parse(...) as Type` 캐스팅 적용, 불필요한 `async` 제거, `kafkajs`의 `EachMessageHandler` 인터페이스 제약으로 불가피한 `require-await` 1건은 사유를 명시해 비활성화하였습니다.
- `chat.gateway.ts`: `Socket.data`용 `ChatSocketData`/`ChatSocket` 타입을 신설해 `client.data.userId` 등의 `any` 접근을 제거하고, `Promise`를 반환할 수 있는 `join`/`leave` 호출에 `void` 연산자를 추가하였습니다.
- `main.ts`, `eureka-client.ts`, `notification-outbox.poller.ts`, `minio.service.ts`: `setInterval(async () => ...)` 패턴을 `no-misused-promises` 위반 없이 재작성하였습니다.
- `message.repository.ts`: 집계 파이프라인에 `PipelineStage`와 전용 결과 타입을 부여하였습니다.
- `chat.service.ts`의 `no-unsafe-enum-comparison`, `config-server.ts`의 `no-base-to-string`, `base-http-client.ts`의 에러 `cause` 체이닝(`preserve-caught-error`) 등도 근본적으로 수정하였습니다.
- `eureka-client.ts`/`main.ts`의 `console.*` 호출을 `Logger`로 교체하고, 남아있던 `any` 캐스팅을 `unknown`으로 정리하였습니다.
- 테스트 파일: 실제로는 불필요했던 `as any` 캐스팅을 제거하고(캐스팅 없이도 컴파일됨을 직접 확인), `private` 메서드 테스트 접근은 `Omit<Class, 'method'> & {...}` 패턴으로 타입 안전하게 처리하였습니다. `Jest`의 `expect.any()`/`expect.objectContaining()`이 구조적으로 `any`를 반환하는 부분만 사유를 명시해 비활성화하였습니다.

### 검증

`tsc --noEmit`, `npm run build`, `jest`(159개 테스트) 모두 통과를 확인하였습니다. `ESLint` 실행 결과는 0 error / 0 warning입니다.
