### PR TITLE
[chat] 전체 로거 메시지 영문 표준화

### DIFF
--- a/cowork-chat/src/block/block.redis.ts
+++ b/cowork-chat/src/block/block.redis.ts
@@ -18,7 +18,7 @@ export class BlockRedis implements OnModuleInit, OnModuleDestroy {
 
         this.client = new Redis({ host, port, lazyConnect: true });
         void this.client.connect().catch((err: unknown) => {
-            this.logger.warn(`Redis 초기 연결 실패: ${err instanceof Error ? err.message : String(err)}`);
+            this.logger.warn(`Redis initial connection failed: ${err instanceof Error ? err.message : String(err)}`);
         });
     }
 

--- a/cowork-chat/src/chat/chat.gateway.ts
+++ b/cowork-chat/src/chat/chat.gateway.ts
@@ -98,10 +98,10 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
             client.data.userId = userId;
             client.data.userRole = payload.role ?? UserRole.USER;
             this.joinRoom(client, `user:${userId}`);
-            this.logger.log(`연결됨: ${client.id} (userId=${userId})`);
+            this.logger.log(`Connected: ${client.id} (userId=${userId})`);
         } catch (err) {
             const message = err instanceof Error ? err.message : '인증 실패';
-            this.logger.warn(`인증 실패로 연결 거부: ${client.id} - ${message}`);
+            this.logger.warn(`Auth failed, rejecting connection: ${client.id} - ${message}`);
             client.emit('exception', { message: '인증 실패: ' + message });
             client.disconnect();
         }
