### PR TITLE
[chat] HTTP 클라이언트 일시 장애 재시도 추가

### DIFF
--- a/cowork-chat/src/chat/service/base-http-client.ts
+++ b/cowork-chat/src/chat/service/base-http-client.ts
@@ -11,6 +11,45 @@ export abstract class BaseHttpClient {
     protected abstract readonly serviceName: string;
 
     /**
+     * 일시적 장애(5xx, 네트워크 오류, 타임아웃)에 대해 exponential backoff 재시도를 수행하며 fetch를 실행한다.
+     *
+     * - 4xx 응답은 확정적 에러로 간주해 재시도하지 않고 즉시 반환한다.
+     * - 5xx 응답 또는 네트워크/타임아웃 에러는 `maxRetries`회까지 재시도한다.
+     * - 대기 시간: 1차 100ms, 2차 200ms, … (100ms × 2^(attempt-1))
+     * - 매 시도마다 `AbortSignal.timeout(timeoutMs)`를 새로 생성하므로 타임아웃이 정확히 적용된다.
+     *
+     * @param url - 요청 대상 URL
+     * @param init - fetch RequestInit (signal 제외)
+     * @param timeoutMs - 단일 시도의 타임아웃(ms)
+     * @param maxRetries - 최대 재시도 횟수 (기본 2 → 최대 3회 시도)
+     * @returns fetch Response
+     * @throws 마지막 시도에서도 네트워크/타임아웃 에러가 발생한 경우
+     */
+    protected async fetchWithRetry(
+        url: string,
+        init: Omit<RequestInit, 'signal'>,
+        timeoutMs: number,
+        maxRetries = 2,
+    ): Promise<Response> {
+        for (let attempt = 0; attempt <= maxRetries; attempt++) {
+            if (attempt > 0) {
+                await new Promise<void>((resolve) => setTimeout(resolve, 100 * 2 ** (attempt - 1)));
+                this.logger.warn(`${this.serviceName} 재시도 ${attempt}/${maxRetries}`);
+            }
+            let res: Response;
+            try {
+                res = await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+            } catch (err) {
+                if (attempt === maxRetries) throw err;
+                continue;
+            }
+            if (res.status >= 500 && attempt < maxRetries) continue;
+            return res;
+        }
+        throw new Error(`${this.serviceName} fetchWithRetry: unreachable`);
+    }
+
+    /**
      * HTTP 오류 응답의 본문을 문자열로 읽는다.
      *
      * 응답 본문 읽기에 실패하더라도 예외를 던지지 않고 `null`을 반환한다.

--- a/cowork-chat/src/chat/service/base-http-client.ts
+++ b/cowork-chat/src/chat/service/base-http-client.ts
@@ -43,7 +43,10 @@ export abstract class BaseHttpClient {
                 if (attempt === maxRetries) throw err;
                 continue;
             }
-            if (res.status >= 500 && attempt < maxRetries) continue;
+            if (res.status >= 500 && attempt < maxRetries) {
+                void res.body?.cancel().catch((err) => this.logger.warn(`${this.serviceName} response body cancel 실패: ${String(err)}`));
+                continue;
+            }
             return res;
         }
         throw new Error(`${this.serviceName} fetchWithRetry: unreachable`);

--- a/cowork-chat/src/chat/service/channel.client.ts
+++ b/cowork-chat/src/chat/service/channel.client.ts
@@ -43,10 +43,11 @@ export class ChannelClient extends BaseHttpClient {
      * @throws {Error} 응답 본문의 형식이 올바르지 않은 경우
      */
     async getChannel(channelId: number, userId: number): Promise<ChannelInfo> {
-        const res = await fetch(`${this.channelServiceUrl}/channels/${channelId}`, {
-            headers: { 'X-User-Id': String(userId) },
-            signal: AbortSignal.timeout(3000),
-        });
+        const res = await this.fetchWithRetry(
+            `${this.channelServiceUrl}/channels/${channelId}`,
+            { headers: { 'X-User-Id': String(userId) } },
+            3000,
+        );
 
         if (!res.ok) {
             const message = await this.readErrorMessage(res);

--- a/cowork-chat/src/chat/service/project.client.ts
+++ b/cowork-chat/src/chat/service/project.client.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { getRequiredConfig } from '../../common/config/config.util';
+import { BaseHttpClient } from './base-http-client';
 
 /**
  * GitHub 저장소 연동 정보.
@@ -18,11 +19,13 @@ export interface GithubRepoInfo {
  * 말미 슬래시는 자동으로 제거된다.
  */
 @Injectable()
-export class ProjectClient {
-    private readonly logger = new Logger(ProjectClient.name);
+export class ProjectClient extends BaseHttpClient {
+    protected readonly logger = new Logger(ProjectClient.name);
+    protected readonly serviceName = 'project-service';
     private readonly projectServiceUrl: string;
 
     constructor(private readonly configService: ConfigService) {
+        super();
         this.projectServiceUrl = getRequiredConfig(this.configService, 'PROJECT_SERVICE_URL').replace(/\/$/, '');
     }
 
@@ -40,14 +43,12 @@ export class ProjectClient {
      */
     async getGithubRepoInfo(projectId: number): Promise<GithubRepoInfo | null> {
         try {
-            const res = await fetch(`${this.projectServiceUrl}/projects/${projectId}`, {
-                signal: AbortSignal.timeout(5000),
-            });
+            const res = await this.fetchWithRetry(`${this.projectServiceUrl}/projects/${projectId}`, {}, 5000);
             if (res.status === 404) return null;
             if (!res.ok) {
                 throw new Error(`프로젝트 서비스 응답 오류: ${res.status}`);
             }
-            const body = await res.json() as { teamId?: number | null; githubRepoUrl?: string | null };
+            const body = await this.readJsonBody<{ teamId?: number | null; githubRepoUrl?: string | null }>(res);
             const repoInfo = this.parseRepoUrl(body.githubRepoUrl);
             if (!repoInfo || typeof body.teamId !== 'number') return null;
             return { teamId: body.teamId, ...repoInfo };
@@ -71,10 +72,11 @@ export class ProjectClient {
      */
     async isMember(projectId: number, userId: number): Promise<boolean> {
         try {
-            const res = await fetch(`${this.projectServiceUrl}/projects/${projectId}/members/me`, {
-                headers: { 'X-User-Id': String(userId) },
-                signal: AbortSignal.timeout(3000),
-            });
+            const res = await this.fetchWithRetry(
+                `${this.projectServiceUrl}/projects/${projectId}/members/me`,
+                { headers: { 'X-User-Id': String(userId) } },
+                3000,
+            );
             if (res.status === 404) return false;
             if (!res.ok) throw new Error(`project-service 오류: ${res.status}`);
             return true;

--- a/cowork-chat/src/chat/service/user.client.ts
+++ b/cowork-chat/src/chat/service/user.client.ts
@@ -35,9 +35,7 @@ export class UserClient extends BaseHttpClient {
     async getDisplayNames(userIds: number[]): Promise<Map<number, string>> {
         if (userIds.length === 0) return new Map();
 
-        const res = await fetch(`${this.userServiceUrl}/users/batch?ids=${userIds.join(',')}`, {
-            signal: AbortSignal.timeout(3000),
-        });
+        const res = await this.fetchWithRetry(`${this.userServiceUrl}/users/batch?ids=${userIds.join(',')}`, {}, 3000);
 
         if (!res.ok) {
             const message = await this.readErrorMessage(res);


### PR DESCRIPTION
## 개요

`cowork-chat`의 마이크로서비스 HTTP 클라이언트에서 일시적 장애(5xx, 네트워크 오류, 타임아웃) 발생 시 즉시 실패하던 문제를 개선하였습니다. `BaseHttpClient`에 `fetchWithRetry` 메서드를 추가하고, `ProjectClient`를 `BaseHttpClient` 상속으로 통일하였습니다.

## 본문

### 문제

`UserClient`, `ChannelClient`, `ProjectClient` 모두 단순 `fetch` 호출만 수행하여 일시적인 5xx 응답이나 네트워크 오류 발생 시 바로 예외를 던졌습니다. 서비스가 일시적으로 불안정한 상황에서도 사용자에게 에러가 노출되는 문제가 있었습니다.

또한 `ProjectClient`는 `BaseHttpClient`를 상속하지 않아 `readJsonBody`, `readErrorMessage` 유틸리티를 사용하지 못하고 `res.json()`을 직접 호출하는 등 일관성이 없었습니다.

### 변경 내용

**`BaseHttpClient` — `fetchWithRetry` 추가**

- 5xx 응답 또는 네트워크/타임아웃 에러에 한해 최대 2회 재시도 (총 3회 시도)
- 4xx 응답은 확정적 에러로 간주해 즉시 반환 (재시도 없음)
- 대기 시간: 1차 100ms, 2차 200ms (100ms × 2^(attempt-1), exponential backoff)
- 매 시도마다 `AbortSignal.timeout(timeoutMs)`를 새로 생성하여 타임아웃이 정확히 적용됨

```ts
protected async fetchWithRetry(
    url: string,
    init: Omit<RequestInit, 'signal'>,
    timeoutMs: number,
    maxRetries = 2,
): Promise<Response>
```

**`ProjectClient` — `BaseHttpClient` 상속으로 통일**

- `extends BaseHttpClient` 추가, `logger` private → protected, `serviceName` 필드 추가
- `res.json()` 직접 호출 → `this.readJsonBody()` 로 교체 (파싱 에러 처리 일관화)
- `fetchWithRetry` 적용으로 재시도 자동 적용

**`UserClient`, `ChannelClient`**

- 기존 `fetch(..., { signal: AbortSignal.timeout(N) })` → `this.fetchWithRetry(url, init, N)` 로 교체
