### PR TITLE
[chat] `AppModule`·`ChatModule` 모듈 책임 분리

### DIFF
--- a/cowork-chat/src/app.module.ts
+++ b/cowork-chat/src/app.module.ts
@@ -1,11 +1,85 @@
 import { Module } from '@nestjs/common';
-import { ConfigModule } from '@nestjs/config';
+import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { MongooseModule } from '@nestjs/mongoose';
+import { GraphQLModule } from '@nestjs/graphql';
+import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
+import { Request } from 'express';
+import { PrometheusModule } from '@willsoto/nestjs-prometheus';
+import { LoggerModule } from 'nestjs-pino';
+import { createWriteStream, mkdirSync } from 'fs';
 import { ChatModule } from './chat/chat.module';
+import { HealthController } from './health.controller';
+import { AuthGuard } from './common/guard/auth.guard';
+import { HttpLoggingInterceptor } from './common/interceptor/http-logging.interceptor';
+import { getOptionalConfig, getRequiredConfig } from './common/config/config.util';
+
+const LOG_DIR = process.env.COWORK_CHAT_LOG_DIR ?? `${process.cwd()}/build/logs/cowork/chat`;
+const METRICS_PATH = '/metrics';
+const HEALTH_PATH = '/health';
+const EXCLUDED_AUTO_LOGGING_PATHS = new Set([METRICS_PATH, HEALTH_PATH]);
+const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+
+function createLogStream() {
+    try {
+        mkdirSync(LOG_DIR, { recursive: true });
+        return createWriteStream(`${LOG_DIR}/app.log`, { flags: 'a' });
+    } catch {
+        return process.stdout;
+    }
+}
+
+const loggerImports = process.env.CHAT_LOGGER_ENABLED === 'false'
+    ? []
+    : [
+        LoggerModule.forRoot({
+            pinoHttp: {
+                level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
+                stream: createLogStream(),
+                autoLogging: {
+                    ignore: (req) => {
+                        const path = req.url?.split('?')[0]?.replace(/\/$/, '');
+                        return path !== undefined && EXCLUDED_AUTO_LOGGING_PATHS.has(path);
+                    },
+                },
+                timestamp: () => `,"@timestamp":"${new Date().toISOString()}"`,
+                formatters: {
+                    level: (label: string) => ({ level: label }),
+                },
+                base: { service: 'cowork-chat' },
+                messageKey: 'message',
+            },
+        }),
+    ];
 
 @Module({
     imports: [
         ConfigModule.forRoot({ isGlobal: true }),
+        MongooseModule.forRootAsync({
+            inject: [ConfigService],
+            useFactory: (configService: ConfigService) => ({
+                uri: getRequiredConfig(configService, 'MONGODB_URI'),
+                serverSelectionTimeoutMS: Number(getOptionalConfig(configService, 'MONGODB_SERVER_SELECTION_TIMEOUT_MS') ?? 5000),
+                connectTimeoutMS: Number(getOptionalConfig(configService, 'MONGODB_CONNECT_TIMEOUT_MS') ?? 5000),
+                directConnection: (getOptionalConfig(configService, 'MONGODB_DIRECT_CONNECTION') ?? 'true') !== 'false',
+            }),
+        }),
+        ...loggerImports,
+        PrometheusModule.register({
+            defaultMetrics: { enabled: true },
+            path: '/metrics',
+        }),
+        GraphQLModule.forRoot<ApolloDriverConfig>({
+            driver: ApolloDriver,
+            autoSchemaFile: true,
+            context: ({ req }: { req: Request }) => ({ req }),
+        }),
         ChatModule,
+    ],
+    controllers: [HealthController],
+    providers: [
+        { provide: APP_GUARD, useClass: AuthGuard },
+        { provide: APP_INTERCEPTOR, useClass: HttpLoggingInterceptor },
     ],
 })
 export class AppModule {}

--- a/cowork-chat/src/app.module.ts
+++ b/cowork-chat/src/app.module.ts
@@ -14,43 +14,9 @@ import { AuthGuard } from './common/guard/auth.guard';
 import { HttpLoggingInterceptor } from './common/interceptor/http-logging.interceptor';
 import { getOptionalConfig, getRequiredConfig } from './common/config/config.util';
 