@@ -113,7 +113,7 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
      * @param client - 연결 해제된 Socket.IO 소켓
      */
     handleDisconnect(client: ChatSocket) {
-        this.logger.log(`연결 해제: ${client.id}`);
+        this.logger.log(`Disconnected: ${client.id}`);
     }
 
     /**
@@ -203,10 +203,10 @@ export class ChatGateway implements OnGatewayInit, OnGatewayConnection, OnGatewa
     }
 
     private joinRoom(client: ChatSocket, room: string): void {
-        Promise.resolve(client.join(room)).catch((err: unknown) => this.logger.error(`방 참여 실패 (room=${room}): ${String(err)}`));
+        Promise.resolve(client.join(room)).catch((err: unknown) => this.logger.error(`Failed to join room (room=${room}): ${String(err)}`));
     }
 
     private leaveRoom(client: ChatSocket, room: string): void {
-        Promise.resolve(client.leave(room)).catch((err: unknown) => this.logger.error(`방 퇴장 실패 (room=${room}): ${String(err)}`));
+        Promise.resolve(client.leave(room)).catch((err: unknown) => this.logger.error(`Failed to leave room (room=${room}): ${String(err)}`));
     }
 }

--- a/cowork-chat/src/chat/chat.service.ts
+++ b/cowork-chat/src/chat/chat.service.ts
@@ -222,12 +222,12 @@ export class ChatService {
                 try {
                     const objectKey = this.minioService.extractObjectKey(attachment.url);
                     if (!objectKey.startsWith(`chat-files/${ctx.channelId}/`)) {
-                        this.logger.warn(`채널 범위를 벗어난 objectKey 삭제를 건너뜁니다 [key=${objectKey}]`);
+                        this.logger.warn(`Skipping deletion of out-of-scope objectKey [key=${objectKey}]`);
                         return;
                     }
                     await this.minioService.removeObject(objectKey);
                 } catch (error) {
-                    this.logger.warn(`MinIO 파일 삭제 실패 [url=${attachment.url}]`, error);
+                    this.logger.warn(`Failed to delete MinIO file [url=${attachment.url}]`, error);
                 }
             }),
         );

--- a/cowork-chat/src/chat/kafka/channel-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/channel-event.consumer.ts
@@ -49,7 +49,7 @@ export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
                             const event = JSON.parse(message.value.toString()) as ChannelEvent;
                             this.handleEvent(event);
                         } catch (err) {
-                            this.logger.error('채널 이벤트 Kafka 메시지 처리 중 예외 발생', err);
+                            this.logger.error('Exception while processing channel.event Kafka message', err);
                             if (!(err instanceof SyntaxError)) throw err;
                         }
                     }
@@ -57,7 +57,7 @@ export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
                 },
             })
             .catch(async (err) => {
-                this.logger.error('채널 이벤트 Kafka consumer 실행 실패', err);
+                this.logger.error('channel.event Kafka consumer failed', err);
                 await this.dicoshot.sendCustom({
                     title: '🔴 Kafka Consumer 중단',
                     description: 'cowork-chat의 channel.event consumer가 복구 불가능한 오류로 종료되어 프로세스를 재시작합니다.',
@@ -81,7 +81,7 @@ export class ChannelEventConsumer implements OnModuleInit, OnModuleDestroy {
             throw new Error('Socket.IO server is not initialized yet');
         }
         if (!event || !event.eventType || !event.teamId) {
-            this.logger.warn('유효하지 않은 채널 이벤트 페이로드입니다: ' + JSON.stringify(event));
+            this.logger.warn('Invalid channel event payload: ' + JSON.stringify(event));
             return;
         }
         const room = `team:${event.teamId}`;

--- a/cowork-chat/src/chat/kafka/chat-message.consumer.ts
+++ b/cowork-chat/src/chat/kafka/chat-message.consumer.ts
@@ -68,13 +68,13 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
                         const event = JSON.parse(message.value.toString()) as ChatMessageEvent;
                         await this.handleMessageEvent(event);
                     } catch (err) {
-                        this.logger.error('Kafka 메시지 처리 중 예외 발생', err);
+                        this.logger.error('Exception while processing Kafka message', err);
                         if (!(err instanceof SyntaxError)) throw err;
                     }
                 },
             })
             .catch(async (err) => {
-                this.logger.error('chat.message Kafka consumer 실행 실패', err);
+                this.logger.error('chat.message Kafka consumer failed', err);
                 await this.dicoshot.sendCustom({
                     title: '🔴 Kafka Consumer 중단',
                     description: 'cowork-chat의 chat.message consumer가 복구 불가능한 오류로 종료되어 프로세스를 재시작합니다.',
@@ -154,7 +154,7 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
             this.io?.to(`chat:${event.channelId}`).emit('message', saved.toObject());
             void this.channelMemberRepository
                 .updateLastRead(event.channelId, event.authorId, saved._id)
-                .catch((err) => this.logger.warn(`lastReadMessageId 업데이트 실패 channelId=${event.channelId} authorId=${event.authorId}: ${err}`));
+                .catch((err) => this.logger.warn(`Failed to update lastReadMessageId channelId=${event.channelId} authorId=${event.authorId}: ${err}`));
 
             if (event.projectId && event.teamId != null) {
                 void this.elasticsearchService.indexMessage({
@@ -172,10 +172,10 @@ export class ChatMessageConsumer implements OnModuleInit, OnModuleDestroy {
             }
         } catch (err) {
             if (typeof err === 'object' && err !== null && 'code' in err && err.code === 11000) {
-                this.logger.warn(`중복 메시지 감지, 스킵합니다 (clientMessageId: ${event.clientMessageId})`);
+                this.logger.warn(`Duplicate message detected, skipping (clientMessageId: ${event.clientMessageId})`);
                 return;
             }
-            this.logger.error('메시지 저장 실패 — offset 미커밋으로 Kafka 재전달 예정', err);
+            this.logger.error('Failed to save message — Kafka will redeliver (offset not committed)', err);
             throw err;
         }
     }

--- a/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
+++ b/cowork-chat/src/chat/kafka/github-issue-result.consumer.ts
@@ -61,13 +61,13 @@ export class GithubIssueResultConsumer implements OnModuleInit, OnModuleDestroy 
                         const event = JSON.parse(message.value.toString()) as GithubIssueResultEvent;
                         await this.handleResultEvent(event);
                     } catch (err) {
-                        this.logger.error('이슈 결과 처리 중 오류 발생', err);
+                        this.logger.error('Failed to process issue result event', err);
                         if (!(err instanceof SyntaxError)) throw err;
                     }
                 },
             })
             .catch(async (err) => {
-                this.logger.error('github.issue.result Kafka consumer 실행 실패', err);
+                this.logger.error('github.issue.result Kafka consumer failed', err);
                 await this.dicoshot.sendCustom({
                     title: '🔴 Kafka Consumer 중단',
                     description: 'cowork-chat의 github.issue.result consumer가 복구 불가능한 오류로 종료되어 프로세스를 재시작합니다.',

--- a/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
+++ b/cowork-chat/src/chat/kafka/notification-outbox.poller.ts
@@ -98,7 +98,7 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
             this.lastReclaimTime = now;
             const reclaimed = await this.messageRepository.reclaimStaleProcessing(PROCESSING_STALE_THRESHOLD_MS);
             if (reclaimed > 0) {
-                this.logger.warn(`stale PROCESSING 메시지 ${reclaimed}개를 PENDING으로 회수했습니다`);
+                this.logger.warn(`Reclaimed ${reclaimed} stale PROCESSING message(s) back to PENDING`);
             }
         }
 
@@ -132,7 +132,7 @@ export class NotificationOutboxPoller implements OnModuleInit, OnModuleDestroy {
             } catch (err) {
                 const retryCount = (msg.notificationRetryCount ?? 0) + 1;
                 const nextStatus = retryCount >= MAX_RETRY ? 'FAILED' : 'PENDING';
-                this.logger.error(`outbox 처리 실패 (messageId: ${msg._id.toString()}, retry: ${retryCount}/${MAX_RETRY}), ${nextStatus} 전환`, err);
+                this.logger.error(`Outbox processing failed (messageId: ${msg._id.toString()}, retry: ${retryCount}/${MAX_RETRY}), transitioning to ${nextStatus}`, err);
                 await this.messageRepository.updateNotificationStatus(msg._id, nextStatus, retryCount);
                 if (nextStatus === 'FAILED' && AlertThrottleUtil.shouldAlert('notification-outbox-message-failed', MESSAGE_FAILURE_ALERT_COOLDOWN_MS)) {
                     void this.dicoshot.sendCustom({

--- a/cowork-chat/src/chat/kafka/project-event.consumer.ts
+++ b/cowork-chat/src/chat/kafka/project-event.consumer.ts
@@ -47,7 +47,7 @@ export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
                             const event = JSON.parse(message.value.toString()) as ProjectEvent;
                             this.handleEvent(event);
                         } catch (err) {
-                            this.logger.error('프로젝트 이벤트 Kafka 메시지 처리 중 예외 발생', err);
+                            this.logger.error('Exception while processing project.event Kafka message', err);
                             if (!(err instanceof SyntaxError)) throw err;
                         }
                     }
@@ -55,7 +55,7 @@ export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
                 },
             })
             .catch(async (err) => {
-                this.logger.error('프로젝트 이벤트 Kafka consumer 실행 실패', err);
+                this.logger.error('project.event Kafka consumer failed', err);
                 await this.dicoshot.sendCustom({
                     title: '🔴 Kafka Consumer 중단',
                     description: 'cowork-chat의 project.event consumer가 복구 불가능한 오류로 종료되어 프로세스를 재시작합니다.',
@@ -79,7 +79,7 @@ export class ProjectEventConsumer implements OnModuleInit, OnModuleDestroy {
             throw new Error('Socket.IO server is not initialized yet');
         }
         if (!event || !event.eventType || !event.teamId) {
-            this.logger.warn('유효하지 않은 프로젝트 이벤트 페이로드입니다: ' + JSON.stringify(event));
+            this.logger.warn('Invalid project event payload: ' + JSON.stringify(event));
             return;
         }
         const room = `team:${event.teamId}`;

--- a/cowork-chat/src/chat/service/base-http-client.ts
+++ b/cowork-chat/src/chat/service/base-http-client.ts
@@ -34,7 +34,7 @@ export abstract class BaseHttpClient {
         for (let attempt = 0; attempt <= maxRetries; attempt++) {
             if (attempt > 0) {
                 await new Promise<void>((resolve) => setTimeout(resolve, 100 * 2 ** (attempt - 1)));
-                this.logger.warn(`${this.serviceName} 재시도 ${attempt}/${maxRetries}`);
+                this.logger.warn(`${this.serviceName} retry ${attempt}/${maxRetries}`);
             }
             let res: Response;
             try {
@@ -44,7 +44,7 @@ export abstract class BaseHttpClient {
                 continue;
             }
             if (res.status >= 500 && attempt < maxRetries) {
-                void res.body?.cancel().catch((err) => this.logger.warn(`${this.serviceName} response body cancel 실패: ${String(err)}`));
+                void res.body?.cancel().catch((err) => this.logger.warn(`${this.serviceName} response body cancel failed: ${String(err)}`));
                 continue;
             }
             return res;
@@ -65,7 +65,7 @@ export abstract class BaseHttpClient {
         try {
             return await res.text();
         } catch (err) {
-            this.logger.warn(`${this.serviceName} 오류 응답 본문 읽기 실패: ${String(err)}`);
+            this.logger.warn(`${this.serviceName} failed to read error response body: ${String(err)}`);
             return null;
         }
     }
@@ -84,8 +84,8 @@ export abstract class BaseHttpClient {
         try {
             return await res.json() as T;
         } catch (err) {
-            this.logger.warn(`${this.serviceName} JSON 응답 파싱 실패: ${String(err)}`);
-            throw new Error(`${this.serviceName} 응답 본문 파싱에 실패했습니다`, { cause: err });
+            this.logger.warn(`${this.serviceName} failed to parse JSON response: ${String(err)}`);
+            throw new Error(`${this.serviceName} failed to parse response body`, { cause: err });
         }
     }
 }

--- a/cowork-chat/src/chat/service/project.client.ts
+++ b/cowork-chat/src/chat/service/project.client.ts
@@ -46,14 +46,14 @@ export class ProjectClient extends BaseHttpClient {
             const res = await this.fetchWithRetry(`${this.projectServiceUrl}/projects/${projectId}`, {}, 5000);
             if (res.status === 404) return null;
             if (!res.ok) {
-                throw new Error(`프로젝트 서비스 응답 오류: ${res.status}`);
+                throw new Error(`project-service error response: ${res.status}`);
             }
             const body = await this.readJsonBody<{ teamId?: number | null; githubRepoUrl?: string | null }>(res);
             const repoInfo = this.parseRepoUrl(body.githubRepoUrl);
             if (!repoInfo || typeof body.teamId !== 'number') return null;
             return { teamId: body.teamId, ...repoInfo };
         } catch (err) {
-            this.logger.error(`프로젝트 서비스 호출 오류 projectId=${projectId}`, err);
+            this.logger.error(`Failed to call project-service projectId=${projectId}`, err);
             throw err;
         }
     }
@@ -78,10 +78,10 @@ export class ProjectClient extends BaseHttpClient {
                 3000,
             );
             if (res.status === 404) return false;
-            if (!res.ok) throw new Error(`project-service 오류: ${res.status}`);
+            if (!res.ok) throw new Error(`project-service error: ${res.status}`);
             return true;
         } catch (err) {
-            this.logger.error(`project-service 멤버 확인 오류 projectId=${projectId} userId=${userId}`, err);
+            this.logger.error(`Failed to check membership in project-service projectId=${projectId} userId=${userId}`, err);
             throw err;
         }
     }

--- a/cowork-chat/src/membership/membership.consumer.ts
+++ b/cowork-chat/src/membership/membership.consumer.ts
@@ -40,12 +40,12 @@ export class MembershipConsumer implements OnModuleInit, OnModuleDestroy {
                         const event = JSON.parse(message.value.toString()) as ChannelMemberEvent;
                         await this.handleEvent(event);
                     } catch (err) {
-                        this.logger.error('멤버십 Kafka 메시지 처리 중 예외 발생', err);
+                        this.logger.error('Exception while processing channel.member.event Kafka message', err);
                         if (!(err instanceof SyntaxError)) throw err;
                     }
                 },
             })
-            .catch((err) => this.logger.error('멤버십 Kafka consumer 실행 실패', err));
+            .catch((err) => this.logger.error('channel.member.event Kafka consumer failed', err));
         this.logger.log('Kafka consumer started: channel.member.event');
     }
 
@@ -55,7 +55,7 @@ export class MembershipConsumer implements OnModuleInit, OnModuleDestroy {
 
     private async handleEvent(event: ChannelMemberEvent): Promise<void> {
         if (!event || !event.eventType || !event.channelId || !event.userId) {
-            this.logger.warn('유효하지 않은 멤버십 이벤트 페이로드입니다: ' + JSON.stringify(event));
+            this.logger.warn('Invalid membership event payload: ' + JSON.stringify(event));
             return;
         }
         const { eventType, channelId, teamId, userId, role } = event;
@@ -77,7 +77,7 @@ export class MembershipConsumer implements OnModuleInit, OnModuleDestroy {
                 this.io?.to(`chat:${channelId}`).emit('member:role:updated', { channelId, teamId, userId, role });
             }
         } catch (err) {
-            this.logger.error(`멤버십 이벤트 처리 실패 [${eventType}]`, err);
+            this.logger.error(`Failed to handle membership event [${eventType}]`, err);
             throw err;
         }
     }

--- a/cowork-chat/src/search/elasticsearch.service.ts
+++ b/cowork-chat/src/search/elasticsearch.service.ts
@@ -97,9 +97,9 @@ export class ElasticsearchService implements OnModuleInit {
             };
             await this.client.indices.create(params);
 
-            this.logger.log(`인덱스 생성 완료: ${INDEX}`);
+            this.logger.log(`Index created: ${INDEX}`);
         } catch (err) {
-            this.logger.error('ES 인덱스 생성 실패', err);
+            this.logger.error('Failed to create ES index', err);
         }
     }
 
@@ -111,7 +111,7 @@ export class ElasticsearchService implements OnModuleInit {
                 document: doc,
             });
         } catch (err) {
-            this.logger.error(`ES 메시지 인덱싱 실패 id=${doc.messageId}`, err);
+            this.logger.error(`Failed to index ES message id=${doc.messageId}`, err);
         }
     }
 
@@ -124,7 +124,7 @@ export class ElasticsearchService implements OnModuleInit {
             });
         } catch (err) {
             if (this.isNotFoundError(err)) return;
-            this.logger.error(`ES 메시지 업데이트 실패 id=${messageId}`, err);
+            this.logger.error(`Failed to update ES message id=${messageId}`, err);
         }
     }
 
@@ -137,7 +137,7 @@ export class ElasticsearchService implements OnModuleInit {
             });
         } catch (err) {
             if (this.isNotFoundError(err)) return;
-            this.logger.error(`ES 메시지 핀 상태 업데이트 실패 id=${messageId}`, err);
+            this.logger.error(`Failed to update ES message pin status id=${messageId}`, err);
         }
     }
 
@@ -146,7 +146,7 @@ export class ElasticsearchService implements OnModuleInit {
             await this.client.delete({ index: INDEX, id: messageId });
         } catch (err) {
             if (this.isNotFoundError(err)) return;
-            this.logger.error(`ES 메시지 삭제 실패 id=${messageId}`, err);
+            this.logger.error(`Failed to delete ES message id=${messageId}`, err);
         }
     }
 

--- a/cowork-chat/src/storage/minio.service.ts
+++ b/cowork-chat/src/storage/minio.service.ts
@@ -103,7 +103,7 @@ export class MinioService implements OnModuleInit, OnModuleDestroy {
             if (code === 'NoSuchKey' || code === 'NotFound') {
                 throw new ConflictException('S3에 파일이 없습니다. 업로드를 먼저 완료하세요');
             }
-            this.logger.error(`MinIO statObject 실패 [key=${objectKey}]`, error);
+            this.logger.error(`MinIO statObject failed [key=${objectKey}]`, error);
             throw new InternalServerErrorException('파일 확인 중 오류가 발생했습니다');
         }
 
@@ -124,7 +124,7 @@ export class MinioService implements OnModuleInit, OnModuleDestroy {
             if (code === 'NoSuchKey' || code === 'NotFound') {
                 return false;
             }
-            this.logger.error(`MinIO statObject 실패 [bucket=${this.config.bucket}, key=${objectKey}]`, error);
+            this.logger.error(`MinIO statObject failed [bucket=${this.config.bucket}, key=${objectKey}]`, error);
             throw new InternalServerErrorException('파일 존재 여부 확인 중 오류가 발생했습니다');
         }
     }


### PR DESCRIPTION
## 개요

`cowork-chat` 모듈 전체에 혼재되어 있던 한국어 로거 메시지를 영어로 통일하였습니다. 13개 파일, 44개 로그 구문이 변경되었으며 로직 변경은 없습니다.

## 본문

### 변경 배경

기존 코드베이스에서 로거 메시지가 한국어와 영어가 혼재된 상태였습니다. 로그 일관성 확보 및 향후 국제화 환경에서의 가독성을 위해 전체 로거 메시지를 영어로 통일하였습니다.

### 변경 파일 및 내용

| 파일 | 주요 변경 내용 |
|------|--------------|
| `block.redis.ts` | `Redis 초기 연결 실패` → `Redis initial connection failed` |
| `chat.gateway.ts` | 연결/해제/룸 참여 관련 메시지 영문화 |
| `chat.service.ts` | `MinIO 파일 삭제 실패`, `objectKey 삭제 건너뜀` 영문화 |
| `chat-message.consumer.ts` | Kafka 처리 예외, 중복 메시지 감지, 저장 실패 메시지 영문화 |
| `channel-event.consumer.ts` | `채널 이벤트 Kafka` 관련 메시지 영문화 |
| `project-event.consumer.ts` | `프로젝트 이벤트 Kafka` 관련 메시지 영문화 |
| `github-issue-result.consumer.ts` | 이슈 결과 처리 오류 메시지 영문화 |
| `notification-outbox.poller.ts` | stale 메시지 회수, outbox 처리 실패 메시지 영문화 |
| `base-http-client.ts` | 재시도, body cancel, JSON 파싱 실패 메시지 영문화 |
| `project.client.ts` | `project-service` 호출/멤버 확인 오류 메시지 영문화 |
| `membership.consumer.ts` | `channel.member.event` Kafka 관련 메시지 영문화 |
| `elasticsearch.service.ts` | ES 인덱스 생성/인덱싱/업데이트/삭제 실패 메시지 영문화 |
| `minio.service.ts` | `MinIO statObject 실패` 메시지 영문화 |

### 검증

- 변경 사항은 로그 메시지 문자열 치환에 한정되며, 비즈니스 로직 및 에러 처리 흐름에 영향 없습니다.
- 변경 후 `grep`으로 한국어 로거 메시지가 잔존하지 않음을 확인하였습니다.
