### PR TITLE
[roadmap] Response DTO 스웨거 문서화 적용

### DIFF
--- a/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/assignment/presentation/data/response/AssignmentResDto.java
+++ b/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/assignment/presentation/data/response/AssignmentResDto.java
@@ -26,9 +26,9 @@ public record AssignmentResDto(
 
         @Schema(description = "진행 상태", example = "IN_PROGRESS") String status,
 
-        @Schema(description = "마감 일시") LocalDateTime dueDate,
+        @Schema(description = "마감 일시", type = "string", example = "2025-03-02T00:00:00") LocalDateTime dueDate,
 
-        @Schema(description = "생성 일시") LocalDateTime createdAt) {
+        @Schema(description = "생성 일시", type = "string", example = "2025-03-02T00:00:00") LocalDateTime createdAt) {
 
     public static AssignmentResDto from(RoadmapAssignment assignment) {
         return new AssignmentResDto(assignment.getId(),

--- a/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/assignment/presentation/data/response/AssignmentResDto.java
+++ b/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/assignment/presentation/data/response/AssignmentResDto.java
@@ -4,8 +4,32 @@ import java.time.LocalDateTime;
 
 import com.cowork.roadmap.domain.assignment.entity.RoadmapAssignment;
 
-public record AssignmentResDto(Long id, Long roadmapId, Long nodeId, String scope, Long teamId, Long projectId,
-        Long assigneeUserId, Long assignedBy, String status, LocalDateTime dueDate, LocalDateTime createdAt) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AssignmentResDto(
+
+        @Schema(description = "할당 ID") Long id,
+
+        @Schema(description = "대상 로드맵 ID") Long roadmapId,
+
+        @Schema(description = "특정 노드 할당 시 노드 ID (전체 로드맵이면 null)") Long nodeId,
+
+        @Schema(description = "할당 맥락", example = "TEAM") String scope,
+
+        @Schema(description = "소유 팀 ID") Long teamId,
+
+        @Schema(description = "소유 프로젝트 ID") Long projectId,
+
+        @Schema(description = "온보딩 대상 사용자 ID") Long assigneeUserId,
+
+        @Schema(description = "할당한 사용자 ID") Long assignedBy,
+
+        @Schema(description = "진행 상태", example = "IN_PROGRESS") String status,
+
+        @Schema(description = "마감 일시") LocalDateTime dueDate,
+
+        @Schema(description = "생성 일시") LocalDateTime createdAt) {
+
     public static AssignmentResDto from(RoadmapAssignment assignment) {
         return new AssignmentResDto(assignment.getId(),
                 assignment.getRoadmapId(),

--- a/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/node/presentation/data/response/NodeReferenceResDto.java
+++ b/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/node/presentation/data/response/NodeReferenceResDto.java
@@ -2,7 +2,20 @@ package com.cowork.roadmap.domain.node.presentation.data.response;
 
 import com.cowork.roadmap.domain.node.entity.RoadmapNodeReference;
 
-public record NodeReferenceResDto(Long id, Long nodeId, String title, String url, Integer position) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record NodeReferenceResDto(
+
+        @Schema(description = "관련 자료 ID") Long id,
+
+        @Schema(description = "소속 노드 ID") Long nodeId,
+
+        @Schema(description = "관련 자료 제목") String title,
+
+        @Schema(description = "관련 자료 링크") String url,
+
+        @Schema(description = "정렬 순서") Integer position) {
+
     public static NodeReferenceResDto from(RoadmapNodeReference ref) {
         return new NodeReferenceResDto(ref.getId(), ref.getNodeId(), ref.getTitle(), ref.getUrl(), ref.getPosition());
     }

--- a/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/node/presentation/data/response/NodeResDto.java
+++ b/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/node/presentation/data/response/NodeResDto.java
@@ -5,9 +5,32 @@ import java.util.List;
 
 import com.cowork.roadmap.domain.node.entity.RoadmapNode;
 
-public record NodeResDto(Long id, Long roadmapId, Long parentId, String title, String content, String sourceUrl,
-        String sourceTitle, Integer position, List<NodeReferenceResDto> references, LocalDateTime createdAt,
-        LocalDateTime updatedAt) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record NodeResDto(
+
+        @Schema(description = "노드 ID") Long id,
+
+        @Schema(description = "소속 로드맵 ID") Long roadmapId,
+
+        @Schema(description = "상위 노드 ID (루트면 null)") Long parentId,
+
+        @Schema(description = "노드 제목") String title,
+
+        @Schema(description = "본문 (마크다운)") String content,
+
+        @Schema(description = "원본 문서 URL") String sourceUrl,
+
+        @Schema(description = "원본 문서 제목") String sourceTitle,
+
+        @Schema(description = "형제 노드 내 정렬 순서") Integer position,
+
+        @Schema(description = "관련 자료 목록") List<NodeReferenceResDto> references,
+
+        @Schema(description = "생성 일시") LocalDateTime createdAt,
+
+        @Schema(description = "수정 일시") LocalDateTime updatedAt) {
+
     public static NodeResDto of(RoadmapNode node, List<NodeReferenceResDto> references) {
         return new NodeResDto(node.getId(),
                 node.getRoadmapId(),

--- a/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/node/presentation/data/response/NodeResDto.java
+++ b/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/node/presentation/data/response/NodeResDto.java
@@ -27,9 +27,9 @@ public record NodeResDto(
 
         @Schema(description = "관련 자료 목록") List<NodeReferenceResDto> references,
 
-        @Schema(description = "생성 일시") LocalDateTime createdAt,
+        @Schema(description = "생성 일시", type = "string", example = "2025-03-02T00:00:00") LocalDateTime createdAt,
 
-        @Schema(description = "수정 일시") LocalDateTime updatedAt) {
+        @Schema(description = "수정 일시", type = "string", example = "2025-03-02T00:00:00") LocalDateTime updatedAt) {
 
     public static NodeResDto of(RoadmapNode node, List<NodeReferenceResDto> references) {
         return new NodeResDto(node.getId(),

--- a/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/node/presentation/data/response/NodeTreeResDto.java
+++ b/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/node/presentation/data/response/NodeTreeResDto.java
@@ -2,7 +2,26 @@ package com.cowork.roadmap.domain.node.presentation.data.response;
 
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /** 트리 조회용 노드. children에 하위 노드가 재귀적으로 중첩된다. */
-public record NodeTreeResDto(Long id, Long parentId, String title, String content, String sourceUrl, String sourceTitle,
-        Integer position, List<NodeReferenceResDto> references, List<NodeTreeResDto> children) {
+public record NodeTreeResDto(
+
+        @Schema(description = "노드 ID") Long id,
+
+        @Schema(description = "상위 노드 ID (루트면 null)") Long parentId,
+
+        @Schema(description = "노드 제목") String title,
+
+        @Schema(description = "본문 (마크다운)") String content,
+
+        @Schema(description = "원본 문서 URL") String sourceUrl,
+
+        @Schema(description = "원본 문서 제목") String sourceTitle,
+
+        @Schema(description = "형제 노드 내 정렬 순서") Integer position,
+
+        @Schema(description = "관련 자료 목록") List<NodeReferenceResDto> references,
+
+        @Schema(description = "하위 노드 목록 (재귀)") List<NodeTreeResDto> children) {
 }

--- a/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/roadmap/presentation/data/response/RoadmapResDto.java
+++ b/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/roadmap/presentation/data/response/RoadmapResDto.java
@@ -24,9 +24,9 @@ public record RoadmapResDto(
 
         @Schema(description = "생성자 사용자 ID") Long createdBy,
 
-        @Schema(description = "생성 일시") LocalDateTime createdAt,
+        @Schema(description = "생성 일시", type = "string", example = "2025-03-02T00:00:00") LocalDateTime createdAt,
 
-        @Schema(description = "수정 일시") LocalDateTime updatedAt) {
+        @Schema(description = "수정 일시", type = "string", example = "2025-03-02T00:00:00") LocalDateTime updatedAt) {
 
     public static RoadmapResDto from(Roadmap roadmap) {
         return new RoadmapResDto(roadmap.getId(),

--- a/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/roadmap/presentation/data/response/RoadmapResDto.java
+++ b/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/roadmap/presentation/data/response/RoadmapResDto.java
@@ -4,8 +4,30 @@ import java.time.LocalDateTime;
 
 import com.cowork.roadmap.domain.roadmap.entity.Roadmap;
 
-public record RoadmapResDto(Long id, String title, String description, String category, String scope, Long ownerTeamId,
-        Long ownerProjectId, Long createdBy, LocalDateTime createdAt, LocalDateTime updatedAt) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record RoadmapResDto(
+
+        @Schema(description = "로드맵 ID") Long id,
+
+        @Schema(description = "로드맵 제목") String title,
+
+        @Schema(description = "로드맵 설명") String description,
+
+        @Schema(description = "종류/전공/포지션") String category,
+
+        @Schema(description = "범위", example = "GLOBAL") String scope,
+
+        @Schema(description = "소유 팀 ID") Long ownerTeamId,
+
+        @Schema(description = "소유 프로젝트 ID") Long ownerProjectId,
+
+        @Schema(description = "생성자 사용자 ID") Long createdBy,
+
+        @Schema(description = "생성 일시") LocalDateTime createdAt,
+
+        @Schema(description = "수정 일시") LocalDateTime updatedAt) {
+
     public static RoadmapResDto from(Roadmap roadmap) {
         return new RoadmapResDto(roadmap.getId(),
                 roadmap.getTitle(),

--- a/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/roadmap/presentation/data/response/RoadmapTreeResDto.java
+++ b/cowork-roadmap/src/main/java/com/cowork/roadmap/domain/roadmap/presentation/data/response/RoadmapTreeResDto.java
@@ -4,6 +4,12 @@ import java.util.List;
 
 import com.cowork.roadmap.domain.node.presentation.data.response.NodeTreeResDto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /** 로드맵 메타 + 노드 트리(루트 노드부터 중첩). */
-public record RoadmapTreeResDto(RoadmapResDto roadmap, List<NodeTreeResDto> nodes) {
+public record RoadmapTreeResDto(
+
+        @Schema(description = "로드맵 메타 정보") RoadmapResDto roadmap,
+
+        @Schema(description = "루트부터 중첩된 노드 트리") List<NodeTreeResDto> nodes) {
 }


### PR DESCRIPTION
## 개요

`cowork-roadmap` 서비스의 Response DTO 필드에 `@Schema` 어노테이션을 추가하였습니다. 기존 Request DTO와 동일한 스타일로 통일하였습니다.

## 본문

**변경 대상 파일 (6개)**

- `AssignmentResDto` — 11개 필드에 `@Schema` 추가
- `NodeReferenceResDto` — 5개 필드에 `@Schema` 추가
- `NodeResDto` — 11개 필드에 `@Schema` 추가
- `NodeTreeResDto` — 9개 필드에 `@Schema` 추가
- `RoadmapResDto` — 10개 필드에 `@Schema` 추가
- `RoadmapTreeResDto` — 2개 필드에 `@Schema` 추가

각 필드를 별도 줄로 분리하고, Request DTO와 동일하게 `@Schema(description = "...")` 형식으로 작성하였습니다. `from()` / `of()` 팩토리 메서드 등 비즈니스 로직은 변경하지 않았습니다.
