### PR TITLE
[project] GitHub PR 보드 목록 엔드포인트 추가

### DIFF
--- a/cowork-project/src/main/kotlin/com/cowork/project/dto/GithubPullRequestBoardResDto.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/dto/GithubPullRequestBoardResDto.kt
@@ -1,0 +1,15 @@
+package com.cowork.project.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+/**
+ * 진행 중 PR 칸반 보드. upstream을 `state=open`으로 조회해 컬럼별로 그룹핑한다.
+ * 머지·종료 컬럼은 후속 과제(`state=all` 또는 별도 조회)로 확장한다.
+ */
+@Schema(description = "진행 중 PR 칸반 보드 (컬럼별 그룹핑)")
+data class GithubPullRequestBoardResDto(
+    @field:Schema(description = "Draft 컬럼 (draft == true)")
+    val draft: List<GithubPullRequestSummaryResDto>,
+    @field:Schema(description = "리뷰중 컬럼 (open 이면서 draft == false)")
+    val inReview: List<GithubPullRequestSummaryResDto>,
+)

--- a/cowork-project/src/main/kotlin/com/cowork/project/dto/GithubPullRequestSummaryResDto.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/dto/GithubPullRequestSummaryResDto.kt
@@ -1,0 +1,27 @@
+package com.cowork.project.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "GitHub PR 목록 요약 (보드 카드)")
+data class GithubPullRequestSummaryResDto(
+    @field:Schema(description = "PR 번호", example = "1")
+    val number: Int,
+    @field:Schema(description = "PR 제목", example = "feat: add login")
+    val title: String,
+    @field:Schema(description = "작성자 GitHub 사용자명", example = "octocat")
+    val author: String,
+    @field:Schema(description = "PR 상태", example = "open")
+    val state: String,
+    @field:Schema(description = "드래프트 여부")
+    val draft: Boolean,
+    @field:Schema(description = "머지 여부")
+    val merged: Boolean,
+    @field:Schema(description = "GitHub PR URL", example = "https://github.com/my-org/my-repo/pull/1")
+    val htmlUrl: String,
+    @field:Schema(description = "라벨 목록", example = "[\"bug\", \"enhancement\"]")
+    val labels: List<String>,
+    @field:Schema(description = "생성 시각(ISO-8601)", example = "2026-06-23T02:30:31Z")
+    val createdAt: String,
+    @field:Schema(description = "수정 시각(ISO-8601)", example = "2026-06-23T02:30:31Z")
+    val updatedAt: String,
+)

--- a/cowork-project/src/main/kotlin/com/cowork/project/github/GithubAppClient.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/github/GithubAppClient.kt
@@ -4,11 +4,13 @@ import com.cowork.project.dto.GithubApproveResultResDto
 import com.cowork.project.dto.GithubMergeResultResDto
 import com.cowork.project.dto.GithubPullRequestFileResDto
 import com.cowork.project.dto.GithubPullRequestResDto
