### PR TITLE
[global] Gradle Wrapper 9.6.0 갱신

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=60000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## 개요

`Gradle Wrapper` 배포 버전을 `9.5.1`에서 `9.6.0`으로 갱신하였습니다.

## 본문

`gradle/wrapper/gradle-wrapper.properties`의 `distributionUrl`을 `Gradle 9.6.0` 배포본으로 변경하였습니다.

`./gradlew --version`으로 `Gradle 9.6.0` 실행을 확인하였습니다.
