### PR TITLE
[promotion] 포지션 설정 키 타입 보강

### DIFF
--- a/cowork-promotion/pages/index.vue
+++ b/cowork-promotion/pages/index.vue
@@ -158,9 +158,11 @@ const positionOrder = [
     "Mobile App Client",
     "Cloud",
     "Design",
-];
+] as const;
 
-const positionConfig: Record<string, { color: string; description: string }> = {
+type PositionName = (typeof positionOrder)[number];
+
+const positionConfig: Record<PositionName, { color: string; description: string }> = {
     Server: {
         color: "#8B5CF6",
         description:
@@ -207,7 +209,7 @@ const positionTechsMap = computed<Record<string, string[]>>(() => {
 });
 
 interface PositionGroup {
-    name: string;
+    name: PositionName;
     color: string;
     description: string;
     techs: string[];


### PR DESCRIPTION
## 개요

`cowork-promotion`의 포지션 설정 타입을 `positionOrder` 기반 리터럴 타입으로 좁혔습니다.
`positionConfig[name]` 접근 시 발생하던 `TS2532` 경고를 해결하였습니다.

## 본문

`positionOrder`에 `as const`를 적용하고 `PositionName` 타입을 추가하였습니다.
`positionConfig`를 `Record<PositionName, ...>`로 선언하여 설정 객체와 포지션 순서의 키 집합이 일치하도록 타입으로 보장하였습니다.
`PositionGroup.name`도 `PositionName`으로 변경하여 계산된 포지션 그룹에서 동일한 타입 흐름을 유지하였습니다.
