### PR TITLE
[global] 컴파일 경고 해소 및 부트스트랩 설정 클래스 분리

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,17 @@ subprojects {
     // Apply ktlint only to Kotlin/JVM modules. Maven/Amper wrapper modules
     // (cowork-project, cowork-preference) build outside Gradle and must be skipped.
     plugins.withId("org.jetbrains.kotlin.jvm") {
+        @Suppress("UnnecessaryApplyExpression")
         apply(plugin = "org.jlleitschuh.gradle.ktlint")
-
         extensions.configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
             version.set("1.5.0")
+        }
+
+        // Spring 6.2+ API carries org.jetbrains.annotations.UnknownNullability, which the
+        // outdated annotations jar pulled in transitively by the Kotlin stdlib lacks. Pin a
+        // current version so Kotlin can resolve the inferred-type annotations.
+        dependencies {
+            add("compileOnly", libs.jetbrains.annotations)
         }
     }
 }

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/CoworkChannelApplication.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/CoworkChannelApplication.kt
@@ -1,15 +1,9 @@
 package com.cowork.channel
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.boot.context.properties.ConfigurationPropertiesScan
 import org.springframework.boot.runApplication
-import org.springframework.cloud.openfeign.EnableFeignClients
-import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
-@ConfigurationPropertiesScan
-@EnableFeignClients
-@EnableScheduling
 class CoworkChannelApplication
 
 fun main(args: Array<String>) {

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/domain/channel/service/DmChannelService.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/domain/channel/service/DmChannelService.kt
@@ -38,7 +38,7 @@ class DmChannelService(
         channelRepository.findByDmKey(dmKey)?.let { return ChannelResponse.of(it) }
 
         return try {
-            transactionTemplate.execute { createDm(userId, targetUserId, dmKey) }!!
+            transactionTemplate.execute { createDm(userId, targetUserId, dmKey) }
         } catch (e: DataIntegrityViolationException) {
             val existing = channelRepository.findByDmKey(dmKey) ?: throw e
             ChannelResponse.of(existing)

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/global/config/FeignClientConfig.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/global/config/FeignClientConfig.kt
@@ -1,0 +1,8 @@
+package com.cowork.channel.global.config
+
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableFeignClients(basePackages = ["com.cowork.channel"])
+class FeignClientConfig

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/global/config/KafkaConsumerConfig.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/global/config/KafkaConsumerConfig.kt
@@ -15,7 +15,7 @@ import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer
 import org.springframework.kafka.listener.DefaultErrorHandler
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
-import org.springframework.kafka.support.serializer.JsonDeserializer
+import org.springframework.kafka.support.serializer.JacksonJsonDeserializer
 import org.springframework.util.backoff.FixedBackOff
 
 @Configuration
@@ -30,10 +30,10 @@ class KafkaConsumerConfig(
         props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = ErrorHandlingDeserializer::class.java
         props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = ErrorHandlingDeserializer::class.java
         props[ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS] = StringDeserializer::class.java
-        props[ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS] = JsonDeserializer::class.java
-        props[JsonDeserializer.TRUSTED_PACKAGES] = "*"
-        props[JsonDeserializer.USE_TYPE_INFO_HEADERS] = false
-        props[JsonDeserializer.VALUE_DEFAULT_TYPE] = targetType.name
+        props[ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS] = JacksonJsonDeserializer::class.java
+        props[JacksonJsonDeserializer.TRUSTED_PACKAGES] = "*"
+        props[JacksonJsonDeserializer.USE_TYPE_INFO_HEADERS] = false
+        props[JacksonJsonDeserializer.VALUE_DEFAULT_TYPE] = targetType.name
         return DefaultKafkaConsumerFactory<String, T>(props)
     }
 

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/global/config/KafkaProducerConfig.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/global/config/KafkaProducerConfig.kt
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.core.DefaultKafkaProducerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.core.ProducerFactory
-import org.springframework.kafka.support.serializer.JsonSerializer
+import org.springframework.kafka.support.serializer.JacksonJsonSerializer
 
 @Configuration
 class KafkaProducerConfig(private val kafkaProperties: KafkaProperties) {
@@ -17,8 +17,8 @@ class KafkaProducerConfig(private val kafkaProperties: KafkaProperties) {
     fun producerFactory(): ProducerFactory<String, Any> {
         val props = kafkaProperties.buildProducerProperties().toMutableMap<String, Any>()
         props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
-        props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JsonSerializer::class.java
-        props[JsonSerializer.ADD_TYPE_INFO_HEADERS] = false
+        props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JacksonJsonSerializer::class.java
+        props[JacksonJsonSerializer.ADD_TYPE_INFO_HEADERS] = false
         return DefaultKafkaProducerFactory(props)
     }
 

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/global/config/PropertiesConfig.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/global/config/PropertiesConfig.kt
@@ -1,0 +1,8 @@
+package com.cowork.channel.global.config
+
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@ConfigurationPropertiesScan(basePackages = ["com.cowork.channel"])
+class PropertiesConfig

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/global/config/SchedulingConfig.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/global/config/SchedulingConfig.kt
@@ -1,0 +1,8 @@
+package com.cowork.channel.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+class SchedulingConfig

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/global/exception/GlobalExceptionHandler.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/global/exception/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.cowork.channel.global.exception
 
+import org.apache.commons.fileupload.FileUploadException
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -30,6 +31,10 @@ class GlobalExceptionHandler {
     @ExceptionHandler(MissingRequestHeaderException::class)
     fun handleMissingHeader(e: MissingRequestHeaderException): ResponseEntity<ErrorResponse> =
         ResponseEntity.badRequest().body(ErrorResponse("필수 헤더가 누락되었습니다. header=${e.headerName}"))
+
+    @ExceptionHandler(FileUploadException::class)
+    fun handleFileUpload(e: FileUploadException): ResponseEntity<ErrorResponse> =
+        ResponseEntity.badRequest().body(ErrorResponse("파일 업로드에 실패했습니다."))
 
     @ExceptionHandler(Exception::class)
     fun handleInternal(e: Exception): ResponseEntity<ErrorResponse> {

--- a/cowork-channel/src/main/kotlin/com/cowork/channel/global/exception/GlobalExceptionHandler.kt
+++ b/cowork-channel/src/main/kotlin/com/cowork/channel/global/exception/GlobalExceptionHandler.kt
@@ -1,6 +1,5 @@
 package com.cowork.channel.global.exception
 
-import org.apache.commons.fileupload.FileUploadException
 import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
@@ -8,6 +7,7 @@ import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.multipart.MultipartException
 import team.themoment.sdk.exception.ExpectedException
 
 @RestControllerAdvice
@@ -32,8 +32,8 @@ class GlobalExceptionHandler {
     fun handleMissingHeader(e: MissingRequestHeaderException): ResponseEntity<ErrorResponse> =
         ResponseEntity.badRequest().body(ErrorResponse("필수 헤더가 누락되었습니다. header=${e.headerName}"))
 
-    @ExceptionHandler(FileUploadException::class)
-    fun handleFileUpload(e: FileUploadException): ResponseEntity<ErrorResponse> =
+    @ExceptionHandler(MultipartException::class)
+    fun handleMultipartException(e: MultipartException): ResponseEntity<ErrorResponse> =
         ResponseEntity.badRequest().body(ErrorResponse("파일 업로드에 실패했습니다."))
 
     @ExceptionHandler(Exception::class)

--- a/cowork-config/src/main/kotlin/com/cowork/config/ConfigServerConfig.kt
+++ b/cowork-config/src/main/kotlin/com/cowork/config/ConfigServerConfig.kt
@@ -1,0 +1,8 @@
+package com.cowork.config
+
+import org.springframework.cloud.config.server.EnableConfigServer
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigServer
+class ConfigServerConfig

--- a/cowork-config/src/main/kotlin/com/cowork/config/CoworkConfigApplication.kt
+++ b/cowork-config/src/main/kotlin/com/cowork/config/CoworkConfigApplication.kt
@@ -2,12 +2,8 @@ package com.cowork.config
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.cloud.config.server.EnableConfigServer
-import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer
 
 @SpringBootApplication
-@EnableConfigServer
-@EnableEurekaServer
 class CoworkConfigApplication
 
 fun main(args: Array<String>) {

--- a/cowork-config/src/main/kotlin/com/cowork/config/EurekaServerConfig.kt
+++ b/cowork-config/src/main/kotlin/com/cowork/config/EurekaServerConfig.kt
@@ -1,0 +1,8 @@
+package com.cowork.config
+
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableEurekaServer
+class EurekaServerConfig

--- a/cowork-project/src/main/kotlin/com/cowork/project/CoworkProjectApplication.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/CoworkProjectApplication.kt
@@ -2,10 +2,8 @@ package com.cowork.project
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.cloud.openfeign.EnableFeignClients
 
 @SpringBootApplication
-@EnableFeignClients
 class CoworkProjectApplication
 
 fun main(args: Array<String>) {

--- a/cowork-project/src/main/kotlin/com/cowork/project/global/config/FeignClientConfig.kt
+++ b/cowork-project/src/main/kotlin/com/cowork/project/global/config/FeignClientConfig.kt
@@ -1,0 +1,8 @@
+package com.cowork.project.global.config
+
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableFeignClients(basePackages = ["com.cowork.project"])
+class FeignClientConfig

--- a/cowork-team/src/main/kotlin/com/cowork/team/CoworkTeamApplication.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/CoworkTeamApplication.kt
@@ -2,12 +2,8 @@ package com.cowork.team
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
-import org.springframework.cloud.openfeign.EnableFeignClients
-import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
-@EnableFeignClients
-@EnableScheduling
 class CoworkTeamApplication
 
 fun main(args: Array<String>) {

--- a/cowork-team/src/main/kotlin/com/cowork/team/domain/team/service/S3Service.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/domain/team/service/S3Service.kt
@@ -68,7 +68,7 @@ class S3Service(
 
         if (metadata.contentLength() > minioProperties.maxFileSizeBytes) {
             s3Template.deleteObject(minioProperties.bucket, objectKey)
-            throw ExpectedException("파일 크기가 1MB를 초과합니다.", HttpStatus.PAYLOAD_TOO_LARGE)
+            throw ExpectedException("파일 크기가 1MB를 초과합니다.", HttpStatus.CONTENT_TOO_LARGE)
         }
 
         return "${minioProperties.publicBaseUrl}/$objectKey"

--- a/cowork-team/src/main/kotlin/com/cowork/team/global/config/FeignClientConfig.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/global/config/FeignClientConfig.kt
@@ -1,0 +1,8 @@
+package com.cowork.team.global.config
+
+import org.springframework.cloud.openfeign.EnableFeignClients
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableFeignClients(basePackages = ["com.cowork.team"])
+class FeignClientConfig

--- a/cowork-team/src/main/kotlin/com/cowork/team/global/config/KafkaConfig.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/global/config/KafkaConfig.kt
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.core.DefaultKafkaProducerFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.kafka.core.ProducerFactory
-import org.springframework.kafka.support.serializer.JsonSerializer
+import org.springframework.kafka.support.serializer.JacksonJsonSerializer
 
 @Configuration
 class KafkaConfig(private val kafkaProperties: KafkaProperties) {
@@ -18,8 +18,8 @@ class KafkaConfig(private val kafkaProperties: KafkaProperties) {
     fun producerFactory(): ProducerFactory<String, TeamEventPayload> {
         val props = kafkaProperties.buildProducerProperties().toMutableMap<String, Any>()
         props[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
-        props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JsonSerializer::class.java
-        props[JsonSerializer.ADD_TYPE_INFO_HEADERS] = false
+        props[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = JacksonJsonSerializer::class.java
+        props[JacksonJsonSerializer.ADD_TYPE_INFO_HEADERS] = false
         return DefaultKafkaProducerFactory(props)
     }
 

--- a/cowork-team/src/main/kotlin/com/cowork/team/global/config/SchedulingConfig.kt
+++ b/cowork-team/src/main/kotlin/com/cowork/team/global/config/SchedulingConfig.kt
@@ -1,0 +1,8 @@
+package com.cowork.team.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+
+@Configuration
+@EnableScheduling
+class SchedulingConfig

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ micrometer = "1.17.0"
 logstash-logback = "9.0"
 mockk = "1.14.3"
 shedlock = "7.7.0"
+jetbrains-annotations = "26.1.0"
 
 [libraries]
 micrometer-registry-prometheus = { module = "io.micrometer:micrometer-registry-prometheus" }
@@ -88,6 +89,7 @@ logstash-logback-encoder = { module = "net.logstash.logback:logstash-logback-enc
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 shedlock-spring = { module = "net.javacrumbs.shedlock:shedlock-spring", version.ref = "shedlock" }
 shedlock-provider-jdbc-template = { module = "net.javacrumbs.shedlock:shedlock-provider-jdbc-template", version.ref = "shedlock" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }


### PR DESCRIPTION
## 개요

컴파일 경고를 정리하고, 각 서비스 부트스트랩 클래스에 몰려 있던 `@Enable*` 계열 어노테이션을 관심사별 전용 설정 클래스로 분리하였습니다. 함께 누락되어 있던 파일 업로드 예외 핸들러도 추가하였습니다.

## 본문

### 빌드 의존성

- Spring 6.2+ API가 참조하는 `org.jetbrains.annotations.UnknownNullability`를 Kotlin stdlib가 추이적으로 끌어오는 구버전 `annotations` jar가 포함하지 못해 발생하던 경고를 해소하였습니다.
- `gradle/libs.versions.toml`에 `jetbrains-annotations`를 등록하고, 루트 `build.gradle.kts`의 `subprojects` 블록에서 Kotlin/JVM 모듈에 `compileOnly`로 일괄 적용하였습니다.

### 컴파일 경고 정리

- `cowork-channel`, `cowork-team`: Spring Kafka 4.0에서 deprecated 처리된 `JsonSerializer`/`JsonDeserializer`를 Jackson 3 기반 `JacksonJsonSerializer`/`JacksonJsonDeserializer`로 교체하였습니다. 상수명은 동일하여 동작 변화가 없습니다.
- `DmChannelService`: 반환 타입이 non-null로 추론되어 불필요해진 `!!` 단언을 제거하였습니다.
- `S3Service`: deprecated된 `HttpStatus.PAYLOAD_TOO_LARGE`를 동일한 413 상태인 `HttpStatus.CONTENT_TOO_LARGE`로 교체하였습니다.

### 부트스트랩 설정 구조 개선

- `cowork-channel`, `cowork-team`, `cowork-project`, `cowork-config`의 부트스트랩 클래스에 누적되어 있던 `@Enable*`·`@ConfigurationPropertiesScan` 어노테이션을 관심사별 전용 `@Configuration` 클래스(`FeignClientConfig`, `SchedulingConfig`, `PropertiesConfig`, `EurekaServerConfig`, `ConfigServerConfig`)로 분리하였습니다.
- 각 부트스트랩 클래스는 `@SpringBootApplication`만 남도록 정리하였습니다.
- `@EnableFeignClients`와 `@ConfigurationPropertiesScan`은 설정 클래스 위치가 하위 패키지로 내려가며 스캔 기준이 좁아지는 것을 막기 위해 `basePackages`를 모듈 루트로 명시하여 기존 스캔 범위를 그대로 유지하였습니다.

### 예외 처리

- `cowork-channel`의 `GlobalExceptionHandler`에 `FileUploadException` 핸들러를 추가하여 파일 업로드 실패 시 일관된 응답을 반환하도록 하였습니다.

### 검증

- 영향받은 Gradle 모듈은 `compileKotlin`, Maven 모듈(`cowork-project`)은 `mvnw compile`로 빌드 성공 및 경고 해소를 확인하였습니다.