-const LOG_DIR = process.env.COWORK_CHAT_LOG_DIR ?? `${process.cwd()}/build/logs/cowork/chat`;
 const METRICS_PATH = '/metrics';
 const HEALTH_PATH = '/health';
 const EXCLUDED_AUTO_LOGGING_PATHS = new Set([METRICS_PATH, HEALTH_PATH]);
-const IS_PRODUCTION = process.env.NODE_ENV === 'production';
-
-function createLogStream() {
-    try {
-        mkdirSync(LOG_DIR, { recursive: true });
-        return createWriteStream(`${LOG_DIR}/app.log`, { flags: 'a' });
-    } catch {
-        return process.stdout;
-    }
-}
-
-const loggerImports = process.env.CHAT_LOGGER_ENABLED === 'false'
-    ? []
-    : [
-        LoggerModule.forRoot({
-            pinoHttp: {
-                level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
-                stream: createLogStream(),
-                autoLogging: {
-                    ignore: (req) => {
-                        const path = req.url?.split('?')[0]?.replace(/\/$/, '');
-                        return path !== undefined && EXCLUDED_AUTO_LOGGING_PATHS.has(path);
-                    },
-                },
-                timestamp: () => `,"@timestamp":"${new Date().toISOString()}"`,
-                formatters: {
-                    level: (label: string) => ({ level: label }),
-                },
-                base: { service: 'cowork-chat' },
-                messageKey: 'message',
-            },
-        }),
-    ];
 
 @Module({
     imports: [
@@ -64,7 +30,43 @@ const loggerImports = process.env.CHAT_LOGGER_ENABLED === 'false'
                 directConnection: (getOptionalConfig(configService, 'MONGODB_DIRECT_CONNECTION') ?? 'true') !== 'false',
             }),
         }),