+import com.cowork.project.dto.GithubPullRequestSummaryResDto
 import org.springframework.cloud.openfeign.FeignClient
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
 
 @FeignClient(
     name = "github-app",
@@ -16,6 +18,13 @@ import org.springframework.web.bind.annotation.RequestBody
     configuration = [GithubAppClientConfig::class],
 )
 interface GithubAppClient {
+
+    @GetMapping("/api/repos/{owner}/{repo}/pulls")
+    fun listPullRequests(
+        @PathVariable owner: String,
+        @PathVariable repo: String,
+        @RequestParam state: String,
+    ): List<GithubPullRequestSummaryResDto>
 
     @GetMapping("/api/repos/{owner}/{repo}/pulls/{number}")
     fun getPullRequest(

--- a/cowork-project/src/main/kotlin/com/cowork/project/github/GithubPullRequestBoardController.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/github/GithubPullRequestBoardController.kt
@@ -1,0 +1,41 @@
+package com.cowork.project.github
+
+import com.cowork.project.dto.GithubPullRequestBoardResDto
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Tag(name = "GitHub PR", description = "프로젝트에 연결된 GitHub 레포지토리의 PR 조회/머지/승인 API")
+@RestController
+@RequestMapping("/projects/{projectId}/github/pulls")
+class GithubPullRequestBoardController(
+    private val githubPullRequestService: GithubPullRequestService,
+) {
+
+    @Operation(
+        summary = "진행 중 PR 보드 조회",
+        description = "연결된 레포의 열린 PR을 Draft / 리뷰중 컬럼으로 그룹핑해 반환한다.",
+        security = [SecurityRequirement(name = "BearerAuth")],
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "조회 성공"),
+        ApiResponse(responseCode = "400", description = "연결된 GitHub 레포지토리 없음"),
+        ApiResponse(responseCode = "403", description = "팀 멤버 아님"),
+        ApiResponse(responseCode = "404", description = "프로젝트 없음"),
+        ApiResponse(responseCode = "502", description = "GitHub 연동 서버 통신 오류"),
+    )
+    @GetMapping
+    fun getBoard(
+        @Parameter(hidden = true) @RequestHeader("X-User-Id") userId: Long,
+        @PathVariable projectId: Long,
+    ): GithubPullRequestBoardResDto =
+        githubPullRequestService.getPullRequestBoard(userId, projectId)
+}

--- a/cowork-project/src/main/kotlin/com/cowork/project/github/GithubPullRequestService.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/github/GithubPullRequestService.kt
@@ -4,6 +4,7 @@ import com.cowork.project.client.UserClient
 import com.cowork.project.domain.Project
 import com.cowork.project.dto.GithubApproveResultResDto
 import com.cowork.project.dto.GithubMergeResultResDto
+import com.cowork.project.dto.GithubPullRequestBoardResDto
 import com.cowork.project.dto.GithubPullRequestFileResDto
 import com.cowork.project.dto.GithubPullRequestResDto
 import com.cowork.project.service.ProjectAccessGuard
@@ -22,6 +23,13 @@ class GithubPullRequestService(
     private val githubAppClient: GithubAppClient,
 ) {
     private val logger = LoggerFactory.getLogger(GithubPullRequestService::class.java)
+
+    fun getPullRequestBoard(userId: Long, projectId: Long): GithubPullRequestBoardResDto {
+        val repo = resolveRepoRefForRead(userId, projectId)
+        val pulls = callGithubApp { githubAppClient.listPullRequests(repo.owner, repo.repo, "open") }
+        val (draft, inReview) = pulls.partition { it.draft }
+        return GithubPullRequestBoardResDto(draft = draft, inReview = inReview)
+    }
 
     fun getPullRequestDetail(userId: Long, projectId: Long, prNumber: Int): GithubPullRequestResDto {
         val repo = resolveRepoRefForRead(userId, projectId)

--- a/cowork-project/src/test/kotlin/com/cowork/project/github/GithubPullRequestServiceTest.kt
+++ b/cowork-project/src/test/kotlin/com/cowork/project/github/GithubPullRequestServiceTest.kt
@@ -5,6 +5,7 @@ import com.cowork.project.client.UserProfileResDto
 import com.cowork.project.domain.Project
 import com.cowork.project.dto.GithubMergeResultResDto
 import com.cowork.project.dto.GithubPullRequestResDto
+import com.cowork.project.dto.GithubPullRequestSummaryResDto
 import com.cowork.project.service.ProjectAccessGuard
 import feign.FeignException
 import feign.Request
@@ -37,7 +38,58 @@ class GithubPullRequestServiceTest : DescribeSpec({
     fun project(githubRepoUrl: String? = "https://github.com/my-org/my-repo") =
         Project(id = 1L, teamId = 100L, name = "p", description = null, createdBy = 1L, githubRepoUrl = githubRepoUrl)
 
+    fun summary(number: Int, draft: Boolean) =
+        GithubPullRequestSummaryResDto(
+            number = number,
+            title = "pr-$number",
+            author = "octocat",
+            state = "open",
+            draft = draft,
+            merged = false,
+            htmlUrl = "https://github.com/my-org/my-repo/pull/$number",
+            labels = emptyList(),
+            createdAt = "2026-06-23T00:00:00Z",
+            updatedAt = "2026-06-23T00:00:00Z",
+        )
+
     describe("GithubPullRequestService 클래스의") {
+        describe("getPullRequestBoard 메서드는") {
+            context("팀 멤버인 경우") {
+                it("열린 PR을 draft/inReview 컬럼으로 분리한다") {
+                    val proj = project()
+                    every { projectAccessGuard.findProjectOrThrow(1L) } returns proj
+                    every { projectAccessGuard.requireTeamMember(100L, 7L) } just Runs
+                    every { githubAppClient.listPullRequests("my-org", "my-repo", "open") } returns
+                        listOf(summary(1, draft = true), summary(2, draft = false), summary(3, draft = false))
+
+                    val board = service.getPullRequestBoard(7L, 1L)
+
+                    board.draft.map { it.number } shouldBe listOf(1)
+                    board.inReview.map { it.number } shouldBe listOf(2, 3)
+                    verify { githubAppClient.listPullRequests("my-org", "my-repo", "open") }
+                }
+            }
+
+            context("githubAppClient 호출 중 네트워크 오류가 발생하는 경우") {
+                it("BAD_GATEWAY로 변환한다") {
+                    val proj = project()
+                    every { projectAccessGuard.findProjectOrThrow(1L) } returns proj
+                    every { projectAccessGuard.requireTeamMember(100L, 7L) } just Runs
+                    val networkError = FeignException.NotFound(
+                        "connect timed out",
+                        Request.create(Request.HttpMethod.GET, "/api/repos/my-org/my-repo/pulls", emptyMap(), null, RequestTemplate()),
+                        null,
+                        emptyMap(),
+                    )
+                    every { githubAppClient.listPullRequests("my-org", "my-repo", "open") } throws networkError
+
+                    val ex = shouldThrow<ExpectedException> { service.getPullRequestBoard(7L, 1L) }
+
+                    ex.statusCode shouldBe HttpStatus.BAD_GATEWAY
+                }
+            }
+        }
+
         describe("getPullRequestDetail 메서드는") {
             context("팀 멤버인 경우") {
                 it("githubAppClient를 호출해 PR 상세를 반환한다") {


### PR DESCRIPTION
## 개요

프로젝트에 연결된 GitHub 레포지토리의 진행 중 PR을 칸반 보드 형태로 조회하는 `GET /projects/{projectId}/github/pulls` 엔드포인트를 추가하였습니다. 열린 PR을 `Draft` / `리뷰중` 컬럼으로 그룹핑하여 반환하며, 카드 클릭 시 기존 단건 상세 API로 인앱 라우팅하는 흐름을 완성하였습니다.

## 본문

### 추가된 엔드포인트

- `GET /projects/{projectId}/github/pulls`
  - 권한: `requireTeamMember` (팀 멤버면 조회 가능, 기존 단건 조회와 동일 레벨)
  - upstream(`cowork-github-app`)을 `state=open`으로 호출한 뒤 `draft` 여부로 컬럼을 분리합니다.
  - `draft == true` → `draft` 컬럼 / `open` 이면서 `draft == false` → `inReview` 컬럼

### upstream 연동

- `cowork-github-app`에 신규 추가된 목록 API(`GET /api/repos/:owner/:repo/pulls`, )를 프록시합니다.
- 클라이언트는 `owner`/`repo`를 직접 보내지 않으며, 서버가 프로젝트의 `githubRepoUrl`을 파싱해 결정합니다(기존 보안 설계 유지).
- 컬럼 그룹핑은 소비자(`cowork-project`) 책임으로 두어, upstream은 단순 목록만 반환하도록 분리하였습니다.

### 변경 파일

- `dto/GithubPullRequestSummaryResDto.kt` (신규): upstream 요약 응답 매핑 (`number`, `title`, `author`, `state`, `draft`, `merged`, `htmlUrl`, `labels`, `createdAt`, `updatedAt`).
- `dto/GithubPullRequestBoardResDto.kt` (신규): 컬럼별 그룹핑 응답 (`draft`, `inReview`).
- `github/GithubAppClient.kt`: Feign 목록 메서드 `listPullRequests(owner, repo, state)`를 추가하였습니다.
- `github/GithubPullRequestService.kt`: `getPullRequestBoard` 메서드를 추가하고 `partition`으로 컬럼을 분리하였습니다.
- `github/GithubPullRequestBoardController.kt` (신규): 목록 경로(`.../pulls`)를 위한 컨트롤러를 추가하였습니다(기존 단건 컨트롤러는 base 경로가 `.../pulls/{prNumber}`라 분리).
- `github/GithubPullRequestServiceTest.kt`: 컬럼 그룹핑과 네트워크 오류 → `BAD_GATEWAY` 변환 테스트를 추가하였습니다.

### 검증

- 유닛 테스트 34개 전체 통과를 확인하였습니다.
- 스텁 upstream을 연결한 실행 컨테이너에서 라이브 스모크 테스트를 수행하여, 정상 조회(`200`, `draft`/`inReview` 그룹핑), 비멤버 접근 거부(`403`), 라우팅·게이트웨이 헤더·레포 파싱·`Feign` 호출(`state=open`)·`JSON` 직렬화가 모두 정상 동작함을 확인하였습니다.

### 후속 과제

- 머지·종료 컬럼은 `GithubPullRequestBoardResDto`에 필드 추가 + `state=all` 조회로 확장 가능하도록 구조를 열어 두었습니다.
- upstream 목록은 MVP 기준 단일 페이지(`per_page=100`)이며, 100개 초과 페이지네이션은 후속 과제입니다.
