### PR TITLE
[global] hook 설정 스키마 수정

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -2,12 +2,22 @@
   "hooks": {
     "PreToolUse": [
       {
-        "command": ".codex/hooks/pre-tool-use.sh"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'root=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; hook=\"$root/.codex/hooks/pre-tool-use.sh\"; if [[ ! -f \"$hook\" ]]; then hook=\"$root/.codex/hooks/dispatcher/pre-tool-use.sh\"; fi; if [[ -f \"$hook\" ]]; then exec bash \"$hook\"; fi; exit 0'"
+          }
+        ]
       }
     ],
     "PostToolUse": [
       {
-        "command": ".codex/hooks/post-tool-use.sh"
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'root=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; hook=\"$root/.codex/hooks/post-tool-use.sh\"; if [[ ! -f \"$hook\" ]]; then hook=\"$root/.codex/hooks/dispatcher/post-tool-use.sh\"; fi; if [[ -f \"$hook\" ]]; then exec bash \"$hook\"; fi; exit 0'"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
## 개요

`Codex` hook 설정을 공식 hook 스키마에 맞게 수정하였습니다.
hook dispatcher가 없는 동기화 조합에서도 실패하지 않도록 no-op fallback을 포함하였습니다.

## 본문

- `.codex/hooks.json`의 `PreToolUse`, `PostToolUse` 항목을 `hooks[].type = "command"` 구조로 변경하였습니다.
- `.codex/hooks/pre-tool-use.sh`와 `.codex/hooks/dispatcher/pre-tool-use.sh` 경로를 모두 지원하도록 처리하였습니다.
- hook 파일이 없는 경우 `exit 0`으로 종료하여 다른 프로젝트 동기화 조합에서도 실패하지 않도록 하였습니다.
- 샘플 `Bash` payload로 logging hook 실행을 검증하였습니다.