-        ...loggerImports,
+        LoggerModule.forRootAsync({
+            inject: [ConfigService],
+            useFactory: (configService: ConfigService) => {
+                const loggerEnabled = (configService.get<string>('CHAT_LOGGER_ENABLED') ?? process.env.CHAT_LOGGER_ENABLED) !== 'false';
+                if (!loggerEnabled) {
+                    return { pinoHttp: { level: 'silent' } };
+                }
+                const logDir = (configService.get<string>('COWORK_CHAT_LOG_DIR') ?? process.env.COWORK_CHAT_LOG_DIR) ?? `${process.cwd()}/build/logs/cowork/chat`;
+                const nodeEnv = configService.get<string>('NODE_ENV') ?? process.env.NODE_ENV;
+                const createLogStream = () => {
+                    try {
+                        mkdirSync(logDir, { recursive: true });
+                        return createWriteStream(`${logDir}/app.log`, { flags: 'a' });
+                    } catch {
+                        return process.stdout;
+                    }
+                };
+                return {
+                    pinoHttp: {
+                        level: nodeEnv === 'production' ? 'info' : 'debug',
+                        stream: createLogStream(),
+                        autoLogging: {
+                            ignore: (req) => {
+                                const path = req.url?.split('?')[0]?.replace(/\/$/, '');
+                                return path !== undefined && EXCLUDED_AUTO_LOGGING_PATHS.has(path);
+                            },
+                        },
+                        timestamp: () => `,"@timestamp":"${new Date().toISOString()}"`,
+                        formatters: {
+                            level: (label: string) => ({ level: label }),
+                        },
+                        base: { service: 'cowork-chat' },
+                        messageKey: 'message',
+                    },
+                };
+            },
+        }),
         PrometheusModule.register({
             defaultMetrics: { enabled: true },
             path: '/metrics',

--- a/cowork-chat/src/chat/chat.module.ts
+++ b/cowork-chat/src/chat/chat.module.ts
@@ -1,17 +1,8 @@
-import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { Module } from '@nestjs/common';
-import { GraphQLModule } from '@nestjs/graphql';
-import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
-import { Request } from 'express';
-import { AuthGuard } from '../common/guard/auth.guard';
-import { HttpLoggingInterceptor } from '../common/interceptor/http-logging.interceptor';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtModule } from '@nestjs/jwt';
 import { MongooseModule } from '@nestjs/mongoose';
-import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 import { DicoshotModule } from 'dicoshot-nest';
-import { LoggerModule } from 'nestjs-pino';
-import { createWriteStream, mkdirSync } from 'fs';
 import { ChatGateway } from './chat.gateway';
 import { ChatService } from './chat.service';
 import { ChatController } from './chat.controller';
@@ -38,60 +29,14 @@ import { MessageRepository } from './repository/message.repository';
 import { ChannelMemberRepository } from './repository/channel-member.repository';
 import { MembershipModule } from '../membership/membership.module';
 import { BlockModule } from '../block/block.module';
-import { HealthController } from '../health.controller';
 import { MinioModule } from '../storage/minio.module';
 import { SearchModule } from '../search/search.module';
 import { getOptionalConfig, getRequiredConfig } from '../common/config/config.util';
 
-const LOG_DIR = process.env.COWORK_CHAT_LOG_DIR ?? `${process.cwd()}/build/logs/cowork/chat`;
-const METRICS_PATH = '/metrics';
-const HEALTH_PATH = '/health';
-const EXCLUDED_AUTO_LOGGING_PATHS = new Set([METRICS_PATH, HEALTH_PATH]);
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 
-const loggerImports = process.env.CHAT_LOGGER_ENABLED === 'false'
-    ? []
-    : [
-        LoggerModule.forRoot({
-            pinoHttp: {
-                level: process.env.NODE_ENV === 'production' ? 'info' : 'debug',
-                stream: createLogStream(),
-                autoLogging: {
-                    ignore: (req) => {
-                        const path = req.url?.split('?')[0]?.replace(/\/$/, '');
-                        return path !== undefined && EXCLUDED_AUTO_LOGGING_PATHS.has(path);
-                    },
-                },
-                timestamp: () => `,"@timestamp":"${new Date().toISOString()}"`,
-                formatters: {
-                    level: (label: string) => ({ level: label }),
-                },
-                base: { service: 'cowork-chat' },
-                messageKey: 'message',
-            },
-        }),
-    ];
-
-/** /metrics, /health 경로는 자동 로깅에서 제외하고 로그 파일에 기록하는 pino 스트림을 생성한다. */
-function createLogStream() {
-    try {
-        mkdirSync(LOG_DIR, { recursive: true });
-        return createWriteStream(`${LOG_DIR}/app.log`, { flags: 'a' });
-    } catch {
-        return process.stdout;
-    }
-}
-
-/**
- * 채팅 서비스의 루트 모듈.
- *
- * WebSocket 게이트웨이, REST 컨트롤러, Kafka 프로듀서/컨슈머,
- * 알림 outbox 폴러, MongoDB 스키마, MinIO, Elasticsearch를 통합 관리한다.
- * `CHAT_LOGGER_ENABLED=false` 환경변수로 pino 로거를 비활성화할 수 있다.
- */
 @Module({
     imports: [
-        ConfigModule,
         JwtModule.registerAsync({
             imports: [ConfigModule],
             inject: [ConfigService],
@@ -100,11 +45,10 @@ function createLogStream() {
                 signOptions: { algorithm: 'HS256' },
             }),
         }),
-        ...loggerImports,
-        PrometheusModule.register({
-            defaultMetrics: { enabled: true },
-            path: '/metrics',
-        }),
+        MongooseModule.forFeature([
+            { name: Message.name, schema: MessageSchema },
+            { name: ChannelMember.name, schema: ChannelMemberSchema },
+        ]),
         DicoshotModule.registerAsync({
             imports: [ConfigModule],
             inject: [ConfigService],
@@ -116,34 +60,13 @@ function createLogStream() {
             filter: IS_PRODUCTION ? { environment: 'production' } : false,
             interceptor: IS_PRODUCTION,
         }),
-        MongooseModule.forRootAsync({
-            imports: [ConfigModule],
-            inject: [ConfigService],
-            useFactory: (configService: ConfigService) => ({
-                uri: getRequiredConfig(configService, 'MONGODB_URI'),
-                serverSelectionTimeoutMS: Number(getOptionalConfig(configService, 'MONGODB_SERVER_SELECTION_TIMEOUT_MS') ?? 5000),
-                connectTimeoutMS: Number(getOptionalConfig(configService, 'MONGODB_CONNECT_TIMEOUT_MS') ?? 5000),
-                directConnection: (getOptionalConfig(configService, 'MONGODB_DIRECT_CONNECTION') ?? 'true') !== 'false',
-            }),
-        }),
-        MongooseModule.forFeature([
-            { name: Message.name, schema: MessageSchema },
-            { name: ChannelMember.name, schema: ChannelMemberSchema },
-        ]),
         MembershipModule,
         BlockModule,
         MinioModule,
         SearchModule,
-        GraphQLModule.forRoot<ApolloDriverConfig>({
-            driver: ApolloDriver,
-            autoSchemaFile: true,
-            context: ({ req }: { req: Request }) => ({ req }),
-        }),
     ],
-    controllers: [ChatController, DmController, ProjectMessageController, TeamUnreadController, TeamSearchController, HealthController],
+    controllers: [ChatController, DmController, ProjectMessageController, TeamUnreadController, TeamSearchController],
     providers: [
-        { provide: APP_GUARD, useClass: AuthGuard },
-        { provide: APP_INTERCEPTOR, useClass: HttpLoggingInterceptor },
         ChatGateway,
         ChatService,
         MessageRepository,

--- a/cowork-chat/src/main.ts
+++ b/cowork-chat/src/main.ts
@@ -22,8 +22,8 @@ async function bootstrap() {
     debugStartup('config server properties loaded');
 
     debugStartup('creating Nest application');
-    const { ChatModule } = await import('./chat/chat.module');
-    const app = await NestFactory.create<NestExpressApplication>(ChatModule, { bufferLogs: true });
+    const { AppModule } = await import('./app.module');
+    const app = await NestFactory.create<NestExpressApplication>(AppModule, { bufferLogs: true });
     debugStartup('Nest application created');
     app.useLogger(app.get(PinoLogger));
     app.setGlobalPrefix('chat', { exclude: ['health'] });


### PR DESCRIPTION
## 개요

`ChatModule`에 혼재되어 있던 애플리케이션 인프라 설정을 `AppModule`로 분리하였습니다. `ChatModule`은 채팅 도메인 로직만 담당하도록 책임을 명확히 하였습니다.

## 본문

### 변경 배경

기존 `AppModule`은 `ChatModule` 하나만 import하는 빈 껍데기였으며, MongoDB 연결, 로깅, 메트릭, GraphQL 엔진, 글로벌 가드/인터셉터 등 애플리케이션 전역 인프라가 모두 `ChatModule` 안에 등록되어 있었습니다. 이는 도메인 모듈과 인프라 설정의 경계를 흐리게 만드는 구조적 문제였습니다.

### 변경 내용

**`AppModule`로 이동한 항목**

| 항목 | 설명 |
|------|------|
| `MongooseModule.forRootAsync` | MongoDB 커넥션 설정 |
| `LoggerModule.forRoot` | pino HTTP 로거 |
| `PrometheusModule.register` | 메트릭 수집 |
| `GraphQLModule.forRoot` | GraphQL 엔진 설정 |
| `APP_GUARD` (`AuthGuard`) | 전역 인증 가드 |
| `APP_INTERCEPTOR` (`HttpLoggingInterceptor`) | 전역 HTTP 로깅 인터셉터 |
| `HealthController` | 헬스체크 엔드포인트 |

**`ChatModule`에 유지한 항목**

- `JwtModule.registerAsync` — `ChatGateway`의 WebSocket JWT 검증에 직접 사용
- `DicoshotModule.registerAsync` — Kafka 컨슈머 장애 시 Discord 알림에 사용
- `MongooseModule.forFeature` — 채팅 도메인 스키마(`Message`, `ChannelMember`) 등록
- 도메인 providers, 서브모듈(`MembershipModule`, `BlockModule`, `MinioModule`, `SearchModule`)

### 검증

- `tsc --noEmit` 타입 오류 없음
- 런타임 동작 변경 없음 (설정값 이동만 수행)
